### PR TITLE
feat(landing): scaffold hero page matching Ledgerly wireframe

### DIFF
--- a/src/app/page.spec.tsx
+++ b/src/app/page.spec.tsx
@@ -9,7 +9,7 @@ describe("Home", () => {
   it("renders the landing page heading", () => {
     render(<Home />);
     expect(
-      screen.getByRole("heading", { name: LANDING_PAGE_COPY.heading }),
+      screen.getByRole("heading", { name: LANDING_PAGE_COPY.headline }),
     ).toBeDefined();
   });
 });

--- a/src/components/home/LandingPage.copy.ts
+++ b/src/components/home/LandingPage.copy.ts
@@ -1,7 +1,9 @@
 export const LANDING_PAGE_COPY = {
-  createAccountButton: "Create account",
-  description:
-    "Track spending across ledgers, manage your cash and investment split, and work toward your financial goals — all in one place.",
-  heading: "Take control of your finances",
-  signInButton: "Sign in",
+  bodyCopy:
+    "Track balances across accounts you keep at any bank. Split each ledger between cash and investments, set goals, and run a monthly reconciliation that tells you exactly what to move where.",
+  eyebrow: "PERSONAL BUDGET · THE CALM KIND",
+  headline: "Money you already have, organized.",
+  placeholderCaption: "placeholder · screenshot of reconciliation home",
+  primaryCta: "Start free",
+  secondaryCta: "How it works",
 } as const;

--- a/src/components/home/LandingPage.spec.tsx
+++ b/src/components/home/LandingPage.spec.tsx
@@ -42,9 +42,11 @@ describe("LandingPage — CTAs", () => {
     expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-up");
   });
 
-  it("renders a How it works element", () => {
+  it("renders a How it works button", () => {
     render(<LandingPage />);
-    expect(screen.getByText(LANDING_PAGE_COPY.secondaryCta)).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: LANDING_PAGE_COPY.secondaryCta }),
+    ).toBeDefined();
   });
 });
 

--- a/src/components/home/LandingPage.spec.tsx
+++ b/src/components/home/LandingPage.spec.tsx
@@ -2,43 +2,71 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { LandingPage } from "./LandingPage";
 import { LANDING_PAGE_COPY } from "./LandingPage.copy";
+import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";
 
 afterEach(cleanup);
 
-describe("LandingPage", () => {
-  describe("service description", () => {
-    it("renders the main heading", () => {
-      render(<LandingPage />);
-      expect(
-        screen.getByRole("heading", { name: LANDING_PAGE_COPY.heading }),
-      ).toBeDefined();
-    });
-
-    it("renders the service description text", () => {
-      render(<LandingPage />);
-      expect(screen.getByText(LANDING_PAGE_COPY.description)).toBeDefined();
-    });
+describe("LandingPage — hero block", () => {
+  it("renders the eyebrow text", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(LANDING_PAGE_COPY.eyebrow)).toBeDefined();
   });
 
-  describe("Sign in CTA", () => {
-    it("renders a Sign in link pointing to /sign-in", () => {
-      render(<LandingPage />);
-      const link = screen.getByRole("link", {
-        name: LANDING_PAGE_COPY.signInButton,
-      });
-      expect(link).toBeDefined();
-      expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-in");
-    });
+  it("renders the headline", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByRole("heading", { name: LANDING_PAGE_COPY.headline }),
+    ).toBeDefined();
   });
 
-  describe("Create account CTA", () => {
-    it("renders a Create account link pointing to /sign-up", () => {
-      render(<LandingPage />);
-      const link = screen.getByRole("link", {
-        name: LANDING_PAGE_COPY.createAccountButton,
-      });
-      expect(link).toBeDefined();
-      expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-up");
+  it("renders the body copy", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(LANDING_PAGE_COPY.bodyCopy)).toBeDefined();
+  });
+
+  it("renders the placeholder block caption", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByText(LANDING_PAGE_COPY.placeholderCaption),
+    ).toBeDefined();
+  });
+});
+
+describe("LandingPage — CTAs", () => {
+  it("renders a Start free link pointing to /sign-up", () => {
+    render(<LandingPage />);
+    const link = screen.getByRole("link", {
+      name: LANDING_PAGE_COPY.primaryCta,
     });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-up");
+  });
+
+  it("renders a How it works element", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(LANDING_PAGE_COPY.secondaryCta)).toBeDefined();
+  });
+});
+
+describe("LandingPage — public header", () => {
+  it("renders the Ledgerly wordmark in the header", () => {
+    render(<LandingPage />);
+    expect(screen.getByText(PUBLIC_HEADER_COPY.brand)).toBeDefined();
+  });
+
+  it("renders a Sign in link pointing to /sign-in", () => {
+    render(<LandingPage />);
+    const link = screen
+      .getAllByRole("link", { name: PUBLIC_HEADER_COPY.navSignIn })
+      .find((el) => el.getAttribute("href") === "/sign-in");
+    expect(link).toBeDefined();
+  });
+
+  it("renders a Get started link pointing to /sign-up", () => {
+    render(<LandingPage />);
+    const link = screen
+      .getAllByRole("link", { name: PUBLIC_HEADER_COPY.navGetStarted })
+      .find((el) => el.getAttribute("href") === "/sign-up");
+    expect(link).toBeDefined();
   });
 });

--- a/src/components/home/LandingPage.stories.tsx
+++ b/src/components/home/LandingPage.stories.tsx
@@ -5,10 +5,23 @@ import { LandingPage } from "./LandingPage";
 const meta: Meta<typeof LandingPage> = {
   title: "Home/LandingPage",
   component: LandingPage,
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof LandingPage>;
 
-export const Default: Story = {};
+export const Desktop: Story = {
+  parameters: {
+    viewport: { defaultViewport: "responsive" },
+  },
+};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+};

--- a/src/components/home/LandingPage.tsx
+++ b/src/components/home/LandingPage.tsx
@@ -22,9 +22,9 @@ export function LandingPage() {
             <Link href="/sign-up" className={buttonVariants({ size: "lg" })}>
               {LANDING_PAGE_COPY.primaryCta}
             </Link>
-            <span className="text-sm text-muted-foreground">
+            <button type="button" className="text-sm text-muted-foreground">
               {LANDING_PAGE_COPY.secondaryCta}
-            </span>
+            </button>
           </div>
         </div>
         <div className="mt-16 flex w-full max-w-4xl items-center justify-center rounded-xl border bg-muted px-6 py-20 text-sm text-muted-foreground">

--- a/src/components/home/LandingPage.tsx
+++ b/src/components/home/LandingPage.tsx
@@ -1,36 +1,36 @@
 import Link from "next/link";
-
-import {
-  buttonVariants,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui";
-
+import { buttonVariants } from "@/components/ui";
+import { PublicHeader } from "./PublicHeader";
 import { LANDING_PAGE_COPY } from "./LandingPage.copy";
 
 export function LandingPage() {
   return (
-    <div className="flex flex-1 items-center justify-center p-6">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>{LANDING_PAGE_COPY.heading}</CardTitle>
-          <CardDescription>{LANDING_PAGE_COPY.description}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <Link href="/sign-in" className={buttonVariants()}>
-            {LANDING_PAGE_COPY.signInButton}
-          </Link>
-          <Link
-            href="/sign-up"
-            className={buttonVariants({ variant: "outline" })}
-          >
-            {LANDING_PAGE_COPY.createAccountButton}
-          </Link>
-        </CardContent>
-      </Card>
+    <div className="flex min-h-screen flex-col">
+      <PublicHeader />
+      <main className="flex flex-1 flex-col items-center px-4 py-20 md:px-8">
+        <div className="w-full max-w-3xl text-center">
+          <p className="mb-4 text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+            {LANDING_PAGE_COPY.eyebrow}
+          </p>
+          <h1 className="mb-6 text-4xl font-bold tracking-tight md:text-5xl">
+            {LANDING_PAGE_COPY.headline}
+          </h1>
+          <p className="mx-auto mb-10 max-w-2xl text-lg text-muted-foreground">
+            {LANDING_PAGE_COPY.bodyCopy}
+          </p>
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Link href="/sign-up" className={buttonVariants({ size: "lg" })}>
+              {LANDING_PAGE_COPY.primaryCta}
+            </Link>
+            <span className="text-sm text-muted-foreground">
+              {LANDING_PAGE_COPY.secondaryCta}
+            </span>
+          </div>
+        </div>
+        <div className="mt-16 flex w-full max-w-4xl items-center justify-center rounded-xl border bg-muted px-6 py-20 text-sm text-muted-foreground">
+          {LANDING_PAGE_COPY.placeholderCaption}
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/components/home/PublicHeader.copy.ts
+++ b/src/components/home/PublicHeader.copy.ts
@@ -1,0 +1,6 @@
+export const PUBLIC_HEADER_COPY = {
+  brand: "Ledgerly",
+  navGetStarted: "Get started",
+  navPricing: "Pricing",
+  navSignIn: "Sign in",
+} as const;

--- a/src/components/home/PublicHeader.spec.tsx
+++ b/src/components/home/PublicHeader.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PublicHeader } from "./PublicHeader";
+import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";
+
+afterEach(cleanup);
+
+describe("PublicHeader — brand", () => {
+  it("renders the Ledgerly wordmark", () => {
+    render(<PublicHeader />);
+    expect(screen.getByText(PUBLIC_HEADER_COPY.brand)).toBeDefined();
+  });
+});
+
+describe("PublicHeader — navigation links", () => {
+  it("renders a Sign in link pointing to /sign-in", () => {
+    render(<PublicHeader />);
+    const link = screen.getByRole("link", {
+      name: PUBLIC_HEADER_COPY.navSignIn,
+    });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-in");
+  });
+
+  it("renders a Get started link pointing to /sign-up", () => {
+    render(<PublicHeader />);
+    const link = screen.getByRole("link", {
+      name: PUBLIC_HEADER_COPY.navGetStarted,
+    });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).getAttribute("href")).toBe("/sign-up");
+  });
+});

--- a/src/components/home/PublicHeader.stories.tsx
+++ b/src/components/home/PublicHeader.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { PublicHeader } from "./PublicHeader";
+
+const meta: Meta<typeof PublicHeader> = {
+  title: "Home/PublicHeader",
+  component: PublicHeader,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PublicHeader>;
+
+export const Default: Story = {};

--- a/src/components/home/PublicHeader.tsx
+++ b/src/components/home/PublicHeader.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";
+
+export function PublicHeader() {
+  return (
+    <header className="flex h-14 items-center justify-between border-b bg-background px-4 md:px-8">
+      <Link href="/" className="text-base font-bold tracking-tight">
+        {PUBLIC_HEADER_COPY.brand}
+      </Link>
+      <nav className="flex items-center gap-4 text-sm">
+        <Link
+          href="#pricing"
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {PUBLIC_HEADER_COPY.navPricing}
+        </Link>
+        <Link
+          href="/sign-in"
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {PUBLIC_HEADER_COPY.navSignIn}
+        </Link>
+        <Link
+          href="/sign-up"
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+        >
+          {PUBLIC_HEADER_COPY.navGetStarted}
+        </Link>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
Replaces the placeholder landing card with the full Ledgerly hero layout from the `pb-landing-screen` wireframe. Unauthenticated users now land on a marketing page with eyebrow text, headline, body copy, primary/secondary CTAs, and a placeholder screenshot block.

A new `PublicHeader` component handles the slim marketing header (wordmark + Pricing / Sign in / Get started links). It is intentionally separate from the authenticated `AppShellNav` — this is a public marketing header, not the app shell.

## Acceptance Criteria

- [x] `/` renders the Ledgerly hero matching the wireframe at desktop widths.
- [x] Mobile viewport collapses gracefully (single-column hero; header links remain inline at small widths).
- [x] CTAs route to `/sign-up` (Start free) and `/sign-in` (Sign in header link).
- [x] No imports from the authenticated app shell (`(app)/layout.tsx`).
- [x] No data hooks required — this page is fully static.

## Tests

12 tests added (9 for `LandingPage`, 3 for `PublicHeader`), all passing. 687 total passing.

Closes #132

---
*Created by Claude Opus 4.7*