### PR TITLE
fix(a11y): add accessible name to Bar progressbar role

### DIFF
--- a/src/components/ledgers/LedgerList.tsx
+++ b/src/components/ledgers/LedgerList.tsx
@@ -165,6 +165,9 @@ export function LedgerList({
                           <Bar
                             value={capUsagePercent}
                             className="max-w-[120px]"
+                            aria-label={LEDGERS_PAGE_COPY.capUsageBarLabel(
+                              ledger.name,
+                            )}
                           />
                         )}
                       </div>

--- a/src/components/ledgers/LedgerListItem.spec.tsx
+++ b/src/components/ledgers/LedgerListItem.spec.tsx
@@ -188,6 +188,32 @@ describe("LedgerListItemView", () => {
       );
       expect(screen.queryByText(LEDGERS_PAGE_COPY.noCashCapLabel)).toBeNull();
     });
+
+    it("renders the cap usage progressbar with a descriptive accessible name", () => {
+      const ledger = makeLedger({
+        name: "Everyday Spending",
+        cashCap: 1000,
+        cashBalance: 750,
+      });
+      render(
+        <table>
+          <tbody>
+            <LedgerListItemView
+              ledger={ledger}
+              onEdit={onEdit}
+              deleteDialogOpen={false}
+              onDeleteDialogOpenChange={vi.fn()}
+              onDeleteMenuClick={vi.fn()}
+              onDeleteConfirm={vi.fn()}
+            />
+          </tbody>
+        </table>,
+      );
+      const bar = screen.getByRole("progressbar", {
+        name: LEDGERS_PAGE_COPY.capUsageBarLabel("Everyday Spending"),
+      });
+      expect(bar).toBeDefined();
+    });
   });
 
   describe("goals column", () => {

--- a/src/components/ledgers/LedgerListItem.tsx
+++ b/src/components/ledgers/LedgerListItem.tsx
@@ -65,7 +65,11 @@ export function LedgerListItemView({
       <td className="w-[25%] px-4 py-3">
         {ledger.cashCap != null ? (
           <div className="flex items-center gap-2">
-            <Bar value={capUsagePercent} className="max-w-24" />
+            <Bar
+              value={capUsagePercent}
+              className="max-w-24"
+              aria-label={LEDGERS_PAGE_COPY.capUsageBarLabel(ledger.name)}
+            />
             <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
               {currencyFormatter.format(ledger.cashBalance)} /{" "}
               {currencyFormatter.format(ledger.cashCap)}

--- a/src/components/ledgers/copy.ts
+++ b/src/components/ledgers/copy.ts
@@ -38,6 +38,7 @@ export const LEDGER_LIST_ITEM_COPY = {
 } as const;
 
 export const LEDGERS_PAGE_COPY = {
+  capUsageBarLabel: (name: string) => `Cash cap usage for ${name}`,
   columnCapUsage: "Cap usage",
   columnCash: "Cash",
   columnGoals: "Goals",

--- a/src/components/ui/bar.spec.tsx
+++ b/src/components/ui/bar.spec.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Bar } from "./bar";
+
+afterEach(cleanup);
+
+describe("BarProps accepts an aria-label forwarded to the progressbar element", () => {
+  it("renders a progressbar with the given aria-label", () => {
+    render(
+      <Bar value={50} aria-label="Cash cap usage for Everyday Spending" />,
+    );
+    const bar = screen.getByRole("progressbar", {
+      name: "Cash cap usage for Everyday Spending",
+    });
+    expect(bar).toBeDefined();
+  });
+
+  it("renders a progressbar without an accessible name when aria-label is omitted", () => {
+    render(<Bar value={50} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-label")).toBeNull();
+  });
+});

--- a/src/components/ui/bar.tsx
+++ b/src/components/ui/bar.tsx
@@ -3,18 +3,23 @@ import { cn } from "@/lib/utils";
 export interface BarProps {
   value: number;
   className?: string;
+  "aria-label"?: string;
 }
 
-export function Bar({ value, className }: BarProps) {
+export function Bar({ value, className, "aria-label": ariaLabel }: BarProps) {
   const clampedValue = Math.min(100, Math.max(0, value));
   return (
     <div
-      className={cn("h-2 w-full overflow-hidden rounded-full bg-muted", className)}
+      className={cn(
+        "h-2 w-full overflow-hidden rounded-full bg-muted",
+        className,
+      )}
     >
       <div
         className="h-full rounded-full bg-primary transition-all"
         style={{ width: `${clampedValue}%` }}
         role="progressbar"
+        aria-label={ariaLabel}
         aria-valuenow={clampedValue}
         aria-valuemin={0}
         aria-valuemax={100}


### PR DESCRIPTION
The `Bar` component's inner `role="progressbar"` element had no accessible name, so screen readers announced a bare percentage with no context about what was being measured. This PR adds an `aria-label` prop to `BarProps`, forwards it to the progressbar element, and wires up descriptive labels at both call sites.

`BarProps` gets an explicit `"aria-label"?: string` rather than spreading all `HTMLAttributes` — this keeps the interface minimal while satisfying the accessibility requirement. The label text is colocated in `LEDGERS_PAGE_COPY.capUsageBarLabel` (a function taking the ledger name) so it stays i18n-ready and testable via copy constants.

## Acceptance Criteria
- [x] `BarProps` accepts an `aria-label` forwarded to the `role="progressbar"` element
- [x] `LedgerListItemView` and the `LedgerList` mobile layout pass a descriptive label to `Bar`
- [x] Tests verify the accessible name is present on the progressbar

## Tests
3 tests added (2 in new `bar.spec.tsx`, 1 in `LedgerListItem.spec.tsx`), all passing (221 total).

Closes #78

---
*Created by Claude Sonnet 4.6*