### PR TITLE
feat(monitoring): set Sentry environment tag from NEXT_PUBLIC_APP_ENV

### DIFF
--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -33,3 +33,6 @@ variables:
   # The actual value is the Client Keys DSN from your Sentry project settings.
   # SENTRY_AUTH_TOKEN and the server DSN are managed as Vercel secrets and never committed.
   NEXT_PUBLIC_SENTRY_DSN: "https://39ad6a2f62056621e3452bee009c1afc@o4511071618072576.ingest.us.sentry.io/4511351011737600"
+  # Sentry environment tag — passed to Sentry.init({ environment }) to separate
+  # production errors from staging noise in the Sentry dashboard.
+  NEXT_PUBLIC_APP_ENV: "production"

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -40,3 +40,6 @@ variables:
   SENTRY_PROJECT: "personal-budget"
   # Sentry public DSN — safe to expose; matched by the NEXT_PUBLIC_* allowed_pattern in schema.yml.
   NEXT_PUBLIC_SENTRY_DSN: "https://39ad6a2f62056621e3452bee009c1afc@o4511071618072576.ingest.us.sentry.io/4511351011737600"
+  # Sentry environment tag — passed to Sentry.init({ environment }) to separate
+  # staging errors from production in the Sentry dashboard.
+  NEXT_PUBLIC_APP_ENV: "staging"

--- a/src/lib/sentry-init.spec.ts
+++ b/src/lib/sentry-init.spec.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 vi.mock("@sentry/nextjs", () => ({
   init: vi.fn(),
@@ -122,5 +124,49 @@ describe("Unhandled exceptions in server components / route handlers are capture
     );
 
     void initSentry;
+  });
+});
+
+// ─── Criterion 1: Sentry environment tag set from NEXT_PUBLIC_APP_ENV ─────────
+
+describe("Sentry errors from staging are distinguishable from production errors via environment tag", () => {
+  it("initSentry passes NEXT_PUBLIC_APP_ENV as environment to Sentry.init", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+    const { initSentry } = await import("./sentry-init");
+    const { init } = await import("@sentry/nextjs");
+
+    initSentry("https://abc@o1.ingest.sentry.io/1");
+
+    expect(init).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "production" }),
+    );
+  });
+
+  it("initSentry falls back to 'development' when NEXT_PUBLIC_APP_ENV is absent", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "");
+    const { initSentry } = await import("./sentry-init");
+    const { init } = await import("@sentry/nextjs");
+
+    initSentry("https://abc@o1.ingest.sentry.io/1");
+
+    expect(init).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "development" }),
+    );
+  });
+});
+
+// ─── Criterion 2: environment tag documented in deployment config ─────────────
+
+describe("The approach is documented in the deployment config", () => {
+  it("deployment/production.yml sets NEXT_PUBLIC_APP_ENV to 'production'", () => {
+    const path = join(import.meta.dirname, "../../deployment/production.yml");
+    const raw = readFileSync(path, "utf-8");
+    expect(raw).toMatch(/NEXT_PUBLIC_APP_ENV:\s*["']?production["']?/);
+  });
+
+  it("deployment/staging.yml sets NEXT_PUBLIC_APP_ENV to 'staging'", () => {
+    const path = join(import.meta.dirname, "../../deployment/staging.yml");
+    const raw = readFileSync(path, "utf-8");
+    expect(raw).toMatch(/NEXT_PUBLIC_APP_ENV:\s*["']?staging["']?/);
   });
 });

--- a/src/lib/sentry-init.ts
+++ b/src/lib/sentry-init.ts
@@ -7,8 +7,10 @@ import * as Sentry from "@sentry/nextjs";
  */
 export function initSentry(dsn: string | undefined): void {
   if (!dsn) return;
+  const appEnv = process.env["NEXT_PUBLIC_APP_ENV"];
   Sentry.init({
     dsn,
+    environment: appEnv !== "" ? (appEnv ?? "development") : "development",
     // Error capture only — no performance tracing or session replay.
     tracesSampleRate: 0,
     replaysSessionSampleRate: 0,

--- a/src/lib/sentry-init.ts
+++ b/src/lib/sentry-init.ts
@@ -7,10 +7,9 @@ import * as Sentry from "@sentry/nextjs";
  */
 export function initSentry(dsn: string | undefined): void {
   if (!dsn) return;
-  const appEnv = process.env["NEXT_PUBLIC_APP_ENV"];
   Sentry.init({
     dsn,
-    environment: appEnv !== "" ? (appEnv ?? "development") : "development",
+    environment: process.env["NEXT_PUBLIC_APP_ENV"] || "development", // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
     // Error capture only — no performance tracing or session replay.
     tracesSampleRate: 0,
     replaysSessionSampleRate: 0,


### PR DESCRIPTION
Passes an `environment` tag to `Sentry.init()` so errors from staging and production land in separate Sentry streams and can be filtered independently. The tag is read from `NEXT_PUBLIC_APP_ENV`, which falls back to `"development"` when absent (local dev, forks, CI without the variable).

`deployment/production.yml` is set to `"production"` and `deployment/staging.yml` to `"staging"`. Both files document the variable with a comment explaining its purpose. `NEXT_PUBLIC_APP_ENV` is covered by the existing `NEXT_PUBLIC_*` allowlist in `deployment/schema.yml` — no schema change required.

## Acceptance Criteria
- [x] Sentry errors from staging are distinguishable from production errors via `environment` tag
- [x] The approach is documented in the deployment config

## Tests
4 tests added, all passing (12 total in sentry-init.spec.ts).

Closes #85

---
*Created by Claude Sonnet 4.6*