### PR TITLE
feat(savings-goals): savings goal list per ledger

### DIFF
--- a/src/components/savings-goals/SavingsGoalList.spec.tsx
+++ b/src/components/savings-goals/SavingsGoalList.spec.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { SavingsGoalListView } from "./SavingsGoalList";
+import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+afterEach(cleanup);
+
+function makeSavingsGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "Emergency Fund",
+    targetAmount: 5000,
+    fundedAmount: 1000,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+describe("SavingsGoalListView", () => {
+  describe("Goals are listed in priority order (highest priority first)", () => {
+    it("renders goals sorted by priority ascending (rank 1 first)", () => {
+      const goals = [
+        makeSavingsGoal({ id: "a", name: "Low Priority", priority: 3 }),
+        makeSavingsGoal({ id: "b", name: "High Priority", priority: 1 }),
+        makeSavingsGoal({ id: "c", name: "Mid Priority", priority: 2 }),
+      ];
+      render(<SavingsGoalListView goals={goals} />);
+      const [, firstRow, secondRow, thirdRow] = screen.getAllByRole("row");
+      // rows[0] is the header row
+      expect(firstRow?.textContent).toContain("High Priority");
+      expect(secondRow?.textContent).toContain("Mid Priority");
+      expect(thirdRow?.textContent).toContain("Low Priority");
+    });
+  });
+
+  describe("Each row shows name, target amount, funded amount, progress percentage, priority rank", () => {
+    it("renders the goal name", () => {
+      const goals = [makeSavingsGoal({ name: "Vacation Fund" })];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("Vacation Fund")).toBeDefined();
+    });
+
+    it("renders the target amount formatted as currency", () => {
+      const goals = [makeSavingsGoal({ targetAmount: 5000 })];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("$5,000.00")).toBeDefined();
+    });
+
+    it("renders the funded amount formatted as currency", () => {
+      const goals = [makeSavingsGoal({ fundedAmount: 1250 })];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("$1,250.00")).toBeDefined();
+    });
+
+    it("renders the progress percentage", () => {
+      const goals = [
+        makeSavingsGoal({ fundedAmount: 2500, targetAmount: 5000 }),
+      ];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("50%")).toBeDefined();
+    });
+
+    it("renders the priority rank", () => {
+      const goals = [makeSavingsGoal({ priority: 2 })];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("2")).toBeDefined();
+    });
+  });
+
+  describe("Empty state prompts the user to create their first goal", () => {
+    it("renders the empty state message when there are no goals", () => {
+      render(<SavingsGoalListView goals={[]} />);
+      expect(
+        screen.getByText(SAVINGS_GOAL_LIST_COPY.emptyStateMessage),
+      ).toBeDefined();
+    });
+
+    it("does not render the empty state message when goals exist", () => {
+      render(<SavingsGoalListView goals={[makeSavingsGoal()]} />);
+      expect(
+        screen.queryByText(SAVINGS_GOAL_LIST_COPY.emptyStateMessage),
+      ).toBeNull();
+    });
+  });
+
+  describe("Component tests verify progress display from fixture goals", () => {
+    it("renders a progress bar for a partially funded goal", () => {
+      const goals = [
+        makeSavingsGoal({ fundedAmount: 1000, targetAmount: 5000 }),
+      ];
+      render(<SavingsGoalListView goals={goals} />);
+      const progressbar = screen.getByRole("progressbar");
+      expect(progressbar).toBeDefined();
+      expect(Number(progressbar.getAttribute("aria-valuenow"))).toBe(20);
+    });
+
+    it("renders 100% progress and full funded amount for a fully funded goal", () => {
+      const goals = [
+        makeSavingsGoal({ fundedAmount: 5000, targetAmount: 5000 }),
+      ];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("100%")).toBeDefined();
+      const progressbar = screen.getByRole("progressbar");
+      expect(Number(progressbar.getAttribute("aria-valuenow"))).toBe(100);
+    });
+
+    it("renders 0% progress for an unfunded goal", () => {
+      const goals = [makeSavingsGoal({ fundedAmount: 0, targetAmount: 5000 })];
+      render(<SavingsGoalListView goals={goals} />);
+      expect(screen.getByText("0%")).toBeDefined();
+    });
+  });
+});

--- a/src/components/savings-goals/SavingsGoalList.stories.tsx
+++ b/src/components/savings-goals/SavingsGoalList.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SavingsGoalListView } from "./SavingsGoalList";
+
+const meta: Meta<typeof SavingsGoalListView> = {
+  component: SavingsGoalListView,
+  title: "Savings Goals/SavingsGoalList",
+};
+
+export default meta;
+type Story = StoryObj<typeof SavingsGoalListView>;
+
+export const Empty: Story = {
+  args: {
+    goals: [],
+  },
+};
+
+export const PartiallyFunded: Story = {
+  args: {
+    goals: [
+      {
+        id: "goal-1",
+        ledgerId: "ledger-1",
+        name: "Emergency Fund",
+        targetAmount: 10000,
+        fundedAmount: 3500,
+        priority: 1,
+      },
+      {
+        id: "goal-2",
+        ledgerId: "ledger-1",
+        name: "Vacation",
+        targetAmount: 2000,
+        fundedAmount: 750,
+        priority: 2,
+      },
+      {
+        id: "goal-3",
+        ledgerId: "ledger-1",
+        name: "New Car",
+        targetAmount: 15000,
+        fundedAmount: 1000,
+        priority: 3,
+      },
+    ],
+  },
+};
+
+export const FullyFunded: Story = {
+  args: {
+    goals: [
+      {
+        id: "goal-1",
+        ledgerId: "ledger-1",
+        name: "Emergency Fund",
+        targetAmount: 10000,
+        fundedAmount: 10000,
+        priority: 1,
+      },
+      {
+        id: "goal-2",
+        ledgerId: "ledger-1",
+        name: "Vacation",
+        targetAmount: 2000,
+        fundedAmount: 2000,
+        priority: 2,
+      },
+    ],
+  },
+};

--- a/src/components/savings-goals/SavingsGoalList.tsx
+++ b/src/components/savings-goals/SavingsGoalList.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { Card } from "@/components/ui/card";
+import { Bar } from "@/components/ui/bar";
+import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+export interface SavingsGoalListViewProps {
+  goals: BudgetLedgerSavingsGoal[];
+}
+
+export function SavingsGoalListView({ goals }: SavingsGoalListViewProps) {
+  const sorted = [...goals].sort((a, b) => a.priority - b.priority);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-xl font-semibold tracking-tight">
+        {SAVINGS_GOAL_LIST_COPY.title}
+      </h2>
+      {sorted.length === 0 ? (
+        <p className="py-8 text-center text-zinc-500 dark:text-zinc-400">
+          {SAVINGS_GOAL_LIST_COPY.emptyStateMessage}
+        </p>
+      ) : (
+        <Card className="overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b bg-muted/50 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3 text-center">
+                  {SAVINGS_GOAL_LIST_COPY.columnPriority}
+                </th>
+                <th className="px-4 py-3">
+                  {SAVINGS_GOAL_LIST_COPY.columnName}
+                </th>
+                <th className="px-4 py-3 text-right">
+                  {SAVINGS_GOAL_LIST_COPY.columnTarget}
+                </th>
+                <th className="px-4 py-3 text-right">
+                  {SAVINGS_GOAL_LIST_COPY.columnFunded}
+                </th>
+                <th className="px-4 py-3">
+                  {SAVINGS_GOAL_LIST_COPY.columnProgress}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((goal) => {
+                const progressPercent =
+                  goal.targetAmount > 0
+                    ? Math.round((goal.fundedAmount / goal.targetAmount) * 100)
+                    : 0;
+
+                return (
+                  <tr key={goal.id} className="border-b last:border-b-0">
+                    <td className="px-4 py-3 text-center font-mono text-sm text-muted-foreground">
+                      {goal.priority}
+                    </td>
+                    <td className="px-4 py-3 font-medium">{goal.name}</td>
+                    <td className="px-4 py-3 text-right font-mono text-sm">
+                      {currencyFormatter.format(goal.targetAmount)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-sm">
+                      {currencyFormatter.format(goal.fundedAmount)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <Bar value={progressPercent} className="max-w-24" />
+                        <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                          {progressPercent}%
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/savings-goals/copy.ts
+++ b/src/components/savings-goals/copy.ts
@@ -1,0 +1,10 @@
+export const SAVINGS_GOAL_LIST_COPY = {
+  columnFunded: "Funded",
+  columnName: "Goal",
+  columnPriority: "#",
+  columnProgress: "Progress",
+  columnTarget: "Target",
+  emptyStateMessage:
+    "No savings goals yet. Create your first goal to get started.",
+  title: "Savings Goals",
+} as const;

--- a/src/components/savings-goals/index.ts
+++ b/src/components/savings-goals/index.ts
@@ -1,0 +1,3 @@
+export { SavingsGoalListView } from "./SavingsGoalList";
+export type { SavingsGoalListViewProps } from "./SavingsGoalList";
+export { SAVINGS_GOAL_LIST_COPY } from "./copy";


### PR DESCRIPTION
Adds a `SavingsGoalListView` component that displays all savings goals for a ledger, sorted by priority (highest priority first), with a progress bar and percentage for each goal.

The component follows the existing presentational-split pattern: `SavingsGoalListView` is a pure presentational component that accepts `goals: BudgetLedgerSavingsGoal[]` as a prop, making it straightforward to wire up to the existing `useSavingsGoals` hook when integrating into a page. All user-facing strings live in `src/components/savings-goals/copy.ts` as `SAVINGS_GOAL_LIST_COPY`.

## Acceptance Criteria
- [x] Goals are listed in priority order (highest priority first)
- [x] Each row shows: name, target amount, funded amount, progress percentage, priority rank
- [x] Empty state prompts the user to create their first goal
- [x] All user-facing strings in a co-located copy file
- [x] Storybook stories cover: empty state, partially funded goals, fully funded goals
- [x] Component tests verify progress display from fixture goals

## Tests
11 tests added, all passing.

Closes #96

---
*Created by Claude Sonnet 4.6*