### PR TITLE
feat(app-shell): scaffold persistent navigation

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { AppShellNav } from "@/components/app-shell";
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  return <AppShellNav>{children}</AppShellNav>;
+}

--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { AppShellNavView } from "./AppShellNav";
+import { APP_SHELL_COPY } from "./copy";
+
+afterEach(cleanup);
+
+describe("AppShellNavView — desktop top nav", () => {
+  it("renders the Ledgerly wordmark", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    expect(screen.getAllByText(APP_SHELL_COPY.brand).length).toBeGreaterThan(0);
+  });
+
+  it("renders a Reconcile link pointing to /reconcile", () => {
+    render(<AppShellNavView pathname="/ledgers">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkReconcile })
+      .find((el) => el.getAttribute("href") === "/reconcile");
+    expect(link).toBeDefined();
+  });
+
+  it("renders a Ledgers link pointing to /ledgers", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkLedgers })
+      .find((el) => el.getAttribute("href") === "/ledgers");
+    expect(link).toBeDefined();
+  });
+
+  it("renders a Goals link pointing to /goals", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkGoals })
+      .find((el) => el.getAttribute("href") === "/goals");
+    expect(link).toBeDefined();
+  });
+
+  it("renders an Investments link pointing to /investments", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkInvestments })
+      .find((el) => el.getAttribute("href") === "/investments");
+    expect(link).toBeDefined();
+  });
+
+  it("renders an Annuities link pointing to /annuities", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkAnnuities })
+      .find((el) => el.getAttribute("href") === "/annuities");
+    expect(link).toBeDefined();
+  });
+
+  it("renders an Accounts link pointing to /accounts", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkAccounts })
+      .find((el) => el.getAttribute("href") === "/accounts");
+    expect(link).toBeDefined();
+  });
+
+  it("renders a Profile link pointing to /profile", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const link = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkProfile })
+      .find((el) => el.getAttribute("href") === "/profile");
+    expect(link).toBeDefined();
+  });
+});
+
+describe("AppShellNavView — active-route styling", () => {
+  it("marks the Ledgers desktop link as active when pathname is /ledgers", () => {
+    render(<AppShellNavView pathname="/ledgers">content</AppShellNavView>);
+    const ledgersLinks = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkLedgers })
+      .filter((el) => el.getAttribute("href") === "/ledgers");
+    const active = ledgersLinks.find(
+      (el) => el.getAttribute("aria-current") === "page",
+    );
+    expect(active).toBeDefined();
+  });
+
+  it("marks the Ledgers desktop link as active for nested paths like /ledgers/abc123", () => {
+    render(
+      <AppShellNavView pathname="/ledgers/abc123">content</AppShellNavView>,
+    );
+    const ledgersLinks = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkLedgers })
+      .filter((el) => el.getAttribute("href") === "/ledgers");
+    const active = ledgersLinks.find(
+      (el) => el.getAttribute("aria-current") === "page",
+    );
+    expect(active).toBeDefined();
+  });
+
+  it("does not mark the Reconcile link as active when pathname is /ledgers", () => {
+    render(<AppShellNavView pathname="/ledgers">content</AppShellNavView>);
+    const reconcile = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkReconcile })
+      .find((el) => el.getAttribute("href") === "/reconcile");
+    expect(reconcile?.getAttribute("aria-current")).not.toBe("page");
+  });
+});
+
+describe("AppShellNavView — mobile bottom tab bar", () => {
+  it("renders a mobile Reconcile tab link pointing to /reconcile", () => {
+    render(<AppShellNavView pathname="/ledgers">content</AppShellNavView>);
+    const tabs = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkReconcile })
+      .filter((el) => el.getAttribute("href") === "/reconcile");
+    // Both desktop and mobile render a Reconcile link, so we expect at least 2
+    expect(tabs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders an Invest mobile tab pointing to /investments", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const tab = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkInvest })
+      .find((el) => el.getAttribute("href") === "/investments");
+    expect(tab).toBeDefined();
+  });
+
+  it("renders a More mobile tab as a button (not a link)", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const moreBtn = screen.getByRole("button", {
+      name: APP_SHELL_COPY.moreLabel,
+    });
+    expect(moreBtn).toBeDefined();
+  });
+});
+
+describe("AppShellNavView — More overflow", () => {
+  it("exposes an Annuities link inside the More overflow once opened", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    fireEvent.click(
+      screen.getByRole("button", { name: APP_SHELL_COPY.moreLabel }),
+    );
+    // When the dialog is open, base-ui-react makes background content inert,
+    // so role queries return only the dialog's content.
+    const annuitiesLink = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkAnnuities })
+      .find((el) => el.getAttribute("href") === "/annuities");
+    expect(annuitiesLink).toBeDefined();
+  });
+
+  it("exposes an Accounts link inside the More overflow once opened", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    fireEvent.click(
+      screen.getByRole("button", { name: APP_SHELL_COPY.moreLabel }),
+    );
+    const accountsLink = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkAccounts })
+      .find((el) => el.getAttribute("href") === "/accounts");
+    expect(accountsLink).toBeDefined();
+  });
+
+  it("exposes a Profile link inside the More overflow once opened", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    fireEvent.click(
+      screen.getByRole("button", { name: APP_SHELL_COPY.moreLabel }),
+    );
+    const profileLink = screen
+      .getAllByRole("link", { name: APP_SHELL_COPY.linkProfile })
+      .find((el) => el.getAttribute("href") === "/profile");
+    expect(profileLink).toBeDefined();
+  });
+
+  it("renders the overflow title when opened", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    fireEvent.click(
+      screen.getByRole("button", { name: APP_SHELL_COPY.moreLabel }),
+    );
+    expect(
+      screen.getAllByText(APP_SHELL_COPY.moreOverflowTitle).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("AppShellNavView — children render", () => {
+  it("renders the child content inside the shell", () => {
+    render(
+      <AppShellNavView pathname="/reconcile">
+        <p data-testid="shell-child">hello shell</p>
+      </AppShellNavView>,
+    );
+    expect(screen.getByTestId("shell-child").textContent).toBe("hello shell");
+  });
+});

--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -103,6 +103,14 @@ describe("AppShellNavView — active-route styling", () => {
 });
 
 describe("AppShellNavView — mobile bottom tab bar", () => {
+  it("renders the mobile nav with the correct aria-label from copy", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const nav = screen.getByRole("navigation", {
+      name: APP_SHELL_COPY.mobileNavLabel,
+    });
+    expect(nav).toBeDefined();
+  });
+
   it("renders a mobile Reconcile tab link pointing to /reconcile", () => {
     render(<AppShellNavView pathname="/ledgers">content</AppShellNavView>);
     const tabs = screen

--- a/src/components/app-shell/AppShellNav.stories.tsx
+++ b/src/components/app-shell/AppShellNav.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AppShellNavView } from "./AppShellNav";
+
+const meta: Meta<typeof AppShellNavView> = {
+  component: AppShellNavView,
+  title: "App Shell/AppShellNav",
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppShellNavView>;
+
+const placeholderChild = (
+  <div className="mx-auto max-w-4xl px-4 py-8 text-sm text-muted-foreground">
+    Placeholder page content lives here.
+  </div>
+);
+
+export const DesktopReconcileActive: Story = {
+  args: {
+    pathname: "/reconcile",
+    children: placeholderChild,
+  },
+  parameters: {
+    viewport: { defaultViewport: "responsive" },
+  },
+};
+
+export const DesktopLedgersActive: Story = {
+  args: {
+    pathname: "/ledgers",
+    children: placeholderChild,
+  },
+};
+
+export const DesktopLedgerDetail: Story = {
+  args: {
+    pathname: "/ledgers/abc123",
+    children: placeholderChild,
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    pathname: "/reconcile",
+    children: placeholderChild,
+  },
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+};

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -119,7 +119,7 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
       <main className="flex-1 pb-20 md:pb-0">{children}</main>
 
       <nav
-        aria-label="Mobile navigation"
+        aria-label={APP_SHELL_COPY.mobileNavLabel}
         className="fixed inset-x-0 bottom-0 z-40 flex h-16 items-stretch border-t bg-background md:hidden"
       >
         {MOBILE_TABS.map((tab) => {
@@ -151,7 +151,7 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
 
       <Dialog open={overflowOpen} onOpenChange={setOverflowOpen}>
         <DialogPortal>
-          <DialogBackdrop />
+          <DialogBackdrop className="z-50" />
           <DialogPopup className="max-w-sm">
             <DialogTitle>{APP_SHELL_COPY.moreOverflowTitle}</DialogTitle>
             <ul className="mt-4 flex flex-col gap-1">

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPopup,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { APP_SHELL_COPY } from "./copy";
+
+interface NavLink {
+  href: string;
+  label: string;
+}
+
+const PRIMARY_LINKS: NavLink[] = [
+  { href: "/reconcile", label: APP_SHELL_COPY.linkReconcile },
+  { href: "/ledgers", label: APP_SHELL_COPY.linkLedgers },
+  { href: "/goals", label: APP_SHELL_COPY.linkGoals },
+  { href: "/investments", label: APP_SHELL_COPY.linkInvestments },
+  { href: "/annuities", label: APP_SHELL_COPY.linkAnnuities },
+  { href: "/accounts", label: APP_SHELL_COPY.linkAccounts },
+  { href: "/profile", label: APP_SHELL_COPY.linkProfile },
+];
+
+const MOBILE_TABS: NavLink[] = [
+  { href: "/reconcile", label: APP_SHELL_COPY.linkReconcile },
+  { href: "/ledgers", label: APP_SHELL_COPY.linkLedgers },
+  { href: "/goals", label: APP_SHELL_COPY.linkGoals },
+  { href: "/investments", label: APP_SHELL_COPY.linkInvest },
+];
+
+const OVERFLOW_LINKS: NavLink[] = [
+  { href: "/annuities", label: APP_SHELL_COPY.linkAnnuities },
+  { href: "/accounts", label: APP_SHELL_COPY.linkAccounts },
+  { href: "/profile", label: APP_SHELL_COPY.linkProfile },
+];
+
+function isActiveRoute(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export interface AppShellNavViewProps {
+  pathname: string;
+  children: React.ReactNode;
+}
+
+export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
+  const [overflowOpen, setOverflowOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="hidden border-b bg-background md:flex">
+        <nav className="mx-auto flex h-14 w-full max-w-6xl items-center justify-between px-4">
+          <Link
+            href="/reconcile"
+            className="text-base font-bold tracking-tight"
+          >
+            {APP_SHELL_COPY.brand}
+          </Link>
+          <ul className="flex items-center gap-1">
+            {PRIMARY_LINKS.map((link) => {
+              const active = isActiveRoute(pathname, link.href);
+              return (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    aria-current={active ? "page" : undefined}
+                    className={cn(
+                      "rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted",
+                      active && "font-semibold",
+                    )}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            type="button"
+            aria-label={APP_SHELL_COPY.userMenuLabel}
+            className="grid size-8 place-items-center rounded-full bg-muted text-xs font-medium"
+          >
+            RM
+          </button>
+        </nav>
+      </header>
+
+      <header className="flex h-14 items-center justify-between border-b bg-background px-4 md:hidden">
+        <button
+          type="button"
+          aria-label={APP_SHELL_COPY.menuButtonLabel}
+          onClick={() => {
+            setOverflowOpen(true);
+          }}
+          className="grid size-9 place-items-center rounded-md hover:bg-muted"
+        >
+          <Menu aria-hidden="true" className="size-5" />
+        </button>
+        <span className="text-base font-bold tracking-tight">
+          {APP_SHELL_COPY.brand}
+        </span>
+        <button
+          type="button"
+          aria-label={APP_SHELL_COPY.userMenuLabel}
+          className="grid size-8 place-items-center rounded-full bg-muted text-xs font-medium"
+        >
+          RM
+        </button>
+      </header>
+
+      <main className="flex-1 pb-20 md:pb-0">{children}</main>
+
+      <nav
+        aria-label="Mobile navigation"
+        className="fixed inset-x-0 bottom-0 z-40 flex h-16 items-stretch border-t bg-background md:hidden"
+      >
+        {MOBILE_TABS.map((tab) => {
+          const active = isActiveRoute(pathname, tab.href);
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "flex flex-1 items-center justify-center text-xs",
+                active ? "font-semibold" : "text-muted-foreground",
+              )}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => {
+            setOverflowOpen(true);
+          }}
+          className="flex flex-1 items-center justify-center text-xs text-muted-foreground"
+        >
+          {APP_SHELL_COPY.moreLabel}
+        </button>
+      </nav>
+
+      <Dialog open={overflowOpen} onOpenChange={setOverflowOpen}>
+        <DialogPortal>
+          <DialogBackdrop />
+          <DialogPopup className="max-w-sm">
+            <DialogTitle>{APP_SHELL_COPY.moreOverflowTitle}</DialogTitle>
+            <ul className="mt-4 flex flex-col gap-1">
+              {OVERFLOW_LINKS.map((link) => {
+                const active = isActiveRoute(pathname, link.href);
+                return (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      aria-current={active ? "page" : undefined}
+                      onClick={() => {
+                        setOverflowOpen(false);
+                      }}
+                      className={cn(
+                        "block rounded-md px-3 py-2 text-sm hover:bg-muted",
+                        active && "font-semibold",
+                      )}
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </DialogPopup>
+        </DialogPortal>
+      </Dialog>
+    </div>
+  );
+}
+
+export function AppShellNav({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return <AppShellNavView pathname={pathname}>{children}</AppShellNavView>;
+}

--- a/src/components/app-shell/copy.ts
+++ b/src/components/app-shell/copy.ts
@@ -9,6 +9,7 @@ export const APP_SHELL_COPY = {
   linkProfile: "Profile",
   linkReconcile: "Reconcile",
   menuButtonLabel: "Open navigation menu",
+  mobileNavLabel: "Mobile navigation",
   moreLabel: "More",
   moreOverflowTitle: "More destinations",
   userMenuLabel: "Open user menu",

--- a/src/components/app-shell/copy.ts
+++ b/src/components/app-shell/copy.ts
@@ -1,0 +1,15 @@
+export const APP_SHELL_COPY = {
+  brand: "Ledgerly",
+  linkAccounts: "Accounts",
+  linkAnnuities: "Annuities",
+  linkGoals: "Goals",
+  linkInvest: "Invest",
+  linkInvestments: "Investments",
+  linkLedgers: "Ledgers",
+  linkProfile: "Profile",
+  linkReconcile: "Reconcile",
+  menuButtonLabel: "Open navigation menu",
+  moreLabel: "More",
+  moreOverflowTitle: "More destinations",
+  userMenuLabel: "Open user menu",
+} as const;

--- a/src/components/app-shell/index.ts
+++ b/src/components/app-shell/index.ts
@@ -1,0 +1,3 @@
+export { AppShellNav, AppShellNavView } from "./AppShellNav";
+export type { AppShellNavViewProps } from "./AppShellNav";
+export { APP_SHELL_COPY } from "./copy";


### PR DESCRIPTION
Adds the persistent navigation shell described in the wireframe set. Every authenticated route now renders inside it via `src/app/(app)/layout.tsx`, giving the per-screen scaffolding tickets (#132–#141) a navigation chrome to attach to.

The component follows the project's view/container split: `AppShellNavView` is presentational and takes `pathname` as a prop (driven directly in tests, no router mocking); `AppShellNav` is the thin container that reads `usePathname()` and forwards it. The "More" overflow uses the existing `Dialog` primitive — there is no `Sheet` component in the project's ShadCN set yet, so a centered modal is the closest analog for the scaffold. Adding a real bottom-sheet variant is left for a later UI polish pass.

Responsive switching is pure CSS (`hidden md:flex` / `md:hidden`) — no JS-side feature detection or window listeners.

## Acceptance Criteria

- [x] `src/app/(app)/layout.tsx` renders the shell around every nested route.
- [x] Top nav links route correctly to `/reconcile`, `/ledgers`, `/goals`, `/investments`, `/annuities`, `/accounts`, `/profile`.
- [x] Active-route styling reflects `usePathname()` (exact match or nested path).
- [x] Mobile bottom-tab bar renders below `md:` breakpoint; desktop top nav renders at and above.
- [x] "More" overflow opens a dialog with `Annuities`, `Accounts`, `Profile`.
- [x] All user-facing strings live in `copy.ts` (`APP_SHELL_COPY`).
- [x] Storybook stories cover desktop (reconcile / ledgers / nested ledger detail) and mobile viewports.
- [x] Component tests verify the link set and active-route styling (19 tests added).

## Manual testing

- Sign in, then visit each top-nav link in turn (target pages will 404 until #132–#141 land — that is expected).
- Confirm the active link is bold on each page.
- Shrink the viewport below the `md` breakpoint and confirm the bottom tab bar replaces the top nav.
- Tap "More" on mobile and confirm Annuities / Accounts / Profile appear in the overflow.

Closes #131

---
*Created by Claude Sonnet 4.6*