### PR TITLE
feat(profile): scaffold Profile screen with settings-list layout

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,14 +1,48 @@
 "use client";
 
-import { UserProfile } from "@/components/profile";
+import { useRouter } from "next/navigation";
+import { ProfileSettingsView } from "@/components/profile";
 import { useAuth } from "@/hooks/use-auth";
+import { signOut } from "@/services/auth";
+
+function deriveInitials(displayName: string, email: string): string {
+  if (displayName.trim() !== "") {
+    const words = displayName.trim().split(/\s+/);
+    return words
+      .slice(0, 2)
+      .map((w) => w[0]?.toUpperCase() ?? "")
+      .join("");
+  }
+  return email[0]?.toUpperCase() ?? "";
+}
 
 export default function ProfilePage() {
   const { user, loading } = useAuth();
+  const router = useRouter();
 
   if (loading || !user) {
     return null;
   }
 
-  return <UserProfile user={user} />;
+  const displayName = user.displayName ?? "";
+  const email = user.email ?? "";
+  const initials = deriveInitials(displayName, email);
+
+  async function handleSignOut() {
+    try {
+      await fetch("/api/auth/session", { method: "DELETE" });
+    } finally {
+      await signOut();
+      router.push("/sign-in");
+    }
+  }
+
+  return (
+    <ProfileSettingsView
+      displayName={displayName}
+      email={email}
+      initials={initials}
+      onSignOut={() => void handleSignOut()}
+    />
+  );
 }

--- a/src/components/profile/ProfileSettingsView.spec.tsx
+++ b/src/components/profile/ProfileSettingsView.spec.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ProfileSettingsView } from "./ProfileSettingsView";
+import { PROFILE_SETTINGS_COPY } from "./copy";
+
+afterEach(cleanup);
+
+function makeProps(
+  overrides: Partial<Parameters<typeof ProfileSettingsView>[0]> = {},
+) {
+  return {
+    displayName: "Reed Martz",
+    email: "reed@example.com",
+    initials: "RM",
+    onSignOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ProfileSettingsView", () => {
+  describe("renders the page header", () => {
+    it("shows the Profile title", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(
+        screen.getByRole("heading", {
+          level: 1,
+          name: PROFILE_SETTINGS_COPY.title,
+        }),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders the identity row", () => {
+    it("shows the user's display name", () => {
+      render(
+        <ProfileSettingsView {...makeProps({ displayName: "Jane Smith" })} />,
+      );
+      expect(screen.getByText("Jane Smith")).toBeDefined();
+    });
+
+    it("shows the user's email", () => {
+      render(
+        <ProfileSettingsView {...makeProps({ email: "jane@example.com" })} />,
+      );
+      expect(screen.getByText("jane@example.com")).toBeDefined();
+    });
+
+    it("shows the avatar initials", () => {
+      render(<ProfileSettingsView {...makeProps({ initials: "JS" })} />);
+      expect(screen.getByText("JS")).toBeDefined();
+    });
+  });
+
+  describe("renders settings rows", () => {
+    it("shows the Display name row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(
+        screen.getByText(PROFILE_SETTINGS_COPY.rowDisplayName),
+      ).toBeDefined();
+    });
+
+    it("shows the Change password row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(
+        screen.getByText(PROFILE_SETTINGS_COPY.rowChangePassword),
+      ).toBeDefined();
+    });
+
+    it("shows the Currency row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(screen.getByText(PROFILE_SETTINGS_COPY.rowCurrency)).toBeDefined();
+    });
+
+    it("shows the Time zone row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(screen.getByText(PROFILE_SETTINGS_COPY.rowTimeZone)).toBeDefined();
+    });
+
+    it("shows the Notifications row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(
+        screen.getByText(PROFILE_SETTINGS_COPY.rowNotifications),
+      ).toBeDefined();
+    });
+
+    it("shows the Sign out row", () => {
+      render(<ProfileSettingsView {...makeProps()} />);
+      expect(screen.getByText(PROFILE_SETTINGS_COPY.rowSignOut)).toBeDefined();
+    });
+  });
+
+  describe("Sign out interaction", () => {
+    it("calls onSignOut when the Sign out row is clicked", () => {
+      const onSignOut = vi.fn();
+      render(<ProfileSettingsView {...makeProps({ onSignOut })} />);
+      fireEvent.click(screen.getByText(PROFILE_SETTINGS_COPY.rowSignOut));
+      expect(onSignOut).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/profile/ProfileSettingsView.stories.tsx
+++ b/src/components/profile/ProfileSettingsView.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProfileSettingsView } from "./ProfileSettingsView";
+
+const meta: Meta<typeof ProfileSettingsView> = {
+  component: ProfileSettingsView,
+  title: "Profile/ProfileSettingsView",
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileSettingsView>;
+
+export const Default: Story = {
+  args: {
+    displayName: "Reed Martz",
+    email: "reed@example.com",
+    initials: "RM",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSignOut: () => {},
+  },
+};
+
+export const SingleName: Story = {
+  args: {
+    displayName: "Alice",
+    email: "alice@example.com",
+    initials: "A",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSignOut: () => {},
+  },
+};
+
+export const EmailFallback: Story = {
+  args: {
+    displayName: "",
+    email: "bob@example.com",
+    initials: "B",
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSignOut: () => {},
+  },
+};

--- a/src/components/profile/ProfileSettingsView.tsx
+++ b/src/components/profile/ProfileSettingsView.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { PROFILE_SETTINGS_COPY } from "./copy";
+
+export interface ProfileSettingsViewProps {
+  displayName: string;
+  email: string;
+  initials: string;
+  onSignOut: () => void;
+}
+
+interface SettingsRowProps {
+  label: string;
+  value?: string;
+  onClick: () => void;
+}
+
+function SettingsRow({ label, value, onClick }: SettingsRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center justify-between px-4 py-3 text-sm hover:bg-muted/50"
+    >
+      <span>{label}</span>
+      <span className="flex items-center gap-2 text-muted-foreground">
+        {value !== undefined && <span>{value}</span>}
+        <span aria-hidden="true">›</span>
+      </span>
+    </button>
+  );
+}
+
+export function ProfileSettingsView({
+  displayName,
+  email,
+  initials,
+  onSignOut,
+}: ProfileSettingsViewProps) {
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-8">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        {PROFILE_SETTINGS_COPY.title}
+      </h1>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Identity card */}
+        <Card className="flex flex-col items-center gap-3 p-6">
+          <p className="text-xs font-semibold tracking-widest text-muted-foreground">
+            {PROFILE_SETTINGS_COPY.accountEyebrow}
+          </p>
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-xl font-bold text-primary-foreground">
+            {initials}
+          </div>
+          <div className="text-center">
+            <p className="font-semibold">{displayName}</p>
+            <p className="text-sm text-muted-foreground">{email}</p>
+          </div>
+        </Card>
+
+        {/* Settings list */}
+        <Card className="overflow-hidden divide-y">
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowDisplayName}
+            onClick={() => {
+              // TODO: user preferences epic
+            }}
+          />
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowChangePassword}
+            onClick={() => {
+              // TODO: user preferences epic
+            }}
+          />
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowCurrency}
+            value={PROFILE_SETTINGS_COPY.currencyDefault}
+            onClick={() => {
+              // TODO: user preferences epic
+            }}
+          />
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowTimeZone}
+            onClick={() => {
+              // TODO: user preferences epic
+            }}
+          />
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowNotifications}
+            onClick={() => {
+              // TODO: user preferences epic
+            }}
+          />
+          <SettingsRow
+            label={PROFILE_SETTINGS_COPY.rowSignOut}
+            onClick={onSignOut}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/copy.ts
+++ b/src/components/profile/copy.ts
@@ -1,3 +1,15 @@
+export const PROFILE_SETTINGS_COPY = {
+  accountEyebrow: "ACCOUNT",
+  currencyDefault: "USD",
+  rowChangePassword: "Change password",
+  rowCurrency: "Currency",
+  rowDisplayName: "Display name",
+  rowNotifications: "Notifications",
+  rowSignOut: "Sign out",
+  rowTimeZone: "Time zone",
+  title: "Profile",
+} as const;
+
 export const USER_PROFILE_COPY = {
   changeEmailButton: "Update Email",
   changeEmailLabel: "New Email Address",

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,4 +1,6 @@
+export { ProfileSettingsView } from "./ProfileSettingsView";
+export type { ProfileSettingsViewProps } from "./ProfileSettingsView";
 export { UserProfile } from "./UserProfile";
 export { UserProfileView } from "./UserProfileView";
 export type { UserProfileViewProps } from "./UserProfileView";
-export { USER_PROFILE_COPY } from "./copy";
+export { PROFILE_SETTINGS_COPY, USER_PROFILE_COPY } from "./copy";


### PR DESCRIPTION
Scaffolds the `/profile` route with the wireframe settings-list layout, replacing the previous form-based view with the avatar + navigation-row design from the mobile wireframe.

The page now shows an identity card (avatar with derived initials, display name, email) alongside a six-row settings list (Display name, Change password, Currency, Time zone, Notifications, Sign out). The Sign out row is wired to real Firebase sign-out (session cookie deletion + Firebase `signOut()` + redirect to `/sign-in`); all other rows are inert with `// TODO: user preferences epic` comments. Avatar initials are derived from the first letter of each word in `displayName` (up to two letters), falling back to the first character of the email local-part. The existing `UserProfileView`, `DisplayNameForm`, `EmailForm`, and `PasswordForm` components are preserved in the codebase for future use in the preferences epic.

Closes #141

---
*Created by Claude Sonnet 4.5*