### PR TITLE
feat(annuities): scaffold Annuities screen with card layout

### DIFF
--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -3,42 +3,100 @@
 import { useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { useAnnuities } from "@/hooks/use-annuities";
-import { AnnuityListView, NewAnnuityDialog } from "@/components/annuities";
+import { Button } from "@/components/ui/button";
+import {
+  AnnuityCard,
+  AnnuityPaymentHistoryTable,
+  AnnuityBalanceTrend,
+  CreateAnnuityDialog,
+} from "@/components/annuities";
+import { ANNUITY_LIST_COPY } from "@/components/annuities/copy";
 import { createAnnuity } from "@/services/annuities";
+import type { CreateAnnuityInput } from "@/components/annuities";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
 
 export default function AnnuitiesPage() {
   const { user, loading: authLoading } = useAuth();
   const uid = user?.uid ?? "";
   const { annuities, isLoading } = useAnnuities(uid);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   if (authLoading || !user) {
     return null;
   }
 
-  const handleSubmit = async (
-    name: string,
-    monthlyAmount: number,
-    durationMonths: number | undefined,
-  ) => {
+  const selectedAnnuity = annuities[selectedIndex] ?? annuities[0];
+  const totalMonthly = annuities.reduce((sum, a) => sum + a.monthlyAmount, 0);
+
+  const handleSubmit = async (data: CreateAnnuityInput) => {
     await createAnnuity(uid, {
-      name,
-      monthlyAmount,
+      name: data.name,
+      monthlyAmount: data.monthlyAmount,
+      monthlyMode: data.monthlyMode,
       startDate: new Date(),
-      durationMonths,
+      durationMonths: data.durationMonths,
     });
   };
 
   return (
-    <div className="mx-auto w-full max-w-2xl px-4 py-8">
-      <AnnuityListView
-        annuities={annuities}
-        isLoading={isLoading}
-        onNewAnnuity={() => {
-          setDialogOpen(true);
-        }}
-      />
-      <NewAnnuityDialog
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {ANNUITY_LIST_COPY.title}
+          </h1>
+          {!isLoading && annuities.length > 0 && (
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {ANNUITY_LIST_COPY.summaryLine(
+                annuities.length,
+                currencyFormatter.format(totalMonthly),
+              )}
+            </p>
+          )}
+        </div>
+        <Button
+          onClick={() => {
+            setDialogOpen(true);
+          }}
+        >
+          {ANNUITY_LIST_COPY.newAnnuityButton}
+        </Button>
+      </div>
+
+      {!isLoading && annuities.length === 0 ? (
+        <p className="py-8 text-center text-muted-foreground">
+          {ANNUITY_LIST_COPY.emptyStateMessage}
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {annuities.map((annuity, index) => (
+              <AnnuityCard
+                key={annuity.id}
+                annuity={annuity}
+                isSelected={index === selectedIndex}
+                onSelect={() => {
+                  setSelectedIndex(index);
+                }}
+              />
+            ))}
+          </div>
+
+          {selectedAnnuity !== undefined && (
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <AnnuityPaymentHistoryTable annuity={selectedAnnuity} />
+              <AnnuityBalanceTrend annuity={selectedAnnuity} />
+            </div>
+          )}
+        </>
+      )}
+
+      <CreateAnnuityDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         onSubmit={handleSubmit}

--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -23,14 +23,15 @@ export default function AnnuitiesPage() {
   const { user, loading: authLoading } = useAuth();
   const uid = user?.uid ?? "";
   const { annuities, isLoading } = useAnnuities(uid);
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   if (authLoading || !user) {
     return null;
   }
 
-  const selectedAnnuity = annuities[selectedIndex] ?? annuities[0];
+  const selectedAnnuity =
+    annuities.find((a) => a.id === selectedId) ?? annuities[0];
   const totalMonthly = annuities.reduce((sum, a) => sum + a.monthlyAmount, 0);
 
   const handleSubmit = async (data: CreateAnnuityInput) => {
@@ -75,13 +76,13 @@ export default function AnnuitiesPage() {
       ) : (
         <>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {annuities.map((annuity, index) => (
+            {annuities.map((annuity) => (
               <AnnuityCard
                 key={annuity.id}
                 annuity={annuity}
-                isSelected={index === selectedIndex}
+                isSelected={annuity.id === selectedAnnuity?.id}
                 onSelect={() => {
-                  setSelectedIndex(index);
+                  setSelectedId(annuity.id);
                 }}
               />
             ))}

--- a/src/components/annuities/AnnuityBalanceTrend.spec.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.spec.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AnnuityBalanceTrend } from "./AnnuityBalanceTrend";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+import { ANNUITY_CARD_COPY } from "./copy";
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+
+afterEach(cleanup);
+
+function makeAnnuity(overrides: Partial<Annuity> = {}): Annuity {
+  return {
+    id: "annuity-1",
+    name: "Mortgage",
+    monthlyAmount: 978.63,
+    startDate: new Date("2020-01-01T00:00:00.000Z"),
+    durationMonths: 360,
+    monthlyMode: AnnuityMonthlyMode.Flat,
+    ...overrides,
+  };
+}
+
+describe("AnnuityBalanceTrend", () => {
+  describe("renders the section title with the annuity name", () => {
+    it("shows the annuity name uppercased in the title", () => {
+      render(
+        <AnnuityBalanceTrend annuity={makeAnnuity({ name: "Auto Loan" })} />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.balanceTrendTitle("AUTO LOAN")),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders the chart placeholder", () => {
+    it("renders an element with the chart placeholder label", () => {
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      expect(
+        screen.getByRole("img", {
+          name: ANNUITY_CARD_COPY.balanceTrendChartPlaceholder,
+        }),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/components/annuities/AnnuityBalanceTrend.spec.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.spec.tsx
@@ -41,4 +41,27 @@ describe("AnnuityBalanceTrend", () => {
       ).toBeDefined();
     });
   });
+
+  describe("renders the Started / Now / Payoff summary row", () => {
+    it("renders the Started label", () => {
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.balanceTrendStartedLabel),
+      ).toBeDefined();
+    });
+
+    it("renders the Now label", () => {
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.balanceTrendNowLabel),
+      ).toBeDefined();
+    });
+
+    it("renders the Payoff label", () => {
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.balanceTrendPayoffLabel),
+      ).toBeDefined();
+    });
+  });
 });

--- a/src/components/annuities/AnnuityBalanceTrend.stories.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AnnuityBalanceTrend } from "./AnnuityBalanceTrend";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+
+const meta: Meta<typeof AnnuityBalanceTrend> = {
+  component: AnnuityBalanceTrend,
+  title: "Annuities/AnnuityBalanceTrend",
+};
+
+export default meta;
+type Story = StoryObj<typeof AnnuityBalanceTrend>;
+
+export const Default: Story = {
+  args: {
+    annuity: {
+      id: "1",
+      name: "Mortgage",
+      monthlyAmount: 978.63,
+      startDate: new Date("2020-01-01"),
+      durationMonths: 360,
+      monthlyMode: AnnuityMonthlyMode.PVDerived,
+    },
+  },
+};

--- a/src/components/annuities/AnnuityBalanceTrend.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+import { Card } from "@/components/ui/card";
+import { ANNUITY_CARD_COPY } from "./copy";
+
+export interface AnnuityBalanceTrendProps {
+  annuity: Annuity;
+}
+
+export function AnnuityBalanceTrend({ annuity }: AnnuityBalanceTrendProps) {
+  return (
+    <Card className="flex flex-col gap-4 p-4">
+      <h3 className="text-sm font-semibold">
+        {ANNUITY_CARD_COPY.balanceTrendTitle(annuity.name.toUpperCase())}
+      </h3>
+      {/* TODO: Replace with Recharts or similar chart library in epic #16 (Annuity Monthly Tracking) */}
+      <div
+        role="img"
+        aria-label={ANNUITY_CARD_COPY.balanceTrendChartPlaceholder}
+        className="flex h-32 items-center justify-center rounded-lg border-2 border-dashed border-muted text-sm text-muted-foreground"
+      >
+        {ANNUITY_CARD_COPY.balanceTrendChartPlaceholder}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/annuities/AnnuityBalanceTrend.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.tsx
@@ -22,6 +22,32 @@ export function AnnuityBalanceTrend({ annuity }: AnnuityBalanceTrendProps) {
       >
         {ANNUITY_CARD_COPY.balanceTrendChartPlaceholder}
       </div>
+      <div className="grid grid-cols-3 divide-x text-center text-sm">
+        <div className="px-2">
+          <p className="text-xs text-muted-foreground">
+            {ANNUITY_CARD_COPY.balanceTrendStartedLabel}
+          </p>
+          <p className="font-medium">
+            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
+          </p>
+        </div>
+        <div className="px-2">
+          <p className="text-xs text-muted-foreground">
+            {ANNUITY_CARD_COPY.balanceTrendNowLabel}
+          </p>
+          <p className="font-medium">
+            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
+          </p>
+        </div>
+        <div className="px-2">
+          <p className="text-xs text-muted-foreground">
+            {ANNUITY_CARD_COPY.balanceTrendPayoffLabel}
+          </p>
+          <p className="font-medium">
+            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
+          </p>
+        </div>
+      </div>
     </Card>
   );
 }

--- a/src/components/annuities/AnnuityCard.spec.tsx
+++ b/src/components/annuities/AnnuityCard.spec.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AnnuityCard } from "./AnnuityCard";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+import { ANNUITY_CARD_COPY } from "./copy";
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+
+afterEach(cleanup);
+
+function makeAnnuity(overrides: Partial<Annuity> = {}): Annuity {
+  return {
+    id: "annuity-1",
+    name: "Mortgage",
+    monthlyAmount: 978.63,
+    startDate: new Date("2020-01-01T00:00:00.000Z"),
+    durationMonths: 360,
+    monthlyMode: AnnuityMonthlyMode.Flat,
+    ...overrides,
+  };
+}
+
+describe("AnnuityCard — content", () => {
+  describe("renders the annuity name as an uppercase eyebrow", () => {
+    it("shows the name in uppercase", () => {
+      render(<AnnuityCard annuity={makeAnnuity({ name: "Car Loan" })} />);
+      expect(screen.getByText("CAR LOAN")).toBeDefined();
+    });
+  });
+
+  describe("renders the monthly amount", () => {
+    it("formats the monthly amount as currency", () => {
+      render(<AnnuityCard annuity={makeAnnuity({ monthlyAmount: 1250 })} />);
+      expect(screen.getByText("$1,250.00")).toBeDefined();
+    });
+  });
+
+  describe("renders the correct monthly mode sublabel", () => {
+    it("shows Flat sublabel for Flat mode", () => {
+      render(
+        <AnnuityCard
+          annuity={makeAnnuity({ monthlyMode: AnnuityMonthlyMode.Flat })}
+        />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.monthlyModeFlatSublabel),
+      ).toBeDefined();
+    });
+
+    it("shows PV-derived sublabel for PVDerived mode", () => {
+      render(
+        <AnnuityCard
+          annuity={makeAnnuity({ monthlyMode: AnnuityMonthlyMode.PVDerived })}
+        />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.monthlyModePVDerivedSublabel),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders term remaining", () => {
+    it("shows 'Ongoing' for an annuity with no duration", () => {
+      render(
+        <AnnuityCard annuity={makeAnnuity({ durationMonths: undefined })} />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.termRemainingIndefinite),
+      ).toBeDefined();
+    });
+
+    it("shows months remaining for a fixed-duration annuity in the future", () => {
+      render(
+        <AnnuityCard
+          annuity={makeAnnuity({
+            startDate: new Date("2099-01-01T00:00:00.000Z"),
+            durationMonths: 24,
+          })}
+        />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.termRemainingMonths(24)),
+      ).toBeDefined();
+    });
+  });
+});
+
+describe("AnnuityCard — selection state", () => {
+  it("sets aria-pressed to true when isSelected is true", () => {
+    render(
+      <AnnuityCard
+        annuity={makeAnnuity()}
+        isSelected={true}
+        onSelect={vi.fn()}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("sets aria-pressed to false when isSelected is false", () => {
+    render(
+      <AnnuityCard
+        annuity={makeAnnuity()}
+        isSelected={false}
+        onSelect={vi.fn()}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/src/components/annuities/AnnuityCard.stories.tsx
+++ b/src/components/annuities/AnnuityCard.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AnnuityCard } from "./AnnuityCard";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+
+const meta: Meta<typeof AnnuityCard> = {
+  component: AnnuityCard,
+  title: "Annuities/AnnuityCard",
+};
+
+export default meta;
+type Story = StoryObj<typeof AnnuityCard>;
+
+const baseAnnuity = {
+  id: "1",
+  name: "Mortgage",
+  monthlyAmount: 978.63,
+  startDate: new Date("2020-01-01"),
+  durationMonths: 360,
+  monthlyMode: AnnuityMonthlyMode.PVDerived,
+};
+
+export const Default: Story = {
+  args: {
+    annuity: baseAnnuity,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    annuity: baseAnnuity,
+    isSelected: true,
+  },
+};
+
+export const FlatMode: Story = {
+  args: {
+    annuity: { ...baseAnnuity, monthlyMode: AnnuityMonthlyMode.Flat },
+  },
+};
+
+export const NoTerm: Story = {
+  args: {
+    annuity: {
+      ...baseAnnuity,
+      name: "Subscription",
+      durationMonths: undefined,
+      monthlyAmount: 15.99,
+    },
+  },
+};

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Card } from "@/components/ui/card";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
 import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
@@ -48,34 +47,30 @@ export function AnnuityCard({
     <button
       type="button"
       onClick={onSelect}
-      className="w-full text-left"
+      className={`w-full rounded-lg border bg-card text-card-foreground shadow-sm flex flex-col gap-3 p-4 text-left transition-colors hover:bg-muted/50 ${
+        isSelected ? "ring-2 ring-primary" : ""
+      }`}
       aria-pressed={isSelected}
     >
-      <Card
-        className={`flex flex-col gap-3 p-4 transition-colors hover:bg-muted/50 ${
-          isSelected ? "ring-2 ring-primary" : ""
-        }`}
-      >
-        <p className="text-xs font-semibold tracking-widest text-muted-foreground">
-          {annuity.name.toUpperCase()}
+      <p className="text-xs font-semibold tracking-widest text-muted-foreground">
+        {annuity.name.toUpperCase()}
+      </p>
+
+      <div>
+        <p className="text-3xl font-bold tabular-nums">
+          {currencyFormatter.format(annuity.monthlyAmount)}
         </p>
+        <p className="text-xs text-muted-foreground">{sublabel}</p>
+      </div>
 
-        <div>
-          <p className="text-3xl font-bold tabular-nums">
-            {currencyFormatter.format(annuity.monthlyAmount)}
-          </p>
-          <p className="text-xs text-muted-foreground">{sublabel}</p>
+      <dl className="flex flex-col gap-1 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">
+            {ANNUITY_CARD_COPY.termRemainingLabel}
+          </dt>
+          <dd className="font-mono font-medium">{termDisplay}</dd>
         </div>
-
-        <dl className="flex flex-col gap-1 text-sm">
-          <div className="flex justify-between">
-            <dt className="text-muted-foreground">
-              {ANNUITY_CARD_COPY.termRemainingLabel}
-            </dt>
-            <dd className="font-mono font-medium">{termDisplay}</dd>
-          </div>
-        </dl>
-      </Card>
+      </dl>
     </button>
   );
 }

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+import { Card } from "@/components/ui/card";
+import { ANNUITY_CARD_COPY } from "./copy";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function monthsRemaining(startDate: Date, durationMonths: number): number {
+  const now = new Date();
+  const elapsed = Math.max(
+    0,
+    (now.getFullYear() - startDate.getFullYear()) * 12 +
+      (now.getMonth() - startDate.getMonth()),
+  );
+  return Math.max(0, durationMonths - elapsed);
+}
+
+export interface AnnuityCardProps {
+  annuity: Annuity;
+  isSelected?: boolean;
+  onSelect?: () => void;
+}
+
+export function AnnuityCard({
+  annuity,
+  isSelected,
+  onSelect,
+}: AnnuityCardProps) {
+  const sublabel =
+    annuity.monthlyMode === AnnuityMonthlyMode.PVDerived
+      ? ANNUITY_CARD_COPY.monthlyModePVDerivedSublabel
+      : ANNUITY_CARD_COPY.monthlyModeFlatSublabel;
+
+  const termDisplay =
+    annuity.durationMonths !== undefined
+      ? ANNUITY_CARD_COPY.termRemainingMonths(
+          monthsRemaining(annuity.startDate, annuity.durationMonths),
+        )
+      : ANNUITY_CARD_COPY.termRemainingIndefinite;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="w-full text-left"
+      aria-pressed={isSelected}
+    >
+      <Card
+        className={`flex flex-col gap-3 p-4 transition-colors hover:bg-muted/50 ${
+          isSelected ? "ring-2 ring-primary" : ""
+        }`}
+      >
+        <p className="text-xs font-semibold tracking-widest text-muted-foreground">
+          {annuity.name.toUpperCase()}
+        </p>
+
+        <div>
+          <p className="text-3xl font-bold tabular-nums">
+            {currencyFormatter.format(annuity.monthlyAmount)}
+          </p>
+          <p className="text-xs text-muted-foreground">{sublabel}</p>
+        </div>
+
+        <dl className="flex flex-col gap-1 text-sm">
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">
+              {ANNUITY_CARD_COPY.termRemainingLabel}
+            </dt>
+            <dd className="font-mono font-medium">{termDisplay}</dd>
+          </div>
+        </dl>
+      </Card>
+    </button>
+  );
+}

--- a/src/components/annuities/AnnuityListView.spec.tsx
+++ b/src/components/annuities/AnnuityListView.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { AnnuityListView } from "./AnnuityListView";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 import { ANNUITY_LIST_COPY } from "./copy";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
 
@@ -13,6 +14,7 @@ function makeAnnuity(overrides: Partial<Annuity> = {}): Annuity {
     monthlyAmount: 100,
     startDate: new Date("2024-01-01T00:00:00.000Z"),
     durationMonths: 12,
+    monthlyMode: AnnuityMonthlyMode.Flat,
     ...overrides,
   };
 }

--- a/src/components/annuities/AnnuityListView.stories.tsx
+++ b/src/components/annuities/AnnuityListView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { AnnuityListView } from "./AnnuityListView";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
 const meta: Meta<typeof AnnuityListView> = {
   component: AnnuityListView,
@@ -39,6 +40,7 @@ export const PopulatedFlatRate: Story = {
         monthlyAmount: 15.99,
         startDate: new Date("2024-01-01"),
         durationMonths: undefined,
+        monthlyMode: AnnuityMonthlyMode.Flat,
       },
       {
         id: "2",
@@ -46,6 +48,7 @@ export const PopulatedFlatRate: Story = {
         monthlyAmount: 9.99,
         startDate: new Date("2024-03-01"),
         durationMonths: undefined,
+        monthlyMode: AnnuityMonthlyMode.Flat,
       },
     ],
   },
@@ -63,6 +66,7 @@ export const PopulatedFixedTerm: Story = {
         monthlyAmount: 425.5,
         startDate: new Date("2023-06-01"),
         durationMonths: 48,
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
       },
       {
         id: "2",
@@ -70,6 +74,7 @@ export const PopulatedFixedTerm: Story = {
         monthlyAmount: 210.0,
         startDate: new Date("2024-01-01"),
         durationMonths: 24,
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
       },
     ],
   },
@@ -87,6 +92,7 @@ export const PopulatedMixed: Story = {
         monthlyAmount: 15.99,
         startDate: new Date("2024-01-01"),
         durationMonths: undefined,
+        monthlyMode: AnnuityMonthlyMode.Flat,
       },
       {
         id: "2",
@@ -94,6 +100,7 @@ export const PopulatedMixed: Story = {
         monthlyAmount: 425.5,
         startDate: new Date("2023-06-01"),
         durationMonths: 48,
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
       },
       {
         id: "3",
@@ -101,6 +108,7 @@ export const PopulatedMixed: Story = {
         monthlyAmount: 1800.0,
         startDate: new Date("2025-01-01"),
         durationMonths: undefined,
+        monthlyMode: AnnuityMonthlyMode.Flat,
       },
       {
         id: "4",
@@ -108,6 +116,7 @@ export const PopulatedMixed: Story = {
         monthlyAmount: 210.0,
         startDate: new Date("2024-01-01"),
         durationMonths: 24,
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
       },
     ],
   },

--- a/src/components/annuities/AnnuityPaymentHistoryTable.spec.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.spec.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AnnuityPaymentHistoryTable } from "./AnnuityPaymentHistoryTable";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+import { ANNUITY_CARD_COPY } from "./copy";
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+
+afterEach(cleanup);
+
+function makeAnnuity(overrides: Partial<Annuity> = {}): Annuity {
+  return {
+    id: "annuity-1",
+    name: "Mortgage",
+    monthlyAmount: 978.63,
+    startDate: new Date("2020-01-01T00:00:00.000Z"),
+    durationMonths: 360,
+    monthlyMode: AnnuityMonthlyMode.Flat,
+    ...overrides,
+  };
+}
+
+describe("AnnuityPaymentHistoryTable", () => {
+  describe("renders the section title with the annuity name", () => {
+    it("shows the annuity name in the title", () => {
+      render(
+        <AnnuityPaymentHistoryTable
+          annuity={makeAnnuity({ name: "Car Loan" })}
+        />,
+      );
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.paymentHistoryTitle("CAR LOAN")),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders table column headers", () => {
+    it("shows the Month column header", () => {
+      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      expect(screen.getByText(ANNUITY_CARD_COPY.columnMonth)).toBeDefined();
+    });
+
+    it("shows the Balance column header", () => {
+      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      expect(screen.getByText(ANNUITY_CARD_COPY.columnBalance)).toBeDefined();
+    });
+  });
+
+  describe("renders empty state", () => {
+    it("shows the empty-state message when no payments exist", () => {
+      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      expect(
+        screen.getByText(ANNUITY_CARD_COPY.paymentHistoryEmpty),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/components/annuities/AnnuityPaymentHistoryTable.stories.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AnnuityPaymentHistoryTable } from "./AnnuityPaymentHistoryTable";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
+
+const meta: Meta<typeof AnnuityPaymentHistoryTable> = {
+  component: AnnuityPaymentHistoryTable,
+  title: "Annuities/AnnuityPaymentHistoryTable",
+};
+
+export default meta;
+type Story = StoryObj<typeof AnnuityPaymentHistoryTable>;
+
+export const Default: Story = {
+  args: {
+    annuity: {
+      id: "1",
+      name: "Mortgage",
+      monthlyAmount: 978.63,
+      startDate: new Date("2020-01-01"),
+      durationMonths: 360,
+      monthlyMode: AnnuityMonthlyMode.PVDerived,
+    },
+  },
+};

--- a/src/components/annuities/AnnuityPaymentHistoryTable.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+import { Card } from "@/components/ui/card";
+import { ANNUITY_CARD_COPY } from "./copy";
+
+export interface AnnuityPaymentHistoryTableProps {
+  annuity: Annuity;
+}
+
+export function AnnuityPaymentHistoryTable({
+  annuity,
+}: AnnuityPaymentHistoryTableProps) {
+  return (
+    <Card>
+      <div className="px-4 py-3">
+        <h3 className="text-sm font-semibold">
+          {ANNUITY_CARD_COPY.paymentHistoryTitle(annuity.name.toUpperCase())}
+        </h3>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs text-muted-foreground">
+            <th className="px-4 py-2 font-medium">
+              {ANNUITY_CARD_COPY.columnMonth}
+            </th>
+            <th className="px-4 py-2 text-right font-medium">
+              {ANNUITY_CARD_COPY.columnPayment}
+            </th>
+            <th className="px-4 py-2 text-right font-medium">
+              {ANNUITY_CARD_COPY.columnPrincipal}
+            </th>
+            <th className="px-4 py-2 text-right font-medium">
+              {ANNUITY_CARD_COPY.columnInterest}
+            </th>
+            <th className="px-4 py-2 text-right font-medium">
+              {ANNUITY_CARD_COPY.columnBalance}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              colSpan={5}
+              className="px-4 py-8 text-center text-muted-foreground"
+            >
+              {ANNUITY_CARD_COPY.paymentHistoryEmpty}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/src/components/annuities/AnnuityPaymentHistoryTable.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.tsx
@@ -19,37 +19,39 @@ export function AnnuityPaymentHistoryTable({
           {ANNUITY_CARD_COPY.paymentHistoryTitle(annuity.name.toUpperCase())}
         </h3>
       </div>
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left text-xs text-muted-foreground">
-            <th className="px-4 py-2 font-medium">
-              {ANNUITY_CARD_COPY.columnMonth}
-            </th>
-            <th className="px-4 py-2 text-right font-medium">
-              {ANNUITY_CARD_COPY.columnPayment}
-            </th>
-            <th className="px-4 py-2 text-right font-medium">
-              {ANNUITY_CARD_COPY.columnPrincipal}
-            </th>
-            <th className="px-4 py-2 text-right font-medium">
-              {ANNUITY_CARD_COPY.columnInterest}
-            </th>
-            <th className="px-4 py-2 text-right font-medium">
-              {ANNUITY_CARD_COPY.columnBalance}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td
-              colSpan={5}
-              className="px-4 py-8 text-center text-muted-foreground"
-            >
-              {ANNUITY_CARD_COPY.paymentHistoryEmpty}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs text-muted-foreground">
+              <th className="px-4 py-2 font-medium">
+                {ANNUITY_CARD_COPY.columnMonth}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {ANNUITY_CARD_COPY.columnPayment}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {ANNUITY_CARD_COPY.columnPrincipal}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {ANNUITY_CARD_COPY.columnInterest}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {ANNUITY_CARD_COPY.columnBalance}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td
+                colSpan={5}
+                className="px-4 py-8 text-center text-muted-foreground"
+              >
+                {ANNUITY_CARD_COPY.paymentHistoryEmpty}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </Card>
   );
 }

--- a/src/components/annuities/CreateAnnuityDialog.spec.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.spec.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { CreateAnnuityDialogView } from "./CreateAnnuityDialog";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 import { CREATE_ANNUITY_DIALOG_COPY } from "./copy";
 
 afterEach(cleanup);
@@ -333,6 +334,7 @@ describe("CreateAnnuityDialog integration", () => {
       expect(onSubmit).toHaveBeenCalledWith({
         name: "Netflix",
         monthlyAmount: 15.99,
+        monthlyMode: AnnuityMonthlyMode.Flat,
         durationMonths: undefined,
       });
     });

--- a/src/components/annuities/CreateAnnuityDialog.spec.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.spec.tsx
@@ -302,10 +302,12 @@ describe("CreateAnnuityDialog integration", () => {
     const callArg = onSubmit.mock.calls[0]![0] as {
       name: string;
       monthlyAmount: number;
+      monthlyMode: AnnuityMonthlyMode;
       durationMonths: number;
     };
     expect(callArg.name).toBe("Car Loan");
     expect(Math.round(callArg.monthlyAmount * 100) / 100).toBe(856.07);
+    expect(callArg.monthlyMode).toBe(AnnuityMonthlyMode.PVDerived);
     expect(callArg.durationMonths).toBe(12);
   });
 

--- a/src/components/annuities/CreateAnnuityDialog.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { calculateMonthlyPayment } from "@/lib/annuity-math";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 import { CREATE_ANNUITY_DIALOG_COPY } from "./copy";
 
 type AnnuityMode = "flat" | "pv";
@@ -22,6 +23,7 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 export interface CreateAnnuityInput {
   name: string;
   monthlyAmount: number;
+  monthlyMode: AnnuityMonthlyMode;
   durationMonths: number | undefined;
 }
 
@@ -506,6 +508,10 @@ export function CreateAnnuityDialog({
       await onSubmit({
         name: name.trim(),
         monthlyAmount: resolvedMonthlyAmount,
+        monthlyMode:
+          mode === "pv"
+            ? AnnuityMonthlyMode.PVDerived
+            : AnnuityMonthlyMode.Flat,
         durationMonths: resolvedDuration,
       });
       handleOpenChange(false);

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -18,7 +18,17 @@ export const ANNUITY_CARD_COPY = {
     `${annuityName} · payment history`,
   termRemainingIndefinite: "Ongoing",
   termRemainingLabel: "Term remaining",
-  termRemainingMonths: (months: number) => `${String(months)} mo left`,
+  termRemainingMonths: (months: number) => {
+    const years = Math.floor(months / 12);
+    const remainingMonths = months % 12;
+    if (years > 0 && remainingMonths > 0) {
+      return `${String(years)} yr ${String(remainingMonths)} mo left`;
+    } else if (years > 0) {
+      return `${String(years)} yr left`;
+    } else {
+      return `${String(remainingMonths)} mo left`;
+    }
+  },
 } as const;
 
 export const ANNUITY_LIST_COPY = {

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -12,8 +12,8 @@ export const ANNUITY_CARD_COPY = {
   paymentHistoryEmpty: "No payment history yet.",
   paymentHistoryTitle: (annuityName: string) =>
     `${annuityName} · payment history`,
-  termRemainingLabel: "Term remaining",
   termRemainingIndefinite: "Ongoing",
+  termRemainingLabel: "Term remaining",
   termRemainingMonths: (months: number) => `${String(months)} mo left`,
 } as const;
 

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -1,3 +1,22 @@
+export const ANNUITY_CARD_COPY = {
+  balanceTrendChartPlaceholder: "Balance trend chart",
+  balanceTrendTitle: (annuityName: string) =>
+    `Balance trend · ${annuityName} principal`,
+  columnBalance: "Balance",
+  columnInterest: "Interest",
+  columnMonth: "Month",
+  columnPayment: "Payment",
+  columnPrincipal: "Principal",
+  monthlyModeFlatSublabel: "monthly · Flat",
+  monthlyModePVDerivedSublabel: "monthly · PV-derived",
+  paymentHistoryEmpty: "No payment history yet.",
+  paymentHistoryTitle: (annuityName: string) =>
+    `${annuityName} · payment history`,
+  termRemainingLabel: "Term remaining",
+  termRemainingIndefinite: "Ongoing",
+  termRemainingMonths: (months: number) => `${String(months)} mo left`,
+} as const;
+
 export const ANNUITY_LIST_COPY = {
   columnMonthly: "Monthly",
   columnName: "Name",
@@ -5,6 +24,8 @@ export const ANNUITY_LIST_COPY = {
   emptyStateMessage: "You don't have any annuities yet.",
   indefiniteTerm: "Indefinite",
   newAnnuityButton: "New Annuity",
+  summaryLine: (count: number, total: string) =>
+    `${String(count)} active · ${total} / month total`,
   termSuffix: "months",
   title: "Annuities",
 } as const;

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -1,5 +1,9 @@
 export const ANNUITY_CARD_COPY = {
   balanceTrendChartPlaceholder: "Balance trend chart",
+  balanceTrendNowLabel: "Now",
+  balanceTrendPayoffLabel: "Payoff",
+  balanceTrendPlaceholderValue: "—",
+  balanceTrendStartedLabel: "Started",
   balanceTrendTitle: (annuityName: string) =>
     `Balance trend · ${annuityName} principal`,
   columnBalance: "Balance",

--- a/src/components/annuities/index.ts
+++ b/src/components/annuities/index.ts
@@ -1,4 +1,10 @@
+export { AnnuityBalanceTrend } from "./AnnuityBalanceTrend";
+export type { AnnuityBalanceTrendProps } from "./AnnuityBalanceTrend";
+export { AnnuityCard } from "./AnnuityCard";
+export type { AnnuityCardProps } from "./AnnuityCard";
 export { AnnuityListView } from "./AnnuityListView";
+export { AnnuityPaymentHistoryTable } from "./AnnuityPaymentHistoryTable";
+export type { AnnuityPaymentHistoryTableProps } from "./AnnuityPaymentHistoryTable";
 export { NewAnnuityDialog } from "./NewAnnuityDialog";
 export {
   CreateAnnuityDialog,

--- a/src/lib/firebase/schema/annuities.spec.ts
+++ b/src/lib/firebase/schema/annuities.spec.ts
@@ -39,6 +39,17 @@ describe("annuityToFirebase", () => {
     });
     expect(result.durationMonths).toBe(60);
   });
+
+  it("serializes PVDerived monthlyMode correctly", () => {
+    const result = annuityToFirebase({
+      name: "Mortgage",
+      monthlyAmount: 978.63,
+      startDate: new Date(),
+      durationMonths: 360,
+      monthlyMode: AnnuityMonthlyMode.PVDerived,
+    });
+    expect(result.monthlyMode).toBe(AnnuityMonthlyMode.PVDerived);
+  });
 });
 
 describe("firebaseToAnnuity", () => {
@@ -95,5 +106,15 @@ describe("firebaseToAnnuity", () => {
     });
     const result = firebaseToAnnuity("a-1", firebase);
     expect(result.startDate.toISOString()).toBe(startDate.toISOString());
+  });
+
+  it("defaults monthlyMode to Flat when field is absent from Firebase record", () => {
+    const result = firebaseToAnnuity("a-1", {
+      name: "Legacy",
+      monthlyAmount: 200,
+      startDate: "2020-01-01T00:00:00.000Z",
+      durationMonths: null,
+    });
+    expect(result.monthlyMode).toBe(AnnuityMonthlyMode.Flat);
   });
 });

--- a/src/lib/firebase/schema/annuities.spec.ts
+++ b/src/lib/firebase/schema/annuities.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { annuityToFirebase, firebaseToAnnuity } from "./annuities";
+import {
+  annuityToFirebase,
+  firebaseToAnnuity,
+  AnnuityMonthlyMode,
+} from "./annuities";
 
 describe("annuityToFirebase", () => {
   it("serializes date to ISO string", () => {
@@ -9,6 +13,7 @@ describe("annuityToFirebase", () => {
       monthlyAmount: 15,
       startDate,
       durationMonths: 12,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
     expect(result.startDate).toBe("2024-01-01T00:00:00.000Z");
   });
@@ -19,6 +24,7 @@ describe("annuityToFirebase", () => {
       monthlyAmount: 1500,
       startDate: new Date(),
       durationMonths: undefined,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
     expect(result.durationMonths).toBeNull();
   });
@@ -29,6 +35,7 @@ describe("annuityToFirebase", () => {
       monthlyAmount: 350,
       startDate: new Date(),
       durationMonths: 60,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
     expect(result.durationMonths).toBe(60);
   });
@@ -71,6 +78,7 @@ describe("firebaseToAnnuity", () => {
       monthlyAmount: 100,
       startDate: new Date(),
       durationMonths: undefined,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
     const result = firebaseToAnnuity("a-1", firebase);
     expect(result.durationMonths).toBeUndefined();
@@ -83,6 +91,7 @@ describe("firebaseToAnnuity", () => {
       monthlyAmount: 50,
       startDate,
       durationMonths: 24,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
     const result = firebaseToAnnuity("a-1", firebase);
     expect(result.startDate.toISOString()).toBe(startDate.toISOString());

--- a/src/lib/firebase/schema/annuities.ts
+++ b/src/lib/firebase/schema/annuities.ts
@@ -1,8 +1,14 @@
+export enum AnnuityMonthlyMode {
+  Flat = "flat",
+  PVDerived = "pv-derived",
+}
+
 export interface FirebaseAnnuity {
   name: string;
   monthlyAmount: number;
   startDate: string;
   durationMonths: number | null;
+  monthlyMode?: AnnuityMonthlyMode;
 }
 
 export interface Annuity {
@@ -11,6 +17,7 @@ export interface Annuity {
   monthlyAmount: number;
   startDate: Date;
   durationMonths: number | undefined;
+  monthlyMode: AnnuityMonthlyMode;
 }
 
 export function annuityToFirebase(
@@ -21,6 +28,7 @@ export function annuityToFirebase(
     monthlyAmount: annuity.monthlyAmount,
     startDate: annuity.startDate.toISOString(),
     durationMonths: annuity.durationMonths ?? null,
+    monthlyMode: annuity.monthlyMode,
   };
 }
 
@@ -31,5 +39,6 @@ export function firebaseToAnnuity(id: string, data: FirebaseAnnuity): Annuity {
     monthlyAmount: data.monthlyAmount,
     startDate: new Date(data.startDate),
     durationMonths: data.durationMonths ?? undefined,
+    monthlyMode: data.monthlyMode ?? AnnuityMonthlyMode.Flat,
   };
 }

--- a/src/services/annuities.spec.ts
+++ b/src/services/annuities.spec.ts
@@ -139,6 +139,26 @@ describe("updateAnnuity", () => {
     >;
     expect("durationMonths" in calledWith).toBe(false);
   });
+
+  it("serializes monthlyMode when provided", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateAnnuity("uid-1", "annuity-1", {
+      monthlyMode: AnnuityMonthlyMode.PVDerived,
+    });
+    expect(update).toHaveBeenCalledWith(mockRef, {
+      monthlyMode: AnnuityMonthlyMode.PVDerived,
+    });
+  });
+
+  it("omits monthlyMode from the update when not provided", async () => {
+    vi.mocked(update).mockResolvedValue(undefined);
+    await updateAnnuity("uid-1", "annuity-1", { monthlyAmount: 20 });
+    const calledWith = vi.mocked(update).mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    expect("monthlyMode" in calledWith).toBe(false);
+  });
 });
 
 describe("deleteAnnuity", () => {

--- a/src/services/annuities.spec.ts
+++ b/src/services/annuities.spec.ts
@@ -29,6 +29,7 @@ import {
   updateAnnuity,
   deleteAnnuity,
 } from "./annuities";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
 const mockDb = { type: "mock-db" };
 const mockRef = { type: "mock-ref" };
@@ -85,6 +86,7 @@ describe("createAnnuity", () => {
       monthlyAmount: 10,
       startDate: new Date("2024-01-01T00:00:00.000Z"),
       durationMonths: undefined,
+      monthlyMode: AnnuityMonthlyMode.Flat,
     });
 
     expect(push).toHaveBeenCalledWith(mockRef);
@@ -100,6 +102,7 @@ describe("createAnnuity", () => {
         monthlyAmount: 50,
         startDate: new Date(),
         durationMonths: 12,
+        monthlyMode: AnnuityMonthlyMode.Flat,
       }),
     ).rejects.toThrow("Failed to generate annuity key");
   });

--- a/src/services/annuities.ts
+++ b/src/services/annuities.ts
@@ -68,6 +68,9 @@ export async function updateAnnuity(
   if ("durationMonths" in data) {
     updates.durationMonths = data.durationMonths ?? null;
   }
+  if (data.monthlyMode !== undefined) {
+    updates.monthlyMode = data.monthlyMode;
+  }
   await update(annuityRef(uid, id), updates);
 }
 


### PR DESCRIPTION
Scaffolds the `/annuities` route with the card-based layout from the wireframes, giving the Annuity Management epic (#15) and Annuity Monthly Tracking epic (#16) a screen to land on.

The page now shows annuity cards in a responsive grid (1-column on mobile, up to 3 columns on desktop), with the selected annuity's payment history table and balance trend chart placeholder rendered below in a two-column panel. Selection defaults to the first annuity and is local component state. The `+ New Annuity` button continues to open the existing `CreateAnnuityDialog`.

Three new presentational components are introduced — `AnnuityCard`, `AnnuityPaymentHistoryTable`, and `AnnuityBalanceTrend` — each with co-located tests and Storybook stories. `AnnuityMonthlyMode` is added as a required field on `Annuity` (optional in the Firebase schema, defaulting to `Flat` on read), which required updating existing fixtures across schema and service specs.

Closes #139

---
*Created by Claude Sonnet 4.5*