### PR TITLE
chore(ci): configure Dependabot to use Conventional Commits format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
     groups:
       dev-dependencies:
         dependency-type: development
@@ -18,3 +22,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"


### PR DESCRIPTION
## Problem

PR #1 is blocked because Dependabot generates PR titles like "Bump the dev-dependencies group with 3 updates", which fails the Conventional Commits title validator enforced by CI.

## Fix

Added `commit-message` configuration to each ecosystem entry in `.github/dependabot.yml`:

- **npm production dependencies** → `chore(deps): ...` (via `prefix`)
- **npm dev dependencies** → `chore(deps-dev): ...` (via `prefix-development`)
- **github-actions** → `chore(ci): ...` (via `prefix`)

Dependabot's built-in `prefix` / `prefix-development` / `include: "scope"` options handle the dev vs prod split natively within the npm ecosystem entry, so no per-group workarounds are needed.

---
*Created by Claude Sonnet 4.6*