### PR TITLE
feat(data-layer): implement typed repository services and real-time hooks

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,7 @@
+export { useAnnuities } from "./use-annuities";
 export { useAuth } from "./use-auth";
+export { useLedgersSubscription } from "./use-ledgers-subscription";
+export { useReconciliationAccounts } from "./use-reconciliation-accounts";
+export { useReconciliationExpenses } from "./use-reconciliation-expenses";
+export { useSavingsGoals } from "./use-savings-goals";
+export { useTransactions } from "./use-transactions";

--- a/src/hooks/use-annuities.spec.ts
+++ b/src/hooks/use-annuities.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { useAnnuities } from "./use-annuities";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useAnnuities", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useAnnuities(""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useAnnuities(""));
+      expect(result.current.annuities).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useAnnuities("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.annuities).toEqual([]);
+    });
+
+    it("maps snapshot data to Annuity objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({
+              "annuity-1": {
+                name: "Netflix",
+                monthlyAmount: 15,
+                startDate: "2024-01-01T00:00:00.000Z",
+                durationMonths: null,
+              },
+            }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useAnnuities("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.annuities).toHaveLength(1);
+      });
+
+      expect(result.current.annuities[0]).toMatchObject({
+        id: "annuity-1",
+        name: "Netflix",
+        monthlyAmount: 15,
+        durationMonths: undefined,
+      });
+      expect(result.current.annuities[0]!.startDate).toBeInstanceOf(Date);
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() => useAnnuities("uid-1"));
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useAnnuities("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-annuities.ts
+++ b/src/hooks/use-annuities.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToAnnuity,
+  type FirebaseAnnuity,
+  type Annuity,
+} from "@/lib/firebase/schema/annuities";
+
+export function useAnnuities(uid: string) {
+  const [annuities, setAnnuities] = useState<Annuity[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setAnnuities([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const annuitiesRef = ref(db, `users/${uid}/annuities`);
+
+    const unsubscribe = onValue(
+      annuitiesRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setAnnuities([]);
+        } else {
+          const data = snapshot.val() as Record<string, FirebaseAnnuity>;
+          setAnnuities(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToAnnuity(id, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid]);
+
+  return { annuities, isLoading, error };
+}

--- a/src/hooks/use-ledgers-subscription.spec.ts
+++ b/src/hooks/use-ledgers-subscription.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { useLedgersSubscription } from "./use-ledgers-subscription";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useLedgersSubscription", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useLedgersSubscription(""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useLedgersSubscription(""));
+      expect(result.current.ledgers).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useLedgersSubscription("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ledgers).toEqual([]);
+    });
+
+    it("maps snapshot data to BudgetLedger objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({
+              "ledger-1": { name: "Everyday Spending", cashCap: 500 },
+              "ledger-2": { name: "Savings", cashCap: null },
+            }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useLedgersSubscription("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.ledgers).toHaveLength(2);
+      });
+
+      expect(result.current.ledgers[0]).toMatchObject({
+        id: "ledger-1",
+        name: "Everyday Spending",
+        cashCap: 500,
+      });
+      expect(result.current.ledgers[1]).toMatchObject({
+        id: "ledger-2",
+        name: "Savings",
+        cashCap: undefined,
+      });
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() => useLedgersSubscription("uid-1"));
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useLedgersSubscription("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-ledgers-subscription.ts
+++ b/src/hooks/use-ledgers-subscription.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToBudgetLedger,
+  type FirebaseBudgetLedger,
+  type BudgetLedger,
+} from "@/lib/firebase/schema/budget-ledgers";
+
+export function useLedgersSubscription(uid: string) {
+  const [ledgers, setLedgers] = useState<BudgetLedger[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setLedgers([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const ledgersRef = ref(db, `users/${uid}/budgetLedgers`);
+
+    const unsubscribe = onValue(
+      ledgersRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setLedgers([]);
+        } else {
+          const data = snapshot.val() as Record<string, FirebaseBudgetLedger>;
+          setLedgers(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToBudgetLedger(id, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid]);
+
+  return { ledgers, isLoading, error };
+}

--- a/src/hooks/use-reconciliation-accounts.spec.ts
+++ b/src/hooks/use-reconciliation-accounts.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { useReconciliationAccounts } from "./use-reconciliation-accounts";
+import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useReconciliationAccounts", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useReconciliationAccounts(""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useReconciliationAccounts(""));
+      expect(result.current.reconciliationAccounts).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationAccounts("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.reconciliationAccounts).toEqual([]);
+    });
+
+    it("maps snapshot data to ReconciliationAccount objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({
+              "account-1": {
+                name: "Chase Checking",
+                tier: ReconciliationAccountTier.ShortTerm,
+                targetFloat: 2000,
+              },
+            }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationAccounts("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.reconciliationAccounts).toHaveLength(1);
+      });
+
+      expect(result.current.reconciliationAccounts[0]).toMatchObject({
+        id: "account-1",
+        name: "Chase Checking",
+        tier: ReconciliationAccountTier.ShortTerm,
+        targetFloat: 2000,
+      });
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() => useReconciliationAccounts("uid-1"));
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationAccounts("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-reconciliation-accounts.ts
+++ b/src/hooks/use-reconciliation-accounts.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToReconciliationAccount,
+  type FirebaseReconciliationAccount,
+  type ReconciliationAccount,
+} from "@/lib/firebase/schema/reconciliation-accounts";
+
+export function useReconciliationAccounts(uid: string) {
+  const [reconciliationAccounts, setReconciliationAccounts] = useState<
+    ReconciliationAccount[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setReconciliationAccounts([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const accountsRef = ref(db, `users/${uid}/reconciliationAccounts`);
+
+    const unsubscribe = onValue(
+      accountsRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setReconciliationAccounts([]);
+        } else {
+          const data = snapshot.val() as Record<
+            string,
+            FirebaseReconciliationAccount
+          >;
+          setReconciliationAccounts(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToReconciliationAccount(id, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid]);
+
+  return { reconciliationAccounts, isLoading, error };
+}

--- a/src/hooks/use-reconciliation-expenses.spec.ts
+++ b/src/hooks/use-reconciliation-expenses.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { useReconciliationExpenses } from "./use-reconciliation-expenses";
+import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useReconciliationExpenses", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useReconciliationExpenses(""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useReconciliationExpenses(""));
+      expect(result.current.reconciliationExpenses).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationExpenses("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.reconciliationExpenses).toEqual([]);
+    });
+
+    it("maps snapshot data to ReconciliationExpense objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({
+              "expense-1": {
+                name: "Electric Bill",
+                type: ReconciliationExpenseType.StatementBalance,
+                typicalAmount: 120,
+              },
+            }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationExpenses("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.reconciliationExpenses).toHaveLength(1);
+      });
+
+      expect(result.current.reconciliationExpenses[0]).toMatchObject({
+        id: "expense-1",
+        name: "Electric Bill",
+        type: ReconciliationExpenseType.StatementBalance,
+        typicalAmount: 120,
+      });
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() => useReconciliationExpenses("uid-1"));
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationExpenses("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-reconciliation-expenses.ts
+++ b/src/hooks/use-reconciliation-expenses.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToReconciliationExpense,
+  type FirebaseReconciliationExpense,
+  type ReconciliationExpense,
+} from "@/lib/firebase/schema/reconciliation-expenses";
+
+export function useReconciliationExpenses(uid: string) {
+  const [reconciliationExpenses, setReconciliationExpenses] = useState<
+    ReconciliationExpense[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setReconciliationExpenses([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const expensesRef = ref(db, `users/${uid}/reconciliationExpenses`);
+
+    const unsubscribe = onValue(
+      expensesRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setReconciliationExpenses([]);
+        } else {
+          const data = snapshot.val() as Record<
+            string,
+            FirebaseReconciliationExpense
+          >;
+          setReconciliationExpenses(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToReconciliationExpense(id, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid]);
+
+  return { reconciliationExpenses, isLoading, error };
+}

--- a/src/hooks/use-savings-goals.spec.ts
+++ b/src/hooks/use-savings-goals.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup, act } from "@testing-library/react";
+import { useSavingsGoals } from "./use-savings-goals";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeFirebaseGoal() {
+  return {
+    name: "Emergency Fund",
+    targetAmount: 5000,
+    fundedAmount: 1000,
+    priority: 1,
+  };
+}
+
+describe("useSavingsGoals", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useSavingsGoals("", "ledger-1"));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("does not subscribe when ledgerId is empty", () => {
+      renderHook(() => useSavingsGoals("uid-1", ""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useSavingsGoals("", "ledger-1"));
+      expect(result.current.savingsGoals).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useSavingsGoals("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.savingsGoals).toEqual([]);
+    });
+
+    it("maps snapshot data to BudgetLedgerSavingsGoal objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({ "goal-1": makeFirebaseGoal() }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useSavingsGoals("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.savingsGoals).toHaveLength(1);
+      });
+
+      expect(result.current.savingsGoals[0]).toMatchObject({
+        id: "goal-1",
+        ledgerId: "ledger-1",
+        name: "Emergency Fund",
+        targetAmount: 5000,
+        fundedAmount: 1000,
+        priority: 1,
+      });
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+
+      const { unmount } = renderHook(() =>
+        useSavingsGoals("uid-1", "ledger-1"),
+      );
+      unmount();
+
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useSavingsGoals("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+
+  describe("re-subscription", () => {
+    it("resubscribes when uid changes", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+
+      const { rerender } = renderHook(
+        ({ uid }: { uid: string }) => useSavingsGoals(uid, "ledger-1"),
+        { initialProps: { uid: "uid-1" } },
+      );
+
+      act(() => {
+        rerender({ uid: "uid-2" });
+      });
+
+      expect(mockOnValue).toHaveBeenCalledTimes(2);
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/use-savings-goals.ts
+++ b/src/hooks/use-savings-goals.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToBudgetLedgerSavingsGoal,
+  type FirebaseBudgetLedgerSavingsGoal,
+  type BudgetLedgerSavingsGoal,
+} from "@/lib/firebase/schema/savings-goals";
+
+export function useSavingsGoals(uid: string, ledgerId: string) {
+  const [savingsGoals, setSavingsGoals] = useState<BudgetLedgerSavingsGoal[]>(
+    [],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid || !ledgerId) {
+      setSavingsGoals([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const goalsRef = ref(
+      db,
+      `users/${uid}/budgetLedgerSavingsGoals/${ledgerId}`,
+    );
+
+    const unsubscribe = onValue(
+      goalsRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setSavingsGoals([]);
+        } else {
+          const data = snapshot.val() as Record<
+            string,
+            FirebaseBudgetLedgerSavingsGoal
+          >;
+          setSavingsGoals(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToBudgetLedgerSavingsGoal(id, ledgerId, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid, ledgerId]);
+
+  return { savingsGoals, isLoading, error };
+}

--- a/src/hooks/use-transactions.spec.ts
+++ b/src/hooks/use-transactions.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { useTransactions } from "./use-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useTransactions", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useTransactions("", "ledger-1"));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("does not subscribe when ledgerId is empty", () => {
+      renderHook(() => useTransactions("uid-1", ""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when uid is empty", () => {
+      const { result } = renderHook(() => useTransactions("", "ledger-1"));
+      expect(result.current.transactions).toEqual([]);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns empty array when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useTransactions("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.transactions).toEqual([]);
+    });
+
+    it("maps snapshot data to BudgetLedgerTransaction objects", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({
+              "tx-1": {
+                type: BudgetLedgerTransactionType.Expense,
+                date: "2024-03-01T00:00:00.000Z",
+                amount: 50,
+                description: "Coffee",
+              },
+            }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useTransactions("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.transactions).toHaveLength(1);
+      });
+
+      expect(result.current.transactions[0]).toMatchObject({
+        id: "tx-1",
+        ledgerId: "ledger-1",
+        type: BudgetLedgerTransactionType.Expense,
+        amount: 50,
+        description: "Coffee",
+      });
+      expect(result.current.transactions[0]!.date).toBeInstanceOf(Date);
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() =>
+        useTransactions("uid-1", "ledger-1"),
+      );
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useTransactions("uid-1", "ledger-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToBudgetLedgerTransaction,
+  type FirebaseBudgetLedgerTransaction,
+  type BudgetLedgerTransaction,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+
+export function useTransactions(uid: string, ledgerId: string) {
+  const [transactions, setTransactions] = useState<BudgetLedgerTransaction[]>(
+    [],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid || !ledgerId) {
+      setTransactions([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const txRef = ref(db, `users/${uid}/budgetLedgerTransactions/${ledgerId}`);
+
+    const unsubscribe = onValue(
+      txRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setTransactions([]);
+        } else {
+          const data = snapshot.val() as Record<
+            string,
+            FirebaseBudgetLedgerTransaction
+          >;
+          setTransactions(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToBudgetLedgerTransaction(id, ledgerId, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid, ledgerId]);
+
+  return { transactions, isLoading, error };
+}

--- a/src/services/annuities.spec.ts
+++ b/src/services/annuities.spec.ts
@@ -120,6 +120,22 @@ describe("updateAnnuity", () => {
       startDate: "2025-01-01T00:00:00.000Z",
     });
   });
+
+  it("writes null to durationMonths when clearing the field", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateAnnuity("uid-1", "annuity-1", { durationMonths: undefined });
+    expect(update).toHaveBeenCalledWith(mockRef, { durationMonths: null });
+  });
+
+  it("omits durationMonths from the update when the key is absent", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateAnnuity("uid-1", "annuity-1", { monthlyAmount: 20 });
+    const calledWith = vi.mocked(update).mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    expect("durationMonths" in calledWith).toBe(false);
+  });
 });
 
 describe("deleteAnnuity", () => {

--- a/src/services/annuities.spec.ts
+++ b/src/services/annuities.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import {
+  getAnnuities,
+  createAnnuity,
+  updateAnnuity,
+  deleteAnnuity,
+} from "./annuities";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getAnnuities", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getAnnuities("uid-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped annuities when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "annuity-1": {
+          name: "Netflix",
+          monthlyAmount: 15,
+          startDate: "2024-01-01T00:00:00.000Z",
+          durationMonths: null,
+        },
+      }),
+    } as never);
+
+    const result = await getAnnuities("uid-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "annuity-1",
+      name: "Netflix",
+      monthlyAmount: 15,
+      durationMonths: undefined,
+    });
+    expect(result[0]!.startDate).toBeInstanceOf(Date);
+  });
+});
+
+describe("createAnnuity", () => {
+  it("pushes to firebase and returns the new annuity", async () => {
+    const newRef = { key: "annuity-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const result = await createAnnuity("uid-1", {
+      name: "Spotify",
+      monthlyAmount: 10,
+      startDate: new Date("2024-01-01T00:00:00.000Z"),
+      durationMonths: undefined,
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(result.id).toBe("annuity-new");
+    expect(result.name).toBe("Spotify");
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createAnnuity("uid-1", {
+        name: "Gym",
+        monthlyAmount: 50,
+        startDate: new Date(),
+        durationMonths: 12,
+      }),
+    ).rejects.toThrow("Failed to generate annuity key");
+  });
+});
+
+describe("updateAnnuity", () => {
+  it("calls update with the partial fields", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateAnnuity("uid-1", "annuity-1", { monthlyAmount: 20 });
+    expect(update).toHaveBeenCalledWith(mockRef, { monthlyAmount: 20 });
+  });
+
+  it("serializes the startDate to ISO string when provided", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    const date = new Date("2025-01-01T00:00:00.000Z");
+    await updateAnnuity("uid-1", "annuity-1", { startDate: date });
+    expect(update).toHaveBeenCalledWith(mockRef, {
+      startDate: "2025-01-01T00:00:00.000Z",
+    });
+  });
+});
+
+describe("deleteAnnuity", () => {
+  it("calls remove on the annuity ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteAnnuity("uid-1", "annuity-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+});

--- a/src/services/annuities.ts
+++ b/src/services/annuities.ts
@@ -1,0 +1,76 @@
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  annuityToFirebase,
+  firebaseToAnnuity,
+  type FirebaseAnnuity,
+  type Annuity,
+} from "@/lib/firebase/schema/annuities";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function annuitiesRef(uid: string) {
+  return ref(db(), `users/${uid}/annuities`);
+}
+
+function annuityRef(uid: string, id: string) {
+  return ref(db(), `users/${uid}/annuities/${id}`);
+}
+
+export async function getAnnuities(uid: string): Promise<Annuity[]> {
+  const snapshot = await get(annuitiesRef(uid));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<string, FirebaseAnnuity>;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToAnnuity(id, entry),
+  );
+}
+
+export async function createAnnuity(
+  uid: string,
+  data: Omit<Annuity, "id">,
+): Promise<Annuity> {
+  const newRef = push(annuitiesRef(uid));
+  if (!newRef.key) {
+    throw new Error("Failed to generate annuity key");
+  }
+  await set(newRef, annuityToFirebase(data));
+  return { id: newRef.key, ...data };
+}
+
+export async function updateAnnuity(
+  uid: string,
+  id: string,
+  data: Partial<Omit<Annuity, "id">>,
+): Promise<void> {
+  const updates: Partial<FirebaseAnnuity> = {};
+  if (data.name !== undefined) {
+    updates.name = data.name;
+  }
+  if (data.monthlyAmount !== undefined) {
+    updates.monthlyAmount = data.monthlyAmount;
+  }
+  if (data.startDate !== undefined) {
+    updates.startDate = data.startDate.toISOString();
+  }
+  if (data.durationMonths !== undefined) {
+    updates.durationMonths = data.durationMonths;
+  }
+  await update(annuityRef(uid, id), updates);
+}
+
+export async function deleteAnnuity(uid: string, id: string): Promise<void> {
+  await remove(annuityRef(uid, id));
+}

--- a/src/services/annuities.ts
+++ b/src/services/annuities.ts
@@ -65,8 +65,8 @@ export async function updateAnnuity(
   if (data.startDate !== undefined) {
     updates.startDate = data.startDate.toISOString();
   }
-  if (data.durationMonths !== undefined) {
-    updates.durationMonths = data.durationMonths;
+  if ("durationMonths" in data) {
+    updates.durationMonths = data.durationMonths ?? null;
   }
   await update(annuityRef(uid, id), updates);
 }

--- a/src/services/reconciliation-accounts.spec.ts
+++ b/src/services/reconciliation-accounts.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import {
+  getReconciliationAccounts,
+  createReconciliationAccount,
+  updateReconciliationAccount,
+  deleteReconciliationAccount,
+} from "./reconciliation-accounts";
+import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getReconciliationAccounts", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getReconciliationAccounts("uid-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped accounts when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "account-1": {
+          name: "Chase Checking",
+          tier: ReconciliationAccountTier.ShortTerm,
+          targetFloat: 2000,
+        },
+      }),
+    } as never);
+
+    const result = await getReconciliationAccounts("uid-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "account-1",
+      name: "Chase Checking",
+      tier: ReconciliationAccountTier.ShortTerm,
+      targetFloat: 2000,
+    });
+  });
+});
+
+describe("createReconciliationAccount", () => {
+  it("pushes to firebase and returns the new account", async () => {
+    const newRef = { key: "account-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const result = await createReconciliationAccount("uid-1", {
+      name: "Savings",
+      tier: ReconciliationAccountTier.Reserve,
+      targetFloat: 5000,
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(result.id).toBe("account-new");
+    expect(result.name).toBe("Savings");
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createReconciliationAccount("uid-1", {
+        name: "Savings",
+        tier: ReconciliationAccountTier.Reserve,
+        targetFloat: 5000,
+      }),
+    ).rejects.toThrow("Failed to generate reconciliation account key");
+  });
+});
+
+describe("updateReconciliationAccount", () => {
+  it("calls update with the partial fields", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateReconciliationAccount("uid-1", "account-1", {
+      targetFloat: 3000,
+    });
+    expect(update).toHaveBeenCalledWith(mockRef, { targetFloat: 3000 });
+  });
+});
+
+describe("deleteReconciliationAccount", () => {
+  it("calls remove on the account ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteReconciliationAccount("uid-1", "account-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+});

--- a/src/services/reconciliation-accounts.ts
+++ b/src/services/reconciliation-accounts.ts
@@ -1,0 +1,78 @@
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  reconciliationAccountToFirebase,
+  firebaseToReconciliationAccount,
+  type FirebaseReconciliationAccount,
+  type ReconciliationAccount,
+} from "@/lib/firebase/schema/reconciliation-accounts";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function reconciliationAccountsRef(uid: string) {
+  return ref(db(), `users/${uid}/reconciliationAccounts`);
+}
+
+function reconciliationAccountRef(uid: string, id: string) {
+  return ref(db(), `users/${uid}/reconciliationAccounts/${id}`);
+}
+
+export async function getReconciliationAccounts(
+  uid: string,
+): Promise<ReconciliationAccount[]> {
+  const snapshot = await get(reconciliationAccountsRef(uid));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<string, FirebaseReconciliationAccount>;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToReconciliationAccount(id, entry),
+  );
+}
+
+export async function createReconciliationAccount(
+  uid: string,
+  data: Omit<ReconciliationAccount, "id">,
+): Promise<ReconciliationAccount> {
+  const newRef = push(reconciliationAccountsRef(uid));
+  if (!newRef.key) {
+    throw new Error("Failed to generate reconciliation account key");
+  }
+  await set(newRef, reconciliationAccountToFirebase(data));
+  return { id: newRef.key, ...data };
+}
+
+export async function updateReconciliationAccount(
+  uid: string,
+  id: string,
+  data: Partial<Omit<ReconciliationAccount, "id">>,
+): Promise<void> {
+  const updates: Partial<FirebaseReconciliationAccount> = {};
+  if (data.name !== undefined) {
+    updates.name = data.name;
+  }
+  if (data.tier !== undefined) {
+    updates.tier = data.tier;
+  }
+  if (data.targetFloat !== undefined) {
+    updates.targetFloat = data.targetFloat;
+  }
+  await update(reconciliationAccountRef(uid, id), updates);
+}
+
+export async function deleteReconciliationAccount(
+  uid: string,
+  id: string,
+): Promise<void> {
+  await remove(reconciliationAccountRef(uid, id));
+}

--- a/src/services/reconciliation-expenses.spec.ts
+++ b/src/services/reconciliation-expenses.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import {
+  getReconciliationExpenses,
+  createReconciliationExpense,
+  updateReconciliationExpense,
+  deleteReconciliationExpense,
+} from "./reconciliation-expenses";
+import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getReconciliationExpenses", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getReconciliationExpenses("uid-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped expenses when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "expense-1": {
+          name: "Electric Bill",
+          type: ReconciliationExpenseType.StatementBalance,
+          typicalAmount: 120,
+        },
+      }),
+    } as never);
+
+    const result = await getReconciliationExpenses("uid-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "expense-1",
+      name: "Electric Bill",
+      type: ReconciliationExpenseType.StatementBalance,
+      typicalAmount: 120,
+    });
+  });
+});
+
+describe("createReconciliationExpense", () => {
+  it("pushes to firebase and returns the new expense", async () => {
+    const newRef = { key: "expense-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const result = await createReconciliationExpense("uid-1", {
+      name: "Internet",
+      type: ReconciliationExpenseType.RunningBalance,
+      typicalAmount: 80,
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(result.id).toBe("expense-new");
+    expect(result.name).toBe("Internet");
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createReconciliationExpense("uid-1", {
+        name: "Internet",
+        type: ReconciliationExpenseType.RunningBalance,
+        typicalAmount: 80,
+      }),
+    ).rejects.toThrow("Failed to generate reconciliation expense key");
+  });
+});
+
+describe("updateReconciliationExpense", () => {
+  it("calls update with the partial fields", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateReconciliationExpense("uid-1", "expense-1", {
+      typicalAmount: 90,
+    });
+    expect(update).toHaveBeenCalledWith(mockRef, { typicalAmount: 90 });
+  });
+});
+
+describe("deleteReconciliationExpense", () => {
+  it("calls remove on the expense ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteReconciliationExpense("uid-1", "expense-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+});

--- a/src/services/reconciliation-expenses.ts
+++ b/src/services/reconciliation-expenses.ts
@@ -1,0 +1,78 @@
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  reconciliationExpenseToFirebase,
+  firebaseToReconciliationExpense,
+  type FirebaseReconciliationExpense,
+  type ReconciliationExpense,
+} from "@/lib/firebase/schema/reconciliation-expenses";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function reconciliationExpensesRef(uid: string) {
+  return ref(db(), `users/${uid}/reconciliationExpenses`);
+}
+
+function reconciliationExpenseRef(uid: string, id: string) {
+  return ref(db(), `users/${uid}/reconciliationExpenses/${id}`);
+}
+
+export async function getReconciliationExpenses(
+  uid: string,
+): Promise<ReconciliationExpense[]> {
+  const snapshot = await get(reconciliationExpensesRef(uid));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<string, FirebaseReconciliationExpense>;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToReconciliationExpense(id, entry),
+  );
+}
+
+export async function createReconciliationExpense(
+  uid: string,
+  data: Omit<ReconciliationExpense, "id">,
+): Promise<ReconciliationExpense> {
+  const newRef = push(reconciliationExpensesRef(uid));
+  if (!newRef.key) {
+    throw new Error("Failed to generate reconciliation expense key");
+  }
+  await set(newRef, reconciliationExpenseToFirebase(data));
+  return { id: newRef.key, ...data };
+}
+
+export async function updateReconciliationExpense(
+  uid: string,
+  id: string,
+  data: Partial<Omit<ReconciliationExpense, "id">>,
+): Promise<void> {
+  const updates: Partial<FirebaseReconciliationExpense> = {};
+  if (data.name !== undefined) {
+    updates.name = data.name;
+  }
+  if (data.type !== undefined) {
+    updates.type = data.type;
+  }
+  if (data.typicalAmount !== undefined) {
+    updates.typicalAmount = data.typicalAmount;
+  }
+  await update(reconciliationExpenseRef(uid, id), updates);
+}
+
+export async function deleteReconciliationExpense(
+  uid: string,
+  id: string,
+): Promise<void> {
+  await remove(reconciliationExpenseRef(uid, id));
+}

--- a/src/services/savings-goals.spec.ts
+++ b/src/services/savings-goals.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import {
+  getSavingsGoals,
+  createSavingsGoal,
+  updateSavingsGoal,
+  deleteSavingsGoal,
+} from "./savings-goals";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSavingsGoals", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getSavingsGoals("uid-1", "ledger-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped goals when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "goal-1": {
+          name: "Emergency Fund",
+          targetAmount: 5000,
+          fundedAmount: 1000,
+          priority: 1,
+        },
+      }),
+    } as never);
+    const result = await getSavingsGoals("uid-1", "ledger-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "goal-1",
+      ledgerId: "ledger-1",
+      name: "Emergency Fund",
+      targetAmount: 5000,
+      fundedAmount: 1000,
+      priority: 1,
+    });
+  });
+});
+
+describe("createSavingsGoal", () => {
+  it("pushes to firebase and returns the new goal", async () => {
+    const newRef = { key: "goal-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const result = await createSavingsGoal("uid-1", "ledger-1", {
+      name: "Vacation",
+      targetAmount: 2000,
+      fundedAmount: 0,
+      priority: 2,
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(set).toHaveBeenCalled();
+    expect(result.id).toBe("goal-new");
+    expect(result.name).toBe("Vacation");
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createSavingsGoal("uid-1", "ledger-1", {
+        name: "Vacation",
+        targetAmount: 2000,
+        fundedAmount: 0,
+        priority: 2,
+      }),
+    ).rejects.toThrow("Failed to generate savings goal key");
+  });
+});
+
+describe("updateSavingsGoal", () => {
+  it("calls update with the partial fields", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateSavingsGoal("uid-1", "ledger-1", "goal-1", {
+      fundedAmount: 500,
+    });
+    expect(update).toHaveBeenCalledWith(mockRef, { fundedAmount: 500 });
+  });
+});
+
+describe("deleteSavingsGoal", () => {
+  it("calls remove on the goal ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteSavingsGoal("uid-1", "ledger-1", "goal-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+});

--- a/src/services/savings-goals.ts
+++ b/src/services/savings-goals.ts
@@ -1,0 +1,88 @@
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  push,
+  remove,
+} from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  budgetLedgerSavingsGoalToFirebase,
+  firebaseToBudgetLedgerSavingsGoal,
+  type FirebaseBudgetLedgerSavingsGoal,
+  type BudgetLedgerSavingsGoal,
+} from "@/lib/firebase/schema/savings-goals";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function savingsGoalsRef(uid: string, ledgerId: string) {
+  return ref(db(), `users/${uid}/budgetLedgerSavingsGoals/${ledgerId}`);
+}
+
+function savingsGoalRef(uid: string, ledgerId: string, id: string) {
+  return ref(db(), `users/${uid}/budgetLedgerSavingsGoals/${ledgerId}/${id}`);
+}
+
+export async function getSavingsGoals(
+  uid: string,
+  ledgerId: string,
+): Promise<BudgetLedgerSavingsGoal[]> {
+  const snapshot = await get(savingsGoalsRef(uid, ledgerId));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<
+    string,
+    FirebaseBudgetLedgerSavingsGoal
+  >;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToBudgetLedgerSavingsGoal(id, ledgerId, entry),
+  );
+}
+
+export async function createSavingsGoal(
+  uid: string,
+  ledgerId: string,
+  data: Omit<BudgetLedgerSavingsGoal, "id" | "ledgerId">,
+): Promise<BudgetLedgerSavingsGoal> {
+  const newRef = push(savingsGoalsRef(uid, ledgerId));
+  if (!newRef.key) {
+    throw new Error("Failed to generate savings goal key");
+  }
+  await set(newRef, budgetLedgerSavingsGoalToFirebase(data));
+  return { id: newRef.key, ledgerId, ...data };
+}
+
+export async function updateSavingsGoal(
+  uid: string,
+  ledgerId: string,
+  id: string,
+  data: Partial<Omit<BudgetLedgerSavingsGoal, "id" | "ledgerId">>,
+): Promise<void> {
+  const updates: Partial<FirebaseBudgetLedgerSavingsGoal> = {};
+  if (data.name !== undefined) {
+    updates.name = data.name;
+  }
+  if (data.targetAmount !== undefined) {
+    updates.targetAmount = data.targetAmount;
+  }
+  if (data.fundedAmount !== undefined) {
+    updates.fundedAmount = data.fundedAmount;
+  }
+  if (data.priority !== undefined) {
+    updates.priority = data.priority;
+  }
+  await update(savingsGoalRef(uid, ledgerId, id), updates);
+}
+
+export async function deleteSavingsGoal(
+  uid: string,
+  ledgerId: string,
+  id: string,
+): Promise<void> {
+  await remove(savingsGoalRef(uid, ledgerId, id));
+}

--- a/src/services/transactions.spec.ts
+++ b/src/services/transactions.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import { getDatabase, ref, get, set, push, remove } from "firebase/database";
+import {
+  getTransactions,
+  createTransaction,
+  deleteTransaction,
+} from "./transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getTransactions", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getTransactions("uid-1", "ledger-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped transactions when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "tx-1": {
+          type: BudgetLedgerTransactionType.Expense,
+          date: "2024-03-01T00:00:00.000Z",
+          amount: 50,
+          description: "Coffee",
+        },
+      }),
+    } as never);
+
+    const result = await getTransactions("uid-1", "ledger-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "tx-1",
+      ledgerId: "ledger-1",
+      type: BudgetLedgerTransactionType.Expense,
+      amount: 50,
+      description: "Coffee",
+    });
+    expect(result[0]!.date).toBeInstanceOf(Date);
+  });
+});
+
+describe("createTransaction", () => {
+  it("pushes to firebase and returns the new transaction", async () => {
+    const newRef = { key: "tx-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const date = new Date("2024-03-01T00:00:00.000Z");
+    const result = await createTransaction("uid-1", "ledger-1", {
+      type: BudgetLedgerTransactionType.Deposit,
+      date,
+      amount: 1000,
+      description: "Paycheck",
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(result.id).toBe("tx-new");
+    expect(result.amount).toBe(1000);
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createTransaction("uid-1", "ledger-1", {
+        type: BudgetLedgerTransactionType.Deposit,
+        date: new Date(),
+        amount: 100,
+        description: "Test",
+      }),
+    ).rejects.toThrow("Failed to generate transaction key");
+  });
+});
+
+describe("deleteTransaction", () => {
+  it("calls remove on the transaction ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteTransaction("uid-1", "ledger-1", "tx-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+});

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -1,0 +1,58 @@
+import { getDatabase, ref, get, set, push, remove } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  budgetLedgerTransactionToFirebase,
+  firebaseToBudgetLedgerTransaction,
+  type FirebaseBudgetLedgerTransaction,
+  type BudgetLedgerTransaction,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function transactionsRef(uid: string, ledgerId: string) {
+  return ref(db(), `users/${uid}/budgetLedgerTransactions/${ledgerId}`);
+}
+
+function transactionRef(uid: string, ledgerId: string, id: string) {
+  return ref(db(), `users/${uid}/budgetLedgerTransactions/${ledgerId}/${id}`);
+}
+
+export async function getTransactions(
+  uid: string,
+  ledgerId: string,
+): Promise<BudgetLedgerTransaction[]> {
+  const snapshot = await get(transactionsRef(uid, ledgerId));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<
+    string,
+    FirebaseBudgetLedgerTransaction
+  >;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToBudgetLedgerTransaction(id, ledgerId, entry),
+  );
+}
+
+export async function createTransaction(
+  uid: string,
+  ledgerId: string,
+  data: Omit<BudgetLedgerTransaction, "id" | "ledgerId">,
+): Promise<BudgetLedgerTransaction> {
+  const newRef = push(transactionsRef(uid, ledgerId));
+  if (!newRef.key) {
+    throw new Error("Failed to generate transaction key");
+  }
+  await set(newRef, budgetLedgerTransactionToFirebase(data));
+  return { id: newRef.key, ledgerId, ...data };
+}
+
+export async function deleteTransaction(
+  uid: string,
+  ledgerId: string,
+  id: string,
+): Promise<void> {
+  await remove(transactionRef(uid, ledgerId, id));
+}


### PR DESCRIPTION
Implements the typed data access layer for all budget domains: typed async CRUD service functions in `src/services/` and real-time `onValue` subscription hooks in `src/hooks/`. All Firebase access is now routed through these modules; no component imports Firebase directly.

Services use the existing Firebase schema converters (`firebaseTo*` / `*ToFirebase`) to map between raw RTDB snapshots and typed domain objects. Hooks follow a consistent pattern — empty-guard early return, `onValue` subscription, cleanup via returned unsubscribe, and `{ data, isLoading, error }` shape.

## Acceptance Criteria
- [x] Service modules exist for: ledgers (pre-existing), savings goals, annuities, reconciliation accounts, reconciliation expenses, transactions
- [x] Each service exposes typed async functions for create, read, update, delete (transactions: create/read/delete; no update needed)
- [x] Read functions return domain types (not raw Firebase snapshots); write functions accept domain types
- [x] Real-time subscription hooks (using `onValue`) in `src/hooks/` for each domain
- [x] No component imports Firebase directly — all access is through services or hooks

**Out of scope — investment ledgers**: Issue #24 lists investment ledgers as a required domain. No Firebase schema has been defined for investment ledgers yet (there is no `src/lib/firebase/schema/investment-ledgers.ts`), so service and hook modules cannot be implemented without first defining the schema. Investment ledgers are deferred to a follow-up issue.

## Tests
11 new spec files covering the full scope of new modules: 6 hook specs (`use-annuities`, `use-ledgers-subscription`, `use-reconciliation-accounts`, `use-reconciliation-expenses`, `use-savings-goals`, `use-transactions`) and 5 service specs (`annuities`, `reconciliation-accounts`, `reconciliation-expenses`, `savings-goals`, `transactions`).

Closes #24

---
*Created by Claude Sonnet 4.6*