### PR TITLE
feat(ledgers): ledger detail page with transaction history and running balance

### DIFF
--- a/src/app/(app)/ledgers/[id]/page.tsx
+++ b/src/app/(app)/ledgers/[id]/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useAuth } from "@/hooks/use-auth";
+import { useTransactions } from "@/hooks/use-transactions";
+import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
+import { LedgerTransactionListView } from "@/components/ledger-transactions";
+
+export default function LedgerDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { user, loading: authLoading } = useAuth();
+  const uid = user?.uid ?? "";
+
+  const { ledgers, isLoading: ledgersLoading } = useLedgersSubscription(uid);
+  const { transactions, isLoading: txLoading } = useTransactions(uid, id);
+
+  const ledger = ledgers.find((l) => l.id === id);
+  const isLoading = authLoading || ledgersLoading || txLoading;
+  const ledgerName = ledger?.name ?? "";
+
+  if (authLoading || !user) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-8">
+      <LedgerTransactionListView
+        ledgerName={ledgerName}
+        transactions={transactions}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}

--- a/src/components/ledger-transactions/LedgerTransactionList.spec.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.spec.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { LedgerTransactionListView } from "./LedgerTransactionList";
+import { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+afterEach(cleanup);
+
+function makeTransaction(
+  overrides: Partial<BudgetLedgerTransaction> = {},
+): BudgetLedgerTransaction {
+  return {
+    id: "tx-1",
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Deposit,
+    date: new Date("2024-01-01T00:00:00.000Z"),
+    amount: 100,
+    description: "Initial deposit",
+    ...overrides,
+  };
+}
+
+describe("LedgerTransactionListView", () => {
+  describe("empty state", () => {
+    it("renders the empty state message when there are no transactions", () => {
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={[]}
+          isLoading={false}
+        />,
+      );
+      expect(
+        screen.getByText(LEDGER_TRANSACTION_LIST_COPY.emptyStateMessage),
+      ).toBeDefined();
+    });
+  });
+
+  describe("loading state", () => {
+    it("does not render the empty state message while loading", () => {
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={[]}
+          isLoading={true}
+        />,
+      );
+      expect(
+        screen.queryByText(LEDGER_TRANSACTION_LIST_COPY.emptyStateMessage),
+      ).toBeNull();
+    });
+  });
+
+  describe("ledger name", () => {
+    it("renders the ledger name in the header", () => {
+      render(
+        <LedgerTransactionListView
+          ledgerName="My Savings"
+          transactions={[]}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText("My Savings")).toBeDefined();
+    });
+  });
+
+  describe("running balance calculation", () => {
+    it("calculates running balance chronologically from oldest to newest", () => {
+      const transactions = [
+        makeTransaction({
+          id: "tx-1",
+          type: BudgetLedgerTransactionType.Deposit,
+          amount: 500,
+          date: new Date("2024-01-01T00:00:00.000Z"),
+          description: "Paycheck",
+        }),
+        makeTransaction({
+          id: "tx-2",
+          type: BudgetLedgerTransactionType.Expense,
+          amount: 150,
+          date: new Date("2024-01-02T00:00:00.000Z"),
+          description: "Groceries",
+        }),
+        makeTransaction({
+          id: "tx-3",
+          type: BudgetLedgerTransactionType.Deposit,
+          amount: 75,
+          date: new Date("2024-01-03T00:00:00.000Z"),
+          description: "Bonus",
+        }),
+      ];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      // After first deposit of 500: balance = $500.00 (same as amount; check via getAllByText)
+      // After expense of 150: balance = $350.00
+      // After second deposit of 75: balance = $425.00
+      expect(screen.getAllByText("$500.00").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("$350.00")).toBeDefined();
+      expect(screen.getByText("$425.00")).toBeDefined();
+    });
+
+    it("orders transactions chronologically regardless of input order", () => {
+      const transactions = [
+        makeTransaction({
+          id: "tx-later",
+          type: BudgetLedgerTransactionType.Deposit,
+          amount: 200,
+          date: new Date("2024-01-03T00:00:00.000Z"),
+          description: "Later",
+        }),
+        makeTransaction({
+          id: "tx-earlier",
+          type: BudgetLedgerTransactionType.Deposit,
+          amount: 300,
+          date: new Date("2024-01-01T00:00:00.000Z"),
+          description: "Earlier",
+        }),
+      ];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      const rows = screen.getAllByRole("row");
+      // Header row + 2 data rows (header is index 0)
+      // Earlier transaction should appear first (oldest first)
+      expect(rows[1]?.textContent).toContain("Earlier");
+      expect(rows[2]?.textContent).toContain("Later");
+    });
+
+    it("treats expense transactions as subtractions from the running balance", () => {
+      const transactions = [
+        makeTransaction({
+          id: "tx-1",
+          type: BudgetLedgerTransactionType.Deposit,
+          amount: 1000,
+          date: new Date("2024-01-01T00:00:00.000Z"),
+          description: "Income",
+        }),
+        makeTransaction({
+          id: "tx-2",
+          type: BudgetLedgerTransactionType.Expense,
+          amount: 375,
+          date: new Date("2024-01-02T00:00:00.000Z"),
+          description: "Rent",
+        }),
+      ];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      // After deposit of 1000: balance = $1,000.00 (same as amount; check via getAllByText)
+      // After expense of 375: balance = $625.00
+      expect(screen.getAllByText("$1,000.00").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("$625.00")).toBeDefined();
+    });
+  });
+
+  describe("transaction row content", () => {
+    it("renders the transaction description", () => {
+      const transactions = [makeTransaction({ description: "Electric bill" })];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      expect(screen.getByText("Electric bill")).toBeDefined();
+    });
+
+    it("renders the transaction type label for a deposit", () => {
+      const transactions = [
+        makeTransaction({ type: BudgetLedgerTransactionType.Deposit }),
+      ];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      expect(
+        screen.getByText(LEDGER_TRANSACTION_LIST_COPY.typeDeposit),
+      ).toBeDefined();
+    });
+
+    it("renders the transaction type label for an expense", () => {
+      const transactions = [
+        makeTransaction({ type: BudgetLedgerTransactionType.Expense }),
+      ];
+
+      render(
+        <LedgerTransactionListView
+          ledgerName="Test Ledger"
+          transactions={transactions}
+          isLoading={false}
+        />,
+      );
+
+      expect(
+        screen.getByText(LEDGER_TRANSACTION_LIST_COPY.typeExpense),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/components/ledger-transactions/LedgerTransactionList.stories.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LedgerTransactionListView } from "./LedgerTransactionList";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+const meta: Meta<typeof LedgerTransactionListView> = {
+  component: LedgerTransactionListView,
+  title: "Ledgers/LedgerTransactionList",
+  args: {
+    ledgerName: "Everyday Spending",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LedgerTransactionListView>;
+
+export const Empty: Story = {
+  args: {
+    transactions: [],
+    isLoading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    transactions: [],
+    isLoading: true,
+  },
+};
+
+export const Populated: Story = {
+  args: {
+    isLoading: false,
+    transactions: [
+      {
+        id: "tx-1",
+        ledgerId: "ledger-1",
+        type: BudgetLedgerTransactionType.Deposit,
+        date: new Date("2024-01-01T00:00:00.000Z"),
+        amount: 2500,
+        description: "January paycheck",
+      },
+      {
+        id: "tx-2",
+        ledgerId: "ledger-1",
+        type: BudgetLedgerTransactionType.Expense,
+        date: new Date("2024-01-05T00:00:00.000Z"),
+        amount: 120.5,
+        description: "Grocery run",
+      },
+      {
+        id: "tx-3",
+        ledgerId: "ledger-1",
+        type: BudgetLedgerTransactionType.Expense,
+        date: new Date("2024-01-10T00:00:00.000Z"),
+        amount: 850,
+        description: "Rent",
+      },
+      {
+        id: "tx-4",
+        ledgerId: "ledger-1",
+        type: BudgetLedgerTransactionType.Deposit,
+        date: new Date("2024-01-15T00:00:00.000Z"),
+        amount: 200,
+        description: "Side project income",
+      },
+    ],
+  },
+};

--- a/src/components/ledger-transactions/LedgerTransactionList.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+interface TransactionWithBalance extends BudgetLedgerTransaction {
+  runningBalance: number;
+}
+
+function computeRunningBalances(
+  transactions: BudgetLedgerTransaction[],
+): TransactionWithBalance[] {
+  const sorted = [...transactions].sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+  let balance = 0;
+  return sorted.map((tx) => {
+    balance =
+      tx.type === BudgetLedgerTransactionType.Deposit
+        ? balance + tx.amount
+        : balance - tx.amount;
+    return { ...tx, runningBalance: balance };
+  });
+}
+
+export interface LedgerTransactionListViewProps {
+  ledgerName: string;
+  transactions: BudgetLedgerTransaction[];
+  isLoading: boolean;
+}
+
+export function LedgerTransactionListView({
+  ledgerName,
+  transactions,
+  isLoading,
+}: LedgerTransactionListViewProps) {
+  const transactionsWithBalance = computeRunningBalances(transactions);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{ledgerName}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {LEDGER_TRANSACTION_LIST_COPY.title}
+        </p>
+      </div>
+
+      {isLoading ? (
+        <Card>
+          <div className="flex flex-col gap-2 p-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </Card>
+      ) : transactions.length === 0 ? (
+        <p className="py-8 text-center text-zinc-500 dark:text-zinc-400">
+          {LEDGER_TRANSACTION_LIST_COPY.emptyStateMessage}
+        </p>
+      ) : (
+        <Card className="overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b bg-muted/50 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">
+                  {LEDGER_TRANSACTION_LIST_COPY.columnDate}
+                </th>
+                <th className="px-4 py-3">
+                  {LEDGER_TRANSACTION_LIST_COPY.columnType}
+                </th>
+                <th className="px-4 py-3">
+                  {LEDGER_TRANSACTION_LIST_COPY.columnDescription}
+                </th>
+                <th className="px-4 py-3 text-right">
+                  {LEDGER_TRANSACTION_LIST_COPY.columnAmount}
+                </th>
+                <th className="px-4 py-3 text-right">
+                  {LEDGER_TRANSACTION_LIST_COPY.columnBalance}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {transactionsWithBalance.map((tx) => (
+                <tr key={tx.id} className="border-b last:border-b-0">
+                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                    {dateFormatter.format(tx.date)}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {tx.type === BudgetLedgerTransactionType.Deposit
+                      ? LEDGER_TRANSACTION_LIST_COPY.typeDeposit
+                      : LEDGER_TRANSACTION_LIST_COPY.typeExpense}
+                  </td>
+                  <td className="px-4 py-3 text-sm">{tx.description}</td>
+                  <td className="px-4 py-3 text-right font-mono text-sm">
+                    {tx.type === BudgetLedgerTransactionType.Expense && "−"}
+                    {currencyFormatter.format(tx.amount)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-sm">
+                    {currencyFormatter.format(tx.runningBalance)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/ledger-transactions/copy.ts
+++ b/src/components/ledger-transactions/copy.ts
@@ -1,0 +1,13 @@
+export const LEDGER_TRANSACTION_LIST_COPY = {
+  columnAmount: "Amount",
+  columnBalance: "Balance",
+  columnDate: "Date",
+  columnDescription: "Description",
+  columnType: "Type",
+  emptyStateMessage:
+    "No transactions yet. Record your first transaction to get started.",
+  loadingMessage: "Loading transactions…",
+  title: "Transaction History",
+  typeDeposit: "Deposit",
+  typeExpense: "Expense",
+} as const;

--- a/src/components/ledger-transactions/copy.ts
+++ b/src/components/ledger-transactions/copy.ts
@@ -6,7 +6,6 @@ export const LEDGER_TRANSACTION_LIST_COPY = {
   columnType: "Type",
   emptyStateMessage:
     "No transactions yet. Record your first transaction to get started.",
-  loadingMessage: "Loading transactions…",
   title: "Transaction History",
   typeDeposit: "Deposit",
   typeExpense: "Expense",

--- a/src/components/ledger-transactions/index.ts
+++ b/src/components/ledger-transactions/index.ts
@@ -1,0 +1,3 @@
+export { LedgerTransactionListView } from "./LedgerTransactionList";
+export type { LedgerTransactionListViewProps } from "./LedgerTransactionList";
+export { LEDGER_TRANSACTION_LIST_COPY } from "./copy";


### PR DESCRIPTION
Adds the `/ledgers/[id]` detail page showing the full transaction history for a budget ledger, with a running balance column that recalculates chronologically from oldest to newest transaction.

The page uses a presentational split (`LedgerTransactionListView`) to keep rendering logic hook-free and directly testable. The `LedgerTransactionListView` component handles empty state, loading state (skeleton cards), and the populated table — all strings live in a co-located `copy.ts` file. The `LedgerDetailPage` wires up `useTransactions` and `useLedgersSubscription` to resolve the ledger name from the URL `[id]` param.

## Acceptance Criteria
- [x] Page at `/ledgers/[id]` shows ledger name and transaction list
- [x] Each row shows: date, type (deposit/expense), description, amount, running balance
- [x] Transactions are ordered chronologically; running balance recalculates from oldest to newest
- [x] Empty state prompts the user to record their first transaction
- [x] Loading state handled gracefully
- [x] All user-facing strings in a co-located copy file
- [x] Storybook stories cover: empty state, loading state, populated list
- [x] Component tests verify running balance calculation from fixture transactions

## Tests
9 tests added, all passing.

Closes #91

---
*Created by Claude Sonnet 4.6*