### PR TITLE
chore: ignore .claude/ in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 dist
 .next
+.claude
 src/components/ui
 pnpm-lock.yaml


### PR DESCRIPTION
Adds `.claude` to `.prettierignore` so Prettier doesn't format Claude Code local config files (`settings.local.json`, worktrees, etc.). ESLint already had `.claude/**` in its ignore list.

---
*Created by Claude Sonnet 4.6*