### PR TITLE
feat(goals): scaffold Goal purchase screen at /goals/[goalId]/purchase

### DIFF
--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { use } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/use-auth";
+import { useSavingsGoal } from "@/hooks/use-savings-goal";
+import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
+import { useSavingsGoals } from "@/hooks/use-savings-goals";
+import { GoalPurchaseView } from "@/components/goal-purchase";
+
+interface GoalPurchasePageProps {
+  params: Promise<{ goalId: string }>;
+}
+
+export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
+  const { goalId } = use(params);
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+  const uid = user?.uid ?? "";
+  const { goal, isLoading: goalLoading } = useSavingsGoal(uid, goalId);
+  const { ledgers } = useLedgersSubscription(uid);
+  const ledgerId = goal?.ledgerId ?? "";
+  const { savingsGoals: siblingGoals } = useSavingsGoals(uid, ledgerId);
+
+  if (authLoading || goalLoading || !user) {
+    return null;
+  }
+
+  if (!goal) {
+    return null;
+  }
+
+  const ledger = ledgers.find((l) => l.id === goal.ledgerId);
+  const ledgerName = ledger?.name ?? goal.ledgerId;
+  const siblings = siblingGoals.filter((g) => g.id !== goal.id);
+
+  function handleSubmit() {
+    // TODO: Implement purchase recording in epic #14 (Goal Purchase Flow)
+    router.push("/goals");
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-8">
+      <GoalPurchaseView
+        goal={goal}
+        ledgerName={ledgerName}
+        siblingGoals={siblings}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  );
+}

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { GoalPurchaseForm } from "./GoalPurchaseForm";
+import { GOAL_PURCHASE_FORM_COPY } from "./copy";
+
+afterEach(cleanup);
+
+describe("GoalPurchaseForm — fields", () => {
+  describe("renders the amount field", () => {
+    it("shows the amount label", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByText(GOAL_PURCHASE_FORM_COPY.amountLabel),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders the date field", () => {
+    it("shows the date label", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(GOAL_PURCHASE_FORM_COPY.dateLabel)).toBeDefined();
+    });
+  });
+
+  describe("renders the note field", () => {
+    it("shows the note label", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(GOAL_PURCHASE_FORM_COPY.noteLabel)).toBeDefined();
+    });
+  });
+
+  describe("renders the expense note", () => {
+    it("shows the ledger name in the expense note", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Travel Fund"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByText(GOAL_PURCHASE_FORM_COPY.expenseNote("Travel Fund")),
+      ).toBeDefined();
+    });
+  });
+});
+
+describe("GoalPurchaseForm — actions", () => {
+  describe("Cancel button links to /goals", () => {
+    it("renders a Cancel link pointing to /goals", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      const cancelLink = screen.getByRole("link", {
+        name: GOAL_PURCHASE_FORM_COPY.cancelButton,
+      });
+      expect(cancelLink.getAttribute("href")).toBe("/goals");
+    });
+  });
+
+  describe("Mark purchased button calls onSubmit", () => {
+    it("calls onSubmit when the submit button is clicked", () => {
+      const onSubmit = vi.fn();
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/goal-purchase/GoalPurchaseForm.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GoalPurchaseForm } from "./GoalPurchaseForm";
+
+const meta: Meta<typeof GoalPurchaseForm> = {
+  component: GoalPurchaseForm,
+  title: "GoalPurchase/GoalPurchaseForm",
+};
+
+export default meta;
+type Story = StoryObj<typeof GoalPurchaseForm>;
+
+export const Default: Story = {
+  args: {
+    ledgerName: "Primary",
+    targetAmount: 1500,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+  },
+};
+
+export const HighValueGoal: Story = {
+  args: {
+    ledgerName: "Tech Fund",
+    targetAmount: 25000,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+  },
+};

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { GOAL_PURCHASE_FORM_COPY } from "./copy";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+export interface GoalPurchaseFormProps {
+  ledgerName: string;
+  targetAmount: number;
+  onSubmit: () => void;
+}
+
+export function GoalPurchaseForm({
+  ledgerName,
+  targetAmount,
+  onSubmit,
+}: GoalPurchaseFormProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="purchase-amount">
+          {GOAL_PURCHASE_FORM_COPY.amountLabel}
+        </Label>
+        <div className="relative">
+          <span className="pointer-events-none absolute inset-y-0 left-2.5 flex items-center text-sm text-muted-foreground">
+            {GOAL_PURCHASE_FORM_COPY.amountPrefix}
+          </span>
+          <Input
+            id="purchase-amount"
+            type="number"
+            min={0}
+            step={0.01}
+            defaultValue={targetAmount}
+            className="pl-6"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="purchase-date">
+          {GOAL_PURCHASE_FORM_COPY.dateLabel}
+        </Label>
+        <Input
+          id="purchase-date"
+          type="date"
+          defaultValue={new Date().toISOString().slice(0, 10)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="purchase-note">
+          {GOAL_PURCHASE_FORM_COPY.noteLabel}
+        </Label>
+        <textarea
+          id="purchase-note"
+          rows={3}
+          placeholder={GOAL_PURCHASE_FORM_COPY.notePlaceholder}
+          className="flex w-full rounded-lg border border-input bg-background px-2.5 py-1.5 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+        <span>{GOAL_PURCHASE_FORM_COPY.expenseNote(ledgerName)}</span>
+        <span className="font-mono font-medium text-foreground">
+          {currencyFormatter.format(targetAmount)}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Link
+          href="/goals"
+          className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+        >
+          {GOAL_PURCHASE_FORM_COPY.cancelButton}
+        </Link>
+        <Button onClick={onSubmit}>
+          {GOAL_PURCHASE_FORM_COPY.submitButton}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/goal-purchase/GoalPurchaseView.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.spec.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { GoalPurchaseView } from "./GoalPurchaseView";
+import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+afterEach(cleanup);
+
+function makeGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "Emergency Fund",
+    targetAmount: 5000,
+    fundedAmount: 1000,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+describe("GoalPurchaseView — header", () => {
+  describe("renders the goal name in the header", () => {
+    it("shows the goal name alongside the header prefix", () => {
+      render(
+        <GoalPurchaseView
+          goal={makeGoal({ name: "New Laptop" })}
+          ledgerName="Tech Fund"
+          siblingGoals={[]}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/New Laptop/)).toBeDefined();
+      expect(
+        screen.getByText(GOAL_PURCHASE_VIEW_COPY.headerPrefix),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders the ledger name and target in the summary line", () => {
+    it("shows the ledger name and target in the summary line", () => {
+      render(
+        <GoalPurchaseView
+          goal={makeGoal({ targetAmount: 10000 })}
+          ledgerName="Primary"
+          siblingGoals={[]}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByText(
+          GOAL_PURCHASE_VIEW_COPY.headerSummary("Primary", "$10,000.00"),
+        ),
+      ).toBeDefined();
+    });
+  });
+});
+
+describe("GoalPurchaseView — panels", () => {
+  describe("renders the warning panel", () => {
+    it("shows the insufficient cash warning headline", () => {
+      render(
+        <GoalPurchaseView
+          goal={makeGoal()}
+          ledgerName="Primary"
+          siblingGoals={[]}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/Insufficient cash/i)).toBeDefined();
+    });
+  });
+
+  describe("renders the sibling projections panel", () => {
+    it("shows the sibling goals section title", () => {
+      render(
+        <GoalPurchaseView
+          goal={makeGoal()}
+          ledgerName="Primary"
+          siblingGoals={[makeGoal({ id: "g2", name: "Vacation" })]}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/Sibling Goals/i)).toBeDefined();
+    });
+  });
+});

--- a/src/components/goal-purchase/GoalPurchaseView.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GoalPurchaseView } from "./GoalPurchaseView";
+
+const meta: Meta<typeof GoalPurchaseView> = {
+  component: GoalPurchaseView,
+  title: "GoalPurchase/GoalPurchaseView",
+};
+
+export default meta;
+type Story = StoryObj<typeof GoalPurchaseView>;
+
+const baseGoal = {
+  id: "goal-1",
+  ledgerId: "ledger-1",
+  name: "Studio Display",
+  targetAmount: 1599,
+  fundedAmount: 1599,
+  priority: 1,
+};
+
+const siblingGoals = [
+  {
+    id: "goal-2",
+    ledgerId: "ledger-1",
+    name: "MacBook Pro",
+    targetAmount: 2499,
+    fundedAmount: 1200,
+    priority: 2,
+  },
+  {
+    id: "goal-3",
+    ledgerId: "ledger-1",
+    name: "Mechanical Keyboard",
+    targetAmount: 350,
+    fundedAmount: 100,
+    priority: 3,
+  },
+];
+
+export const NoSiblings: Story = {
+  args: {
+    goal: baseGoal,
+    ledgerName: "Tech Fund",
+    siblingGoals: [],
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+  },
+};
+
+export const WithSiblings: Story = {
+  args: {
+    goal: baseGoal,
+    ledgerName: "Tech Fund",
+    siblingGoals,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+  },
+};

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import { GoalPurchaseForm } from "./GoalPurchaseForm";
+import { GoalPurchaseWarning } from "./GoalPurchaseWarning";
+import { GoalSiblingProjections } from "./GoalSiblingProjections";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+export interface GoalPurchaseViewProps {
+  goal: BudgetLedgerSavingsGoal;
+  ledgerName: string;
+  siblingGoals: BudgetLedgerSavingsGoal[];
+  onSubmit: () => void;
+}
+
+export function GoalPurchaseView({
+  goal,
+  ledgerName,
+  siblingGoals,
+  onSubmit,
+}: GoalPurchaseViewProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <Link
+          href="/goals"
+          className="mb-1 text-sm text-muted-foreground hover:underline"
+        >
+          {GOAL_PURCHASE_VIEW_COPY.breadcrumbParent}
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {GOAL_PURCHASE_VIEW_COPY.headerPrefix} · {goal.name}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {GOAL_PURCHASE_VIEW_COPY.headerSummary(
+            ledgerName,
+            currencyFormatter.format(goal.targetAmount),
+          )}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <GoalPurchaseForm
+          ledgerName={ledgerName}
+          targetAmount={goal.targetAmount}
+          onSubmit={onSubmit}
+        />
+
+        <div className="flex flex-col gap-4">
+          <GoalPurchaseWarning />
+          <GoalSiblingProjections siblingGoals={siblingGoals} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/goal-purchase/GoalPurchaseWarning.tsx
+++ b/src/components/goal-purchase/GoalPurchaseWarning.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { GOAL_PURCHASE_WARNING_COPY } from "./copy";
+
+export function GoalPurchaseWarning() {
+  return (
+    <Card className="border-destructive/50 bg-destructive/5">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold text-destructive">
+          {GOAL_PURCHASE_WARNING_COPY.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          {GOAL_PURCHASE_WARNING_COPY.description}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -24,7 +24,9 @@ export function GoalSiblingProjections({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-left text-xs text-muted-foreground">
-                <th className="px-4 py-2 font-medium">Goal</th>
+                <th className="px-4 py-2 font-medium">
+                  {GOAL_SIBLING_PROJECTIONS_COPY.columnGoal}
+                </th>
                 <th className="px-4 py-2 font-medium">
                   {GOAL_SIBLING_PROJECTIONS_COPY.columnPriorEta}
                 </th>

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
+
+export interface GoalSiblingProjectionsProps {
+  siblingGoals: BudgetLedgerSavingsGoal[];
+}
+
+export function GoalSiblingProjections({
+  siblingGoals,
+}: GoalSiblingProjectionsProps) {
+  // TODO: Implement real ETA recalculation in epic #14 (Goal Purchase Flow)
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">
+          {GOAL_SIBLING_PROJECTIONS_COPY.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {siblingGoals.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-4 py-2 font-medium">Goal</th>
+                <th className="px-4 py-2 font-medium">
+                  {GOAL_SIBLING_PROJECTIONS_COPY.columnPriorEta}
+                </th>
+                <th className="px-4 py-2 font-medium">
+                  {GOAL_SIBLING_PROJECTIONS_COPY.columnNewEta}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {siblingGoals.map((goal) => (
+                <tr key={goal.id} className="border-b last:border-b-0">
+                  <td className="px-4 py-2 font-medium">{goal.name}</td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="px-4 py-3 text-xs text-muted-foreground">
+          {GOAL_SIBLING_PROJECTIONS_COPY.footer}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/goal-purchase/copy.ts
+++ b/src/components/goal-purchase/copy.ts
@@ -1,0 +1,33 @@
+export const GOAL_PURCHASE_VIEW_COPY = {
+  breadcrumbParent: "Goals",
+  headerPrefix: "Mark purchased",
+  headerSummary: (ledgerName: string, targetAmount: string) =>
+    `${ledgerName} · ${targetAmount} target`,
+} as const;
+
+export const GOAL_PURCHASE_FORM_COPY = {
+  amountLabel: "Amount actually spent",
+  amountPrefix: "$",
+  cancelButton: "Cancel",
+  dateLabel: "Date",
+  expenseNote: (ledgerName: string) =>
+    `Will record an expense in ${ledgerName}`,
+  noteLabel: "Note",
+  notePlaceholder: "e.g. Studio Display refurb…",
+  submitButton: "Mark purchased",
+} as const;
+
+export const GOAL_PURCHASE_WARNING_COPY = {
+  description:
+    "This ledger does not have enough cash to cover this purchase. The difference will be reallocated from the investment portion at the next reconciliation.",
+  title: "Insufficient cash in ledger",
+} as const;
+
+export const GOAL_SIBLING_PROJECTIONS_COPY = {
+  columnNewEta: "New ETA",
+  columnPriorEta: "Was",
+  etaPlaceholder: "—",
+  footer:
+    "Recalculated using current Zipf weights and the ledger's monthly allocation.",
+  title: "Sibling Goals · Projected Funding",
+} as const;

--- a/src/components/goal-purchase/copy.ts
+++ b/src/components/goal-purchase/copy.ts
@@ -24,6 +24,7 @@ export const GOAL_PURCHASE_WARNING_COPY = {
 } as const;
 
 export const GOAL_SIBLING_PROJECTIONS_COPY = {
+  columnGoal: "Goal",
   columnNewEta: "New ETA",
   columnPriorEta: "Was",
   etaPlaceholder: "—",

--- a/src/components/goal-purchase/index.ts
+++ b/src/components/goal-purchase/index.ts
@@ -1,0 +1,7 @@
+export { GoalPurchaseForm } from "./GoalPurchaseForm";
+export type { GoalPurchaseFormProps } from "./GoalPurchaseForm";
+export { GoalPurchaseView } from "./GoalPurchaseView";
+export type { GoalPurchaseViewProps } from "./GoalPurchaseView";
+export { GoalPurchaseWarning } from "./GoalPurchaseWarning";
+export { GoalSiblingProjections } from "./GoalSiblingProjections";
+export type { GoalSiblingProjectionsProps } from "./GoalSiblingProjections";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ export { useDeleteSavingsGoal } from "./use-delete-savings-goal";
 export { useLedgersSubscription } from "./use-ledgers-subscription";
 export { useReconciliationAccounts } from "./use-reconciliation-accounts";
 export { useReconciliationExpenses } from "./use-reconciliation-expenses";
+export { useSavingsGoal } from "./use-savings-goal";
 export { useSavingsGoals } from "./use-savings-goals";
 export { useTransactions } from "./use-transactions";
 export { useUpdateSavingsGoal } from "./use-update-savings-goal";

--- a/src/hooks/use-savings-goal.ts
+++ b/src/hooks/use-savings-goal.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getDatabase, ref, onValue } from "firebase/database";
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  firebaseToBudgetLedgerSavingsGoal,
+  type FirebaseBudgetLedgerSavingsGoal,
+  type BudgetLedgerSavingsGoal,
+} from "@/lib/firebase/schema/savings-goals";
+
+interface UseSavingsGoalResult {
+  goal: BudgetLedgerSavingsGoal | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+export function useSavingsGoal(
+  uid: string,
+  goalId: string,
+): UseSavingsGoalResult {
+  const [goal, setGoal] = useState<BudgetLedgerSavingsGoal | undefined>(
+    undefined,
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid || !goalId) {
+      setGoal(undefined);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const allGoalsRef = ref(db, `users/${uid}/budgetLedgerSavingsGoals`);
+
+    const unsubscribe = onValue(
+      allGoalsRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setGoal(undefined);
+        } else {
+          const data = snapshot.val() as Record<
+            string,
+            Record<string, FirebaseBudgetLedgerSavingsGoal>
+          >;
+          let found: BudgetLedgerSavingsGoal | undefined;
+          for (const [ledgerId, ledgerGoals] of Object.entries(data)) {
+            const entry = ledgerGoals[goalId];
+            if (entry !== undefined) {
+              found = firebaseToBudgetLedgerSavingsGoal(
+                goalId,
+                ledgerId,
+                entry,
+              );
+              break;
+            }
+          }
+          setGoal(found);
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid, goalId]);
+
+  return { goal, isLoading, error };
+}


### PR DESCRIPTION
Adds the `/goals/[goalId]/purchase` dynamic route inside the app shell. The page resolves the goal by ID via a new `useSavingsGoal(uid, goalId)` hook that subscribes to the parent `budgetLedgerSavingsGoals` Firebase path and locates the matching entry. Three presentational components render the wireframe layout: `GoalPurchaseForm` (amount/date/note fields with Cancel → `/goals`), `GoalPurchaseWarning` (always-on placeholder for insufficient-cash warning), and `GoalSiblingProjections` (sibling-goal ETA table with placeholder data). The form's `Mark purchased` action is a no-op with a TODO referencing epic #14 (Goal Purchase Flow). The two-column layout collapses to single column on mobile.

## Acceptance Criteria
- [x] `/goals/[goalId]/purchase` renders inside the app shell
- [x] Page header pulls the goal name and ledger name from real data
- [x] Form renders all fields shown in the wireframe with appropriate ShadCN inputs
- [x] `Cancel` routes to `/goals`
- [x] `Mark purchased` is wired to a no-op handler (with a clear TODO naming epic #14)
- [x] Warning panel and sibling-projections panel render in their static/placeholder form
- [x] Mobile viewport collapses to a single column

## Tests
10 tests added, all passing.

Closes #137

---
*Created by Claude Sonnet 4.5*