### PR TITLE
chore: fix doubled Dependabot commit scopes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "chore"
       include: "scope"
     groups:
       dev-dependencies:
@@ -23,5 +22,5 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
The `include: "scope"` directive was combined with prefix values that already embedded the scope (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`), causing Dependabot to append the scope a second time — producing titles like `chore(deps)(deps):` and `chore(deps-dev)(deps-dev):`.

Fixes this by removing the hardcoded scopes from the prefix values and letting `include: "scope"` derive them automatically, which is its intended use.

Closes #47
Closes #48

---
*Created by Claude Sonnet 4.6*