### PR TITLE
fix(auth): tighten /api/auth exclusion to segment boundary in middleware

### DIFF
--- a/src/middleware.spec.ts
+++ b/src/middleware.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
-import { middleware } from "./middleware";
+import { middleware, config } from "./middleware";
 
 function makeSessionCookie(): string {
   const now = Math.floor(Date.now() / 1000);
@@ -122,5 +122,39 @@ describe("middleware", () => {
     expect(response.headers.get("location")).toBe(
       "https://example.com/ledgers",
     );
+  });
+});
+
+// ─── Criterion 1: /api/auth paths are excluded from session check ─────────────
+
+describe("/api/auth and sub-paths are excluded from the session check", () => {
+  it("allows unauthenticated requests to /api/auth through without redirecting", async () => {
+    const response = await middleware(makeRequest("/api/auth"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("allows unauthenticated requests to /api/auth/session through without redirecting", async () => {
+    const response = await middleware(makeRequest("/api/auth/session"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+});
+
+// ─── Criterion 2: config.matcher uses segment-boundary pattern ────────────────
+
+describe("config.matcher excludes /api/auth at a segment boundary", () => {
+  it("config.matcher pattern contains the segment-boundary api/auth lookahead", () => {
+    expect(config.matcher[0]).toMatch(/api\/auth\(\?:\/\|\$\)/);
+  });
+});
+
+// ─── Criterion 3: /api/authentication is NOT excluded ────────────────────────
+
+describe("/api/authentication is not excluded from the session check", () => {
+  it("redirects unauthenticated requests to /api/authentication to /sign-in", async () => {
+    const response = await middleware(makeRequest("/api/authentication"));
+    const location = response.headers.get("location");
+    expect(location).toContain("/sign-in");
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,12 @@ function isAuthRoute(pathname: string): boolean {
 }
 
 function isExcludedPath(pathname: string): boolean {
-  return pathname.startsWith("/_next/") || pathname === "/favicon.ico";
+  return (
+    pathname.startsWith("/_next/") ||
+    pathname === "/favicon.ico" ||
+    pathname === "/api/auth" ||
+    pathname.startsWith("/api/auth/")
+  );
 }
 
 export async function middleware(request: NextRequest) {
@@ -161,5 +166,5 @@ async function verifySessionCookie(
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/auth/session).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/auth(?:/|$)).*)"],
 };


### PR DESCRIPTION
The `/api/auth` exclusion in middleware was previously handled only through `config.matcher` (excluding the specific `api/auth/session` path), leaving no runtime guard in `isExcludedPath`. A bare prefix match could silently bypass the session check for any future path starting with `/api/auth` — such as a hypothetical `/api/authentication`.

This PR moves the exclusion into `isExcludedPath` using exact segment-boundary matching (`pathname === "/api/auth" || pathname.startsWith("/api/auth/")`), and updates `config.matcher` to use `api/auth(?:/|$)` so the static and runtime exclusions agree. A regression test confirms `/api/authentication` is still subject to the session check.

## Acceptance Criteria
- [x] `isExcludedPath` uses exact-segment match: `pathname === "/api/auth" || pathname.startsWith("/api/auth/")`
- [x] `config.matcher` negative lookahead uses `api/auth(?:/|$)`
- [x] `/api/authentication` is not excluded and is redirected to `/sign-in` when unauthenticated

## Tests
4 tests added, all passing (9 total in middleware.spec.ts).

Closes #63

---
*Created by Claude Sonnet 4.6*