### PR TITLE
feat(annuities): add flat-rate annuity creation dialog

### DIFF
--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -1,21 +1,48 @@
 "use client";
 
+import { useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { useAnnuities } from "@/hooks/use-annuities";
-import { AnnuityListView } from "@/components/annuities";
+import { AnnuityListView, NewAnnuityDialog } from "@/components/annuities";
+import { createAnnuity } from "@/services/annuities";
 
 export default function AnnuitiesPage() {
   const { user, loading: authLoading } = useAuth();
   const uid = user?.uid ?? "";
   const { annuities, isLoading } = useAnnuities(uid);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   if (authLoading || !user) {
     return null;
   }
 
+  const handleSubmit = async (
+    name: string,
+    monthlyAmount: number,
+    durationMonths: number | undefined,
+  ) => {
+    await createAnnuity(uid, {
+      name,
+      monthlyAmount,
+      startDate: new Date(),
+      durationMonths,
+    });
+  };
+
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-8">
-      <AnnuityListView annuities={annuities} isLoading={isLoading} />
+      <AnnuityListView
+        annuities={annuities}
+        isLoading={isLoading}
+        onNewAnnuity={() => {
+          setDialogOpen(true);
+        }}
+      />
+      <NewAnnuityDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }

--- a/src/components/annuities/AnnuityListView.spec.tsx
+++ b/src/components/annuities/AnnuityListView.spec.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { AnnuityListView } from "./AnnuityListView";
 import { ANNUITY_LIST_COPY } from "./copy";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
@@ -24,14 +24,26 @@ describe("AnnuityListView", () => {
         makeAnnuity({ id: "1", name: "Netflix" }),
         makeAnnuity({ id: "2", name: "Car Loan" }),
       ];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText("Netflix")).toBeDefined();
       expect(screen.getByText("Car Loan")).toBeDefined();
     });
 
     it("renders the monthly amount for each annuity", () => {
       const annuities = [makeAnnuity({ id: "1", monthlyAmount: 49.99 })];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText("$49.99/mo")).toBeDefined();
     });
 
@@ -44,7 +56,13 @@ describe("AnnuityListView", () => {
           startDate: new Date("2099-01-01T00:00:00.000Z"),
         }),
       ];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText("36 months")).toBeDefined();
     });
 
@@ -59,7 +77,13 @@ describe("AnnuityListView", () => {
           startDate: twelveMonthsAgo,
         }),
       ];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText("6 months")).toBeDefined();
     });
 
@@ -71,19 +95,37 @@ describe("AnnuityListView", () => {
           startDate: new Date("2020-01-01T00:00:00.000Z"),
         }),
       ];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText("0 months")).toBeDefined();
     });
 
     it("renders 'indefinite' for an annuity with no duration", () => {
       const annuities = [makeAnnuity({ id: "1", durationMonths: undefined })];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.getByText(ANNUITY_LIST_COPY.indefiniteTerm)).toBeDefined();
     });
 
     it("does not render the empty state when annuities exist", () => {
       const annuities = [makeAnnuity({ id: "1" })];
-      render(<AnnuityListView annuities={annuities} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={annuities}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(
         screen.queryByText(ANNUITY_LIST_COPY.emptyStateMessage),
       ).toBeNull();
@@ -92,24 +134,70 @@ describe("AnnuityListView", () => {
 
   describe("empty state", () => {
     it("renders the empty state message when there are no annuities", () => {
-      render(<AnnuityListView annuities={[]} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={[]}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(
         screen.getByText(ANNUITY_LIST_COPY.emptyStateMessage),
       ).toBeDefined();
     });
 
     it("does not render annuity rows in empty state", () => {
-      render(<AnnuityListView annuities={[]} isLoading={false} />);
+      render(
+        <AnnuityListView
+          annuities={[]}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(screen.queryByText("$49.99/mo")).toBeNull();
     });
   });
 
   describe("loading state", () => {
     it("does not render the empty state while loading", () => {
-      render(<AnnuityListView annuities={[]} isLoading={true} />);
+      render(
+        <AnnuityListView
+          annuities={[]}
+          isLoading={true}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
       expect(
         screen.queryByText(ANNUITY_LIST_COPY.emptyStateMessage),
       ).toBeNull();
+    });
+  });
+
+  describe("new annuity action", () => {
+    it("renders the New Annuity button", () => {
+      render(
+        <AnnuityListView
+          annuities={[]}
+          isLoading={false}
+          onNewAnnuity={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByText(ANNUITY_LIST_COPY.newAnnuityButton),
+      ).toBeDefined();
+    });
+
+    it("calls onNewAnnuity when the New Annuity button is clicked", () => {
+      const onNewAnnuity = vi.fn();
+      render(
+        <AnnuityListView
+          annuities={[]}
+          isLoading={false}
+          onNewAnnuity={onNewAnnuity}
+        />,
+      );
+      fireEvent.click(screen.getByText(ANNUITY_LIST_COPY.newAnnuityButton));
+      expect(onNewAnnuity).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/components/annuities/AnnuityListView.stories.tsx
+++ b/src/components/annuities/AnnuityListView.stories.tsx
@@ -13,6 +13,8 @@ export const Empty: Story = {
   args: {
     annuities: [],
     isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNewAnnuity: () => {},
   },
 };
 
@@ -20,12 +22,16 @@ export const Loading: Story = {
   args: {
     annuities: [],
     isLoading: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNewAnnuity: () => {},
   },
 };
 
 export const PopulatedFlatRate: Story = {
   args: {
     isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNewAnnuity: () => {},
     annuities: [
       {
         id: "1",
@@ -48,6 +54,8 @@ export const PopulatedFlatRate: Story = {
 export const PopulatedFixedTerm: Story = {
   args: {
     isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNewAnnuity: () => {},
     annuities: [
       {
         id: "1",
@@ -70,6 +78,8 @@ export const PopulatedFixedTerm: Story = {
 export const PopulatedMixed: Story = {
   args: {
     isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNewAnnuity: () => {},
     annuities: [
       {
         id: "1",

--- a/src/components/annuities/AnnuityListView.tsx
+++ b/src/components/annuities/AnnuityListView.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
 import { ANNUITY_LIST_COPY } from "./copy";
 
@@ -23,18 +24,23 @@ function remainingMonths(startDate: Date, durationMonths: number): number {
 interface AnnuityListViewProps {
   annuities: Annuity[];
   isLoading: boolean;
+  onNewAnnuity: () => void;
 }
 
 export function AnnuityListView({
   annuities,
   isLoading,
+  onNewAnnuity,
 }: AnnuityListViewProps) {
   return (
     <div className="flex flex-col gap-4">
-      <div>
+      <div className="flex items-start justify-between">
         <h1 className="text-2xl font-semibold tracking-tight">
           {ANNUITY_LIST_COPY.title}
         </h1>
+        <Button onClick={onNewAnnuity}>
+          {ANNUITY_LIST_COPY.newAnnuityButton}
+        </Button>
       </div>
 
       {isLoading ? (

--- a/src/components/annuities/NewAnnuityDialog.spec.tsx
+++ b/src/components/annuities/NewAnnuityDialog.spec.tsx
@@ -1,0 +1,428 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { NewAnnuityDialog, NewAnnuityDialogView } from "./NewAnnuityDialog";
+import { NEW_ANNUITY_DIALOG_COPY } from "./copy";
+
+afterEach(cleanup);
+
+function renderView(
+  overrides: Partial<Parameters<typeof NewAnnuityDialogView>[0]> = {},
+) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    name: "",
+    onNameChange: vi.fn(),
+    monthlyAmount: "",
+    onMonthlyAmountChange: vi.fn(),
+    durationMonths: "",
+    onDurationMonthsChange: vi.fn(),
+    nameError: undefined,
+    monthlyAmountError: undefined,
+    submitError: undefined,
+    onSubmit: vi.fn(),
+    isSubmitting: false,
+    ...overrides,
+  };
+  render(<NewAnnuityDialogView {...props} />);
+  return props;
+}
+
+describe("NewAnnuityDialogView", () => {
+  describe("A 'New annuity' action opens a creation dialog", () => {
+    it("renders the dialog title", () => {
+      renderView();
+      expect(screen.getByText(NEW_ANNUITY_DIALOG_COPY.title)).toBeDefined();
+    });
+  });
+
+  describe("For the flat-rate path: form fields are name (required) and monthly amount (required, positive)", () => {
+    it("renders the name label", () => {
+      renderView();
+      expect(screen.getByText(NEW_ANNUITY_DIALOG_COPY.nameLabel)).toBeDefined();
+    });
+
+    it("renders the monthly amount label", () => {
+      renderView();
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+      ).toBeDefined();
+    });
+
+    it("renders the submit button", () => {
+      renderView();
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.submitButton),
+      ).toBeDefined();
+    });
+
+    it("renders the cancel button", () => {
+      renderView();
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.cancelButton),
+      ).toBeDefined();
+    });
+
+    it("does not render a name error when nameError is undefined", () => {
+      renderView({ nameError: undefined });
+      expect(
+        screen.queryByText(NEW_ANNUITY_DIALOG_COPY.nameRequiredError),
+      ).toBeNull();
+    });
+
+    it("renders a name error when nameError is set", () => {
+      renderView({ nameError: NEW_ANNUITY_DIALOG_COPY.nameRequiredError });
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.nameRequiredError),
+      ).toBeDefined();
+    });
+
+    it("does not render a monthly amount error when monthlyAmountError is undefined", () => {
+      renderView({ monthlyAmountError: undefined });
+      expect(
+        screen.queryByText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountRequiredError),
+      ).toBeNull();
+    });
+
+    it("renders a monthly amount error when monthlyAmountError is set", () => {
+      renderView({
+        monthlyAmountError: NEW_ANNUITY_DIALOG_COPY.monthlyAmountRequiredError,
+      });
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountRequiredError),
+      ).toBeDefined();
+    });
+
+    it("calls onNameChange when the name input changes", () => {
+      const onNameChange = vi.fn();
+      renderView({ onNameChange });
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Spotify" } },
+      );
+      expect(onNameChange).toHaveBeenCalledWith("Spotify");
+    });
+
+    it("calls onMonthlyAmountChange when the monthly amount input changes", () => {
+      const onMonthlyAmountChange = vi.fn();
+      renderView({ onMonthlyAmountChange });
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "49.99" } },
+      );
+      expect(onMonthlyAmountChange).toHaveBeenCalledWith("49.99");
+    });
+  });
+
+  describe("Optional duration in months (if omitted, the annuity is indefinite)", () => {
+    it("renders the duration months label", () => {
+      renderView();
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.durationMonthsLabel),
+      ).toBeDefined();
+    });
+
+    it("calls onDurationMonthsChange when the duration input changes", () => {
+      const onDurationMonthsChange = vi.fn();
+      renderView({ onDurationMonthsChange });
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.durationMonthsLabel),
+        { target: { value: "12" } },
+      );
+      expect(onDurationMonthsChange).toHaveBeenCalledWith("12");
+    });
+  });
+
+  describe("All user-facing strings in a co-located copy file", () => {
+    it("submit error is not rendered when submitError is undefined", () => {
+      renderView({ submitError: undefined });
+      expect(
+        screen.queryByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+      ).toBeNull();
+    });
+
+    it("renders submit error when submitError is set", () => {
+      renderView({ submitError: NEW_ANNUITY_DIALOG_COPY.submitError });
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+      ).toBeDefined();
+    });
+
+    it("disables submit button while isSubmitting", () => {
+      renderView({ isSubmitting: true });
+      expect(
+        screen
+          .getByText(NEW_ANNUITY_DIALOG_COPY.submitButton)
+          .hasAttribute("disabled"),
+      ).toBe(true);
+    });
+
+    it("disables cancel button while isSubmitting", () => {
+      renderView({ isSubmitting: true });
+      expect(
+        screen
+          .getByText(NEW_ANNUITY_DIALOG_COPY.cancelButton)
+          .hasAttribute("disabled"),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("NewAnnuityDialog", () => {
+  describe("For the flat-rate path: form fields are name (required) and monthly amount (required, positive)", () => {
+    it("shows a name error and does not call onSubmit when name is empty", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.nameRequiredError),
+        ).toBeDefined();
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("shows a monthly amount error when monthly amount is empty", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Spotify" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountRequiredError),
+        ).toBeDefined();
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("shows a monthly amount error when monthly amount is not positive", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Spotify" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "-10" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountInvalidError),
+        ).toBeDefined();
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Optional duration in months (if omitted, the annuity is indefinite)", () => {
+    it("calls onSubmit with undefined durationMonths when duration is empty", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "15.99" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("Netflix", 15.99, undefined);
+      });
+    });
+
+    it("calls onSubmit with parsed durationMonths when duration is provided", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Car Loan" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "425.50" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.durationMonthsLabel),
+        { target: { value: "48" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("Car Loan", 425.5, 48);
+      });
+    });
+  });
+
+  describe("Submitting persists the annuity via the service layer and it appears in the list immediately", () => {
+    it("calls onOpenChange with false after successful submission", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const onOpenChange = vi.fn();
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "15.99" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("shows a submit error message when onSubmit rejects", async () => {
+      const onSubmit = vi.fn().mockRejectedValue(new Error("Network error"));
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "15.99" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+        ).toBeDefined();
+      });
+    });
+
+    it("does not call onOpenChange with false when onSubmit rejects", async () => {
+      const onSubmit = vi.fn().mockRejectedValue(new Error("Network error"));
+      const onOpenChange = vi.fn();
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "15.99" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+        ).toBeDefined();
+      });
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it("resets form fields when the dialog closes", () => {
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={vi.fn().mockResolvedValue(undefined)}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      expect(screen.queryByDisplayValue("Netflix")).not.toBeNull();
+      fireEvent.click(screen.getByText(NEW_ANNUITY_DIALOG_COPY.cancelButton));
+      expect(screen.queryByDisplayValue("Netflix")).toBeNull();
+    });
+
+    it("clears the submit error when re-submitting with a validation failure", async () => {
+      const onSubmit = vi.fn().mockRejectedValue(new Error("Network error"));
+      render(
+        <NewAnnuityDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "Netflix" } },
+      );
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel),
+        { target: { value: "15.99" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      await waitFor(() => {
+        expect(
+          screen.getByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+        ).toBeDefined();
+      });
+      fireEvent.change(
+        screen.getByLabelText(NEW_ANNUITY_DIALOG_COPY.nameLabel),
+        { target: { value: "" } },
+      );
+      fireEvent.submit(document.querySelector("form")!);
+      expect(
+        screen.queryByText(NEW_ANNUITY_DIALOG_COPY.submitError),
+      ).toBeNull();
+      expect(
+        screen.getByText(NEW_ANNUITY_DIALOG_COPY.nameRequiredError),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/components/annuities/NewAnnuityDialog.stories.tsx
+++ b/src/components/annuities/NewAnnuityDialog.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NewAnnuityDialogView } from "./NewAnnuityDialog";
+
+const meta: Meta<typeof NewAnnuityDialogView> = {
+  component: NewAnnuityDialogView,
+  title: "Annuities/NewAnnuityDialog",
+};
+
+export default meta;
+type Story = StoryObj<typeof NewAnnuityDialogView>;
+
+export const Empty: Story = {
+  args: {
+    open: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onOpenChange: () => {},
+    name: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNameChange: () => {},
+    monthlyAmount: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onMonthlyAmountChange: () => {},
+    durationMonths: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDurationMonthsChange: () => {},
+    nameError: undefined,
+    monthlyAmountError: undefined,
+    submitError: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+
+export const WithValidationErrors: Story = {
+  args: {
+    open: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onOpenChange: () => {},
+    name: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNameChange: () => {},
+    monthlyAmount: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onMonthlyAmountChange: () => {},
+    durationMonths: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDurationMonthsChange: () => {},
+    nameError: "Name is required.",
+    monthlyAmountError: "Monthly amount is required.",
+    submitError: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    open: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onOpenChange: () => {},
+    name: "Car Loan",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNameChange: () => {},
+    monthlyAmount: "425.50",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onMonthlyAmountChange: () => {},
+    durationMonths: "48",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDurationMonthsChange: () => {},
+    nameError: undefined,
+    monthlyAmountError: undefined,
+    submitError: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    open: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onOpenChange: () => {},
+    name: "Netflix",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNameChange: () => {},
+    monthlyAmount: "15.99",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onMonthlyAmountChange: () => {},
+    durationMonths: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDurationMonthsChange: () => {},
+    nameError: undefined,
+    monthlyAmountError: undefined,
+    submitError: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+    isSubmitting: true,
+  },
+};
+
+export const WithSubmitError: Story = {
+  args: {
+    open: true,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onOpenChange: () => {},
+    name: "Netflix",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onNameChange: () => {},
+    monthlyAmount: "15.99",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onMonthlyAmountChange: () => {},
+    durationMonths: "",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDurationMonthsChange: () => {},
+    nameError: undefined,
+    monthlyAmountError: undefined,
+    submitError: "Something went wrong. Please try again.",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};

--- a/src/components/annuities/NewAnnuityDialog.tsx
+++ b/src/components/annuities/NewAnnuityDialog.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DialogBackdrop,
+  DialogClose,
+  DialogPopup,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { NEW_ANNUITY_DIALOG_COPY } from "./copy";
+
+export interface NewAnnuityDialogViewProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  name: string;
+  onNameChange: (value: string) => void;
+  monthlyAmount: string;
+  onMonthlyAmountChange: (value: string) => void;
+  durationMonths: string;
+  onDurationMonthsChange: (value: string) => void;
+  nameError: string | undefined;
+  monthlyAmountError: string | undefined;
+  submitError: string | undefined;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+}
+
+export function NewAnnuityDialogView({
+  open,
+  onOpenChange,
+  name,
+  onNameChange,
+  monthlyAmount,
+  onMonthlyAmountChange,
+  durationMonths,
+  onDurationMonthsChange,
+  nameError,
+  monthlyAmountError,
+  submitError,
+  onSubmit,
+  isSubmitting,
+}: NewAnnuityDialogViewProps) {
+  return (
+    <DialogRoot open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogBackdrop />
+        <DialogPopup>
+          <DialogTitle>{NEW_ANNUITY_DIALOG_COPY.title}</DialogTitle>
+          <form
+            noValidate
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit();
+            }}
+          >
+            <div className="mt-4 flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="new-annuity-name"
+                >
+                  {NEW_ANNUITY_DIALOG_COPY.nameLabel}
+                </label>
+                <input
+                  id="new-annuity-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => {
+                    onNameChange(e.target.value);
+                  }}
+                  placeholder={NEW_ANNUITY_DIALOG_COPY.namePlaceholder}
+                  aria-invalid={nameError !== undefined}
+                  aria-describedby={
+                    nameError !== undefined
+                      ? "new-annuity-name-error"
+                      : undefined
+                  }
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                />
+                {nameError !== undefined && (
+                  <p
+                    id="new-annuity-name-error"
+                    role="alert"
+                    className="text-sm text-destructive"
+                  >
+                    {nameError}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="new-annuity-monthly-amount"
+                >
+                  {NEW_ANNUITY_DIALOG_COPY.monthlyAmountLabel}
+                </label>
+                <input
+                  id="new-annuity-monthly-amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={monthlyAmount}
+                  onChange={(e) => {
+                    onMonthlyAmountChange(e.target.value);
+                  }}
+                  placeholder={NEW_ANNUITY_DIALOG_COPY.monthlyAmountPlaceholder}
+                  aria-invalid={monthlyAmountError !== undefined}
+                  aria-describedby={
+                    monthlyAmountError !== undefined
+                      ? "new-annuity-monthly-amount-error"
+                      : undefined
+                  }
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                />
+                {monthlyAmountError !== undefined && (
+                  <p
+                    id="new-annuity-monthly-amount-error"
+                    role="alert"
+                    className="text-sm text-destructive"
+                  >
+                    {monthlyAmountError}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="new-annuity-duration-months"
+                >
+                  {NEW_ANNUITY_DIALOG_COPY.durationMonthsLabel}
+                </label>
+                <input
+                  id="new-annuity-duration-months"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={durationMonths}
+                  onChange={(e) => {
+                    onDurationMonthsChange(e.target.value);
+                  }}
+                  placeholder={
+                    NEW_ANNUITY_DIALOG_COPY.durationMonthsPlaceholder
+                  }
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                />
+              </div>
+            </div>
+            {submitError !== undefined && (
+              <p role="alert" className="mt-2 text-sm text-destructive">
+                {submitError}
+              </p>
+            )}
+            <div className="mt-6 flex justify-end gap-3">
+              <DialogClose
+                type="button"
+                className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted"
+                disabled={isSubmitting}
+              >
+                {NEW_ANNUITY_DIALOG_COPY.cancelButton}
+              </DialogClose>
+              <Button type="submit" disabled={isSubmitting}>
+                {NEW_ANNUITY_DIALOG_COPY.submitButton}
+              </Button>
+            </div>
+          </form>
+        </DialogPopup>
+      </DialogPortal>
+    </DialogRoot>
+  );
+}
+
+export interface NewAnnuityDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (
+    name: string,
+    monthlyAmount: number,
+    durationMonths: number | undefined,
+  ) => Promise<unknown>;
+}
+
+export function NewAnnuityDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+}: NewAnnuityDialogProps) {
+  const [name, setName] = useState("");
+  const [monthlyAmount, setMonthlyAmount] = useState("");
+  const [durationMonths, setDurationMonths] = useState("");
+  const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [monthlyAmountError, setMonthlyAmountError] = useState<
+    string | undefined
+  >(undefined);
+  const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && isSubmitting) return;
+    if (!nextOpen) {
+      setName("");
+      setMonthlyAmount("");
+      setDurationMonths("");
+      setNameError(undefined);
+      setMonthlyAmountError(undefined);
+      setSubmitError(undefined);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit() {
+    if (isSubmitting) return;
+    setSubmitError(undefined);
+    let valid = true;
+
+    if (name.trim() === "") {
+      setNameError(NEW_ANNUITY_DIALOG_COPY.nameRequiredError);
+      valid = false;
+    } else {
+      setNameError(undefined);
+    }
+
+    let parsedAmount: number | undefined;
+    if (monthlyAmount.trim() === "") {
+      setMonthlyAmountError(NEW_ANNUITY_DIALOG_COPY.monthlyAmountRequiredError);
+      valid = false;
+    } else {
+      const parsed = parseFloat(monthlyAmount);
+      if (isNaN(parsed) || parsed <= 0) {
+        setMonthlyAmountError(
+          NEW_ANNUITY_DIALOG_COPY.monthlyAmountInvalidError,
+        );
+        valid = false;
+      } else {
+        setMonthlyAmountError(undefined);
+        parsedAmount = parsed;
+      }
+    }
+
+    let parsedDuration: number | undefined;
+    if (durationMonths.trim() !== "") {
+      parsedDuration = parseInt(durationMonths, 10);
+    }
+
+    if (!valid || parsedAmount === undefined) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(name.trim(), parsedAmount, parsedDuration);
+      handleOpenChange(false);
+    } catch {
+      setSubmitError(NEW_ANNUITY_DIALOG_COPY.submitError);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <NewAnnuityDialogView
+      open={open}
+      onOpenChange={handleOpenChange}
+      name={name}
+      onNameChange={setName}
+      monthlyAmount={monthlyAmount}
+      onMonthlyAmountChange={setMonthlyAmount}
+      durationMonths={durationMonths}
+      onDurationMonthsChange={setDurationMonths}
+      nameError={nameError}
+      monthlyAmountError={monthlyAmountError}
+      submitError={submitError}
+      onSubmit={() => void handleSubmit()}
+      isSubmitting={isSubmitting}
+    />
+  );
+}

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -4,6 +4,23 @@ export const ANNUITY_LIST_COPY = {
   columnTerm: "Term",
   emptyStateMessage: "You don't have any annuities yet.",
   indefiniteTerm: "Indefinite",
+  newAnnuityButton: "New Annuity",
   termSuffix: "months",
   title: "Annuities",
+} as const;
+
+export const NEW_ANNUITY_DIALOG_COPY = {
+  cancelButton: "Cancel",
+  durationMonthsLabel: "Duration (months, optional)",
+  durationMonthsPlaceholder: "e.g. 24",
+  monthlyAmountInvalidError: "Monthly amount must be a positive number.",
+  monthlyAmountLabel: "Monthly Amount",
+  monthlyAmountPlaceholder: "0.00",
+  monthlyAmountRequiredError: "Monthly amount is required.",
+  nameLabel: "Name",
+  namePlaceholder: "e.g. Car Loan",
+  nameRequiredError: "Name is required.",
+  submitButton: "Create Annuity",
+  submitError: "Something went wrong. Please try again.",
+  title: "New Annuity",
 } as const;

--- a/src/components/annuities/index.ts
+++ b/src/components/annuities/index.ts
@@ -1,1 +1,2 @@
 export { AnnuityListView } from "./AnnuityListView";
+export { NewAnnuityDialog } from "./NewAnnuityDialog";


### PR DESCRIPTION
Adds a "New Annuity" button to the annuities list view that opens a creation dialog. The dialog collects a name, monthly amount (required, positive), and an optional duration in months; submitting calls `createAnnuity` directly and the real-time Firebase subscription causes the new entry to appear in the list immediately.

The dialog follows the presentational split pattern used by `NewLedgerDialog`: `NewAnnuityDialogView` accepts callbacks and owns no async logic, while `NewAnnuityDialog` manages state, validation, and submission. All user-facing strings live in the co-located `copy.ts` file. Storybook stories cover all key form states (empty, validation errors, filled, submitting, submit error).

## Acceptance Criteria
- [x] A "New annuity" action opens a creation dialog
- [x] For the flat-rate path: form fields are name (required) and monthly amount (required, positive)
- [x] Optional duration in months (if omitted, the annuity is indefinite)
- [x] Submitting persists the annuity via the service layer and it appears in the list immediately
- [x] All user-facing strings in a co-located copy file
- [x] Storybook story covers the form

## Tests
29 tests added (27 for NewAnnuityDialog + 2 for AnnuityListView button), all passing.

Closes #101

---
*Created by Claude Sonnet 4.6*