### PR TITLE
feat(data-layer): add Firebase Realtime Database security rules with user-scoped access

### DIFF
--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -1,11 +1,18 @@
+// Firebase Realtime Database security rules.
+// Parsed by the Firebase CLI, which supports JS-style // comments.
 {
   "rules": {
+    // Each user can only read and write data under their own UID path.
+    // The $uid wildcard captures the path segment and is compared to
+    // the authenticated user's UID so cross-user access is impossible.
     "users": {
       "$uid": {
         ".read": "auth != null && auth.uid === $uid",
         ".write": "auth != null && auth.uid === $uid"
       }
     },
+    // Deny all reads and writes that do not match a more specific rule above.
+    // This is a safe default: new paths are private until explicitly opened.
     ".read": false,
     ".write": false
   }

--- a/src/firebase-rules.spec.ts
+++ b/src/firebase-rules.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const rulesPath = resolve(
+  import.meta.dirname,
+  "../firebase/database.rules.json",
+);
+const firebaseConfigPath = resolve(import.meta.dirname, "../firebase.json");
+
+function readRulesJson(): Record<string, unknown> {
+  const raw = readFileSync(rulesPath, "utf-8");
+  // Strip JS-style line comments before parsing (Firebase CLI allows them)
+  const stripped = raw.replace(/\/\/[^\n]*/g, "");
+  return JSON.parse(stripped) as Record<string, unknown>;
+}
+
+function getRulesRoot(rules: Record<string, unknown>): Record<string, unknown> {
+  return rules["rules"] as Record<string, unknown>;
+}
+
+function getUidNode(rules: Record<string, unknown>): Record<string, unknown> {
+  const root = getRulesRoot(rules);
+  const users = root["users"] as Record<string, unknown>;
+  return users["$uid"] as Record<string, unknown>;
+}
+
+describe("firebase/database.rules.json — structure", () => {
+  it("has a top-level rules object", () => {
+    const rules = readRulesJson();
+    expect(rules["rules"]).toBeDefined();
+  });
+
+  it("has a users.$uid path with read and write rules", () => {
+    const rules = readRulesJson();
+    const root = getRulesRoot(rules);
+    const users = root["users"] as Record<string, unknown>;
+    expect(users).toBeDefined();
+    const uidNode = users["$uid"] as Record<string, unknown>;
+    expect(uidNode).toBeDefined();
+    expect(typeof uidNode[".read"]).toBe("string");
+    expect(typeof uidNode[".write"]).toBe("string");
+  });
+
+  it("restricts read access to the authenticated owner of each uid path", () => {
+    const rules = readRulesJson();
+    const uidNode = getUidNode(rules);
+    const readRule = uidNode[".read"] as string;
+    expect(readRule).toContain("auth != null");
+    expect(readRule).toContain("auth.uid === $uid");
+  });
+
+  it("restricts write access to the authenticated owner of each uid path", () => {
+    const rules = readRulesJson();
+    const uidNode = getUidNode(rules);
+    const writeRule = uidNode[".write"] as string;
+    expect(writeRule).toContain("auth != null");
+    expect(writeRule).toContain("auth.uid === $uid");
+  });
+
+  it("denies all reads at the root level", () => {
+    const rules = readRulesJson();
+    const root = getRulesRoot(rules);
+    expect(root[".read"]).toBe(false);
+  });
+
+  it("denies all writes at the root level", () => {
+    const rules = readRulesJson();
+    const root = getRulesRoot(rules);
+    expect(root[".write"]).toBe(false);
+  });
+});
+
+describe("firebase/database.rules.json — documentation", () => {
+  it("contains inline comments explaining each section", () => {
+    const raw = readFileSync(rulesPath, "utf-8");
+    expect(raw).toContain("//");
+  });
+
+  it("has at least two comment lines", () => {
+    const raw = readFileSync(rulesPath, "utf-8");
+    const lines = raw.split("\n");
+    const commentLines = lines.filter((l) => l.trimStart().startsWith("//"));
+    expect(commentLines.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("firebase.json", () => {
+  it("references firebase/database.rules.json as the database rules file", () => {
+    const config = JSON.parse(
+      readFileSync(firebaseConfigPath, "utf-8"),
+    ) as Record<string, unknown>;
+    const database = config["database"] as Record<string, unknown>;
+    expect(database).toBeDefined();
+    expect(database["rules"]).toBe("firebase/database.rules.json");
+  });
+});


### PR DESCRIPTION
Adds Firebase Realtime Database security rules that enforce user-scoped data access: each authenticated user can read and write only data under their own `/users/{uid}/` path, and all other paths deny access by default.

The rules file uses JS-style `//` comments (supported by the Firebase CLI's forgiving JSON parser) to explain each section inline. A structural test suite in `src/firebase-rules.spec.ts` validates the rule definitions (auth conditions, root deny rules) and the `firebase.json` configuration reference.

## Acceptance Criteria
- [x] Rules are defined in `firebase/database.rules.json`
- [x] Each user can read and write only paths under `/users/{their-uid}/`
- [x] Unauthenticated reads and writes are rejected for all user-scoped paths
- [x] Rules are documented with inline comments explaining each section
- [x] A `firebase.json` config file is present at the project root referencing the rules file

## Tests
9 tests added, all passing.

Closes #25

---
*Created by Claude Sonnet 4.6*