### PR TITLE
chore(lint): enforce alphabetical import ordering via eslint-plugin-simple-import-sort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,10 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 - **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
 - **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
 - **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
-- **Enums and constant objects** should be kept in alphabetical order to minimize merge conflicts.
+- **Alphabetical ordering** applies wherever sequence has no semantic value, to minimize merge conflicts:
+  - **Import statements** — enforced automatically by ESLint (`simple-import-sort`). Run `pnpm lint --fix` to auto-correct.
+  - **Enum members and `as const` objects** — kept in alphabetical order by convention (no automated enforcement yet; reviewers should flag violations).
+  - **Re-exports in barrel files** — enforced automatically by ESLint alongside import statements.
 - **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum Status { Active = "active", Inactive = "inactive" }` rather than `"active" | "inactive"`). String enum values must match the current serialized schema. Export new enums from the module barrel (the directory-level `index.ts` when one exists or is required by the barrel rule above).
 
 ## Naming Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ pnpm dev
 
 This project uses [Husky](https://typicode.github.io/husky/) with [lint-staged](https://github.com/lint-staged/lint-staged) to run checks on staged files before each commit:
 
-- **ESLint** — Lints and auto-fixes `.ts`, `.tsx`, `.js`, `.mjs`, `.cjs` files
+- **ESLint** — Lints and auto-fixes `.ts`, `.tsx`, `.js`, `.mjs`, `.cjs` files, including automatic import sorting (`simple-import-sort`)
 - **Prettier** — Formats `.ts`, `.tsx`, `.js`, `.mjs`, `.cjs`, `.json`, `.md`, `.yml`, `.yaml` files
 
 If a pre-commit hook fails, fix the issues and try committing again.
@@ -59,6 +59,7 @@ See [AGENTS.md](AGENTS.md) for the full list of code conventions, including:
 - Co-located test files (`Component.spec.tsx`) and stories (`Component.stories.tsx`)
 - User-facing strings in co-located copy files for i18n readiness
 - File size limits (~200 lines for source, ~300 lines for tests)
+- Alphabetical ordering for imports (ESLint-enforced), enum members, and barrel re-exports
 
 ## Commit Messages
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,9 @@
 import js from "@eslint/js";
+import reactHooks from "eslint-plugin-react-hooks";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+import storybook from "eslint-plugin-storybook";
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import reactHooks from "eslint-plugin-react-hooks";
-import storybook from "eslint-plugin-storybook";
 
 export default tseslint.config(
   {
@@ -34,6 +35,16 @@ export default tseslint.config(
         project: ["./tsconfig.json"],
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+  {
+    files: ["**/*.{ts,tsx,js,mjs,cjs}"],
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
+    rules: {
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
     },
   },
   {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
-import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
+import type { NextConfig } from "next";
+
 import { makeSentryBuildOptions } from "./src/lib/sentry-build-options";
 
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@vitest/browser-playwright": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "eslint-plugin-storybook": "^10.3.6",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-simple-import-sort:
+        specifier: ^13.0.0
+        version: 13.0.0(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-storybook:
         specifier: ^10.3.6
         version: 10.3.6(eslint@10.3.0(jiti@2.7.0))(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
@@ -3580,6 +3583,11 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-simple-import-sort@13.0.0:
+    resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-storybook@10.3.6:
     resolution: {integrity: sha512-8udrL+Rmp5LFaZvgRe4J226X1MYls25bWCyHuzR5X8s2qbFTryX+wKC+o/0Ato4A1AvwnDg8OOMPc6yWJ9JpcA==}
@@ -9648,6 +9656,10 @@ snapshots:
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.3.0(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.3.0(jiti@2.7.0)
 
   eslint-plugin-storybook@10.3.6(eslint@10.3.0(jiti@2.7.0))(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3):
     dependencies:

--- a/scripts/validate-config.mjs
+++ b/scripts/validate-config.mjs
@@ -12,8 +12,8 @@
  * Accepts optional --env=<name> to validate a single environment.
  */
 
-import { readFileSync, existsSync } from "fs";
-import { join, dirname } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");

--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth } from "@/hooks/use-auth";
-import { useAnnuities } from "@/hooks/use-annuities";
+
 import { AnnuityListView, NewAnnuityDialog } from "@/components/annuities";
+import { useAnnuities } from "@/hooks/use-annuities";
+import { useAuth } from "@/hooks/use-auth";
 import { createAnnuity } from "@/services/annuities";
 
 export default function AnnuitiesPage() {

--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { use } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/hooks/use-auth";
-import { useSavingsGoal } from "@/hooks/use-savings-goal";
-import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
-import { useSavingsGoals } from "@/hooks/use-savings-goals";
+import { use } from "react";
+
 import { GoalPurchaseView } from "@/components/goal-purchase";
+import { useAuth } from "@/hooks/use-auth";
+import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
+import { useSavingsGoal } from "@/hooks/use-savings-goal";
+import { useSavingsGoals } from "@/hooks/use-savings-goals";
 
 interface GoalPurchasePageProps {
   params: Promise<{ goalId: string }>;

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+
 import { AppShellNav } from "@/components/app-shell";
 
 export default function AppLayout({ children }: { children: ReactNode }) {

--- a/src/app/(app)/ledgers/[id]/page.tsx
+++ b/src/app/(app)/ledgers/[id]/page.tsx
@@ -1,28 +1,29 @@
 "use client";
 
-import { useState } from "react";
 import { useParams } from "next/navigation";
-import { useAuth } from "@/hooks/use-auth";
-import { useTransactions } from "@/hooks/use-transactions";
-import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
-import { useCreateTransaction } from "@/hooks/use-create-transaction";
-import { useCreateDeposit } from "@/hooks/use-create-deposit";
-import { useDeleteTransaction } from "@/hooks/use-delete-transaction";
-import { useSavingsGoals } from "@/hooks/use-savings-goals";
-import { useUpdateSavingsGoal } from "@/hooks/use-update-savings-goal";
-import { useDeleteSavingsGoal } from "@/hooks/use-delete-savings-goal";
-import { useUpdateTransaction } from "@/hooks/use-update-transaction";
+import { useState } from "react";
+
+import { LedgerDetailView } from "@/components/ledger-detail/LedgerDetailView";
 import {
   AddExpenseDialog,
   EditTransactionDialog,
 } from "@/components/ledger-transactions";
 import { AddDepositDialog } from "@/components/ledgers";
 import { NewSavingsGoalDialog } from "@/components/savings-goals";
-import { LedgerDetailView } from "@/components/ledger-detail/LedgerDetailView";
-import { updateLedger } from "@/services/ledgers";
-import { createSavingsGoal } from "@/services/savings-goals";
+import { useAuth } from "@/hooks/use-auth";
+import { useCreateDeposit } from "@/hooks/use-create-deposit";
+import { useCreateTransaction } from "@/hooks/use-create-transaction";
+import { useDeleteSavingsGoal } from "@/hooks/use-delete-savings-goal";
+import { useDeleteTransaction } from "@/hooks/use-delete-transaction";
+import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
+import { useSavingsGoals } from "@/hooks/use-savings-goals";
+import { useTransactions } from "@/hooks/use-transactions";
+import { useUpdateSavingsGoal } from "@/hooks/use-update-savings-goal";
+import { useUpdateTransaction } from "@/hooks/use-update-transaction";
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
 import type { Ledger, UpdateLedgerInput } from "@/lib/types";
+import { updateLedger } from "@/services/ledgers";
+import { createSavingsGoal } from "@/services/savings-goals";
 
 type DepositInput = Omit<BudgetLedgerTransaction, "id" | "ledgerId" | "type">;
 

--- a/src/app/(app)/ledgers/page.tsx
+++ b/src/app/(app)/ledgers/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
 import { LedgerList, NewLedgerDialog } from "@/components/ledgers";
-import { useLedgers } from "@/hooks/use-ledgers";
-import { useDeleteLedger } from "@/hooks/use-delete-ledger";
-import { useCreateLedger } from "@/hooks/use-create-ledger";
 import { useAuth } from "@/hooks/use-auth";
-import { updateLedger } from "@/services/ledgers";
+import { useCreateLedger } from "@/hooks/use-create-ledger";
+import { useDeleteLedger } from "@/hooks/use-delete-ledger";
+import { useLedgers } from "@/hooks/use-ledgers";
 import type { UpdateLedgerInput } from "@/lib/types";
+import { updateLedger } from "@/services/ledgers";
 
 export default function LedgersPage() {
   const { user, loading: authLoading } = useAuth();

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+
 import { ProfileSettingsView } from "@/components/profile";
 import { useAuth } from "@/hooks/use-auth";
 import { signOut } from "@/services/auth";

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+
 import { ForgotPasswordFormView } from "@/components/auth/ForgotPasswordForm";
 import { FORGOT_PASSWORD_FORM_COPY } from "@/components/auth/ForgotPasswordForm.copy";
 import { sendPasswordReset } from "@/services/auth";

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+
 import { SignInFormView } from "@/components/auth/SignInForm";
 import { SIGN_IN_FORM_COPY } from "@/components/auth/SignInForm.copy";
 import { signIn } from "@/services/auth";

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+
 import { SignUpFormView } from "@/components/auth/SignUpForm";
 import { SIGN_UP_FORM_COPY } from "@/components/auth/SignUpForm.copy";
 import { signUp } from "@/services/auth";

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
-import { getAdminAuth } from "@/lib/firebase/admin";
+
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
+import { getAdminAuth } from "@/lib/firebase/admin";
 
 const SESSION_EXPIRY_MS = 60 * 60 * 24 * 5 * 1000; // 5 days
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
+import "./globals.css";
+
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+
 import { Providers } from "./providers";
-import "./globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/page.spec.tsx
+++ b/src/app/page.spec.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import Home from "./page";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { LANDING_PAGE_COPY } from "@/components/home/LandingPage.copy";
+
+import Home from "./page";
 
 afterEach(cleanup);
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 import { Provider } from "react-redux";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { store } from "@/store";
+
 import { AuthProvider } from "@/components/auth";
+import { store } from "@/store";
 
 interface ProvidersProps {
   children: React.ReactNode;

--- a/src/components/accounts/CreateAccountDialog-tests/integration.spec.tsx
+++ b/src/components/accounts/CreateAccountDialog-tests/integration.spec.tsx
@@ -1,14 +1,16 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { CreateAccountDialog } from "../CreateAccountDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
 import { CREATE_ACCOUNT_DIALOG_COPY } from "../copy";
+import { CreateAccountDialog } from "../CreateAccountDialog";
 
 afterEach(cleanup);
 

--- a/src/components/accounts/CreateAccountDialog-tests/view.spec.tsx
+++ b/src/components/accounts/CreateAccountDialog-tests/view.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { CreateAccountDialogView } from "../CreateAccountDialogView";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
 import { CREATE_ACCOUNT_DIALOG_COPY } from "../copy";
+import { CreateAccountDialogView } from "../CreateAccountDialogView";
 
 afterEach(cleanup);
 

--- a/src/components/accounts/CreateAccountDialog.stories.tsx
+++ b/src/components/accounts/CreateAccountDialog.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { CreateAccountDialogView } from "./CreateAccountDialogView";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
+import { CreateAccountDialogView } from "./CreateAccountDialogView";
 
 const meta: Meta<typeof CreateAccountDialogView> = {
   component: CreateAccountDialogView,

--- a/src/components/accounts/CreateAccountDialog.tsx
+++ b/src/components/accounts/CreateAccountDialog.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState } from "react";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
 import { CREATE_ACCOUNT_DIALOG_COPY } from "./copy";
 import { CreateAccountDialogView, isCashTier } from "./CreateAccountDialogView";
 

--- a/src/components/accounts/CreateAccountDialogView.tsx
+++ b/src/components/accounts/CreateAccountDialogView.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
 import { CREATE_ACCOUNT_DIALOG_COPY } from "./copy";
 
 const CASH_TIERS = new Set<ReconciliationAccountTier>([

--- a/src/components/annuities/AnnuityListView.spec.tsx
+++ b/src/components/annuities/AnnuityListView.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Annuity } from "@/lib/firebase/schema/annuities";
+
 import { AnnuityListView } from "./AnnuityListView";
 import { ANNUITY_LIST_COPY } from "./copy";
-import type { Annuity } from "@/lib/firebase/schema/annuities";
 
 afterEach(cleanup);
 

--- a/src/components/annuities/AnnuityListView.stories.tsx
+++ b/src/components/annuities/AnnuityListView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { AnnuityListView } from "./AnnuityListView";
 
 const meta: Meta<typeof AnnuityListView> = {

--- a/src/components/annuities/AnnuityListView.tsx
+++ b/src/components/annuities/AnnuityListView.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
+
 import { ANNUITY_LIST_COPY } from "./copy";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/src/components/annuities/CreateAnnuityDialog.spec.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { CreateAnnuityDialogView } from "./CreateAnnuityDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { CREATE_ANNUITY_DIALOG_COPY } from "./copy";
+import { CreateAnnuityDialogView } from "./CreateAnnuityDialog";
 
 afterEach(cleanup);
 

--- a/src/components/annuities/CreateAnnuityDialog.stories.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { CreateAnnuityDialogView } from "./CreateAnnuityDialog";
 
 const meta: Meta<typeof CreateAnnuityDialogView> = {

--- a/src/components/annuities/CreateAnnuityDialog.tsx
+++ b/src/components/annuities/CreateAnnuityDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useId } from "react";
+import { useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { calculateMonthlyPayment } from "@/lib/annuity-math";
+
 import { CREATE_ANNUITY_DIALOG_COPY } from "./copy";
 
 type AnnuityMode = "flat" | "pv";

--- a/src/components/annuities/NewAnnuityDialog.spec.tsx
+++ b/src/components/annuities/NewAnnuityDialog.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { NewAnnuityDialog, NewAnnuityDialogView } from "./NewAnnuityDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { NEW_ANNUITY_DIALOG_COPY } from "./copy";
+import { NewAnnuityDialog, NewAnnuityDialogView } from "./NewAnnuityDialog";
 
 afterEach(cleanup);
 

--- a/src/components/annuities/NewAnnuityDialog.stories.tsx
+++ b/src/components/annuities/NewAnnuityDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { NewAnnuityDialogView } from "./NewAnnuityDialog";
 
 const meta: Meta<typeof NewAnnuityDialogView> = {

--- a/src/components/annuities/NewAnnuityDialog.tsx
+++ b/src/components/annuities/NewAnnuityDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   DialogBackdrop,
@@ -10,6 +11,7 @@ import {
   DialogRoot,
   DialogTitle,
 } from "@/components/ui/dialog";
+
 import { NEW_ANNUITY_DIALOG_COPY } from "./copy";
 
 export interface NewAnnuityDialogViewProps {

--- a/src/components/annuities/index.ts
+++ b/src/components/annuities/index.ts
@@ -1,7 +1,7 @@
 export { AnnuityListView } from "./AnnuityListView";
-export { NewAnnuityDialog } from "./NewAnnuityDialog";
+export type { CreateAnnuityInput } from "./CreateAnnuityDialog";
 export {
   CreateAnnuityDialog,
   CreateAnnuityDialogView,
 } from "./CreateAnnuityDialog";
-export type { CreateAnnuityInput } from "./CreateAnnuityDialog";
+export { NewAnnuityDialog } from "./NewAnnuityDialog";

--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { AppShellNavView } from "./AppShellNav";
 import { APP_SHELL_COPY } from "./copy";
 

--- a/src/components/app-shell/AppShellNav.stories.tsx
+++ b/src/components/app-shell/AppShellNav.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { AppShellNavView } from "./AppShellNav";
 
 const meta: Meta<typeof AppShellNavView> = {

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { Menu } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useState } from "react";
+
 import {
   Dialog,
   DialogBackdrop,
@@ -12,6 +12,8 @@ import {
   DialogPortal,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
 import { APP_SHELL_COPY } from "./copy";
 
 interface NavLink {

--- a/src/components/app-shell/index.ts
+++ b/src/components/app-shell/index.ts
@@ -1,3 +1,3 @@
-export { AppShellNav, AppShellNavView } from "./AppShellNav";
 export type { AppShellNavViewProps } from "./AppShellNav";
+export { AppShellNav, AppShellNavView } from "./AppShellNav";
 export { APP_SHELL_COPY } from "./copy";

--- a/src/components/auth/AuthProvider.stories.tsx
+++ b/src/components/auth/AuthProvider.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { AuthProviderView } from "./AuthProvider";
 import type { User } from "firebase/auth";
+
+import { AuthProviderView } from "./AuthProvider";
 
 const meta: Meta<typeof AuthProviderView> = {
   component: AuthProviderView,

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { createContext, useEffect, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
+import { createContext, useEffect, useState } from "react";
+
 import { getClientAuth } from "@/lib/firebase/client";
 
 export interface AuthContextValue {

--- a/src/components/auth/ForgotPasswordForm.spec.tsx
+++ b/src/components/auth/ForgotPasswordForm.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { ForgotPasswordFormView } from "./ForgotPasswordForm";
 import { FORGOT_PASSWORD_FORM_COPY } from "./ForgotPasswordForm.copy";
 

--- a/src/components/auth/ForgotPasswordForm.stories.tsx
+++ b/src/components/auth/ForgotPasswordForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { ForgotPasswordFormView } from "./ForgotPasswordForm";
 
 const meta: Meta<typeof ForgotPasswordFormView> = {

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -10,9 +12,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { FORGOT_PASSWORD_FORM_COPY } from "./ForgotPasswordForm.copy";
 
 export interface ForgotPasswordFormViewProps {

--- a/src/components/auth/SignInForm.spec.tsx
+++ b/src/components/auth/SignInForm.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { SignInFormView } from "./SignInForm";
 import { SIGN_IN_FORM_COPY } from "./SignInForm.copy";
 

--- a/src/components/auth/SignInForm.stories.tsx
+++ b/src/components/auth/SignInForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { SignInFormView } from "./SignInForm";
 
 const meta: Meta<typeof SignInFormView> = {

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -10,9 +12,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { SIGN_IN_FORM_COPY } from "./SignInForm.copy";
 
 export interface SignInFormViewProps {

--- a/src/components/auth/SignUpForm.spec.tsx
+++ b/src/components/auth/SignUpForm.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { SignUpFormView } from "./SignUpForm";
 import { SIGN_UP_FORM_COPY } from "./SignUpForm.copy";
 

--- a/src/components/auth/SignUpForm.stories.tsx
+++ b/src/components/auth/SignUpForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { SignUpFormView } from "./SignUpForm";
 
 const meta: Meta<typeof SignUpFormView> = {

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -10,9 +12,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { SIGN_UP_FORM_COPY } from "./SignUpForm.copy";
 
 export interface SignUpFormViewProps {

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,15 +1,12 @@
-export { AuthProvider, AuthProviderView, AuthContext } from "./AuthProvider";
 export type {
   AuthContextValue,
   AuthProviderProps,
   AuthProviderViewProps,
 } from "./AuthProvider";
-
-export { SignInFormView } from "./SignInForm";
-export type { SignInFormViewProps } from "./SignInForm";
-
-export { SignUpFormView } from "./SignUpForm";
-export type { SignUpFormViewProps } from "./SignUpForm";
-
-export { ForgotPasswordFormView } from "./ForgotPasswordForm";
+export { AuthContext, AuthProvider, AuthProviderView } from "./AuthProvider";
 export type { ForgotPasswordFormViewProps } from "./ForgotPasswordForm";
+export { ForgotPasswordFormView } from "./ForgotPasswordForm";
+export type { SignInFormViewProps } from "./SignInForm";
+export { SignInFormView } from "./SignInForm";
+export type { SignUpFormViewProps } from "./SignUpForm";
+export { SignUpFormView } from "./SignUpForm";

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { GoalPurchaseForm } from "./GoalPurchaseForm";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { GOAL_PURCHASE_FORM_COPY } from "./copy";
+import { GoalPurchaseForm } from "./GoalPurchaseForm";
 
 afterEach(cleanup);
 

--- a/src/components/goal-purchase/GoalPurchaseForm.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { GoalPurchaseForm } from "./GoalPurchaseForm";
 
 const meta: Meta<typeof GoalPurchaseForm> = {

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { GOAL_PURCHASE_FORM_COPY } from "./copy";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/src/components/goal-purchase/GoalPurchaseView.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import { GoalPurchaseView } from "./GoalPurchaseView";
-import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import { GoalPurchaseView } from "./GoalPurchaseView";
 
 afterEach(cleanup);
 

--- a/src/components/goal-purchase/GoalPurchaseView.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { GoalPurchaseView } from "./GoalPurchaseView";
 
 const meta: Meta<typeof GoalPurchaseView> = {

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
 import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
 import { GoalPurchaseForm } from "./GoalPurchaseForm";
 import { GoalPurchaseWarning } from "./GoalPurchaseWarning";

--- a/src/components/goal-purchase/GoalPurchaseWarning.tsx
+++ b/src/components/goal-purchase/GoalPurchaseWarning.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
 import { GOAL_PURCHASE_WARNING_COPY } from "./copy";
 
 export function GoalPurchaseWarning() {

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
 import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
 
 export interface GoalSiblingProjectionsProps {

--- a/src/components/goal-purchase/index.ts
+++ b/src/components/goal-purchase/index.ts
@@ -1,7 +1,7 @@
-export { GoalPurchaseForm } from "./GoalPurchaseForm";
 export type { GoalPurchaseFormProps } from "./GoalPurchaseForm";
-export { GoalPurchaseView } from "./GoalPurchaseView";
+export { GoalPurchaseForm } from "./GoalPurchaseForm";
 export type { GoalPurchaseViewProps } from "./GoalPurchaseView";
+export { GoalPurchaseView } from "./GoalPurchaseView";
 export { GoalPurchaseWarning } from "./GoalPurchaseWarning";
-export { GoalSiblingProjections } from "./GoalSiblingProjections";
 export type { GoalSiblingProjectionsProps } from "./GoalSiblingProjections";
+export { GoalSiblingProjections } from "./GoalSiblingProjections";

--- a/src/components/home/LandingPage.spec.tsx
+++ b/src/components/home/LandingPage.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { LandingPage } from "./LandingPage";
 import { LANDING_PAGE_COPY } from "./LandingPage.copy";
 import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";

--- a/src/components/home/LandingPage.tsx
+++ b/src/components/home/LandingPage.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
+
 import { buttonVariants } from "@/components/ui";
-import { PublicHeader } from "./PublicHeader";
+
 import { LANDING_PAGE_COPY } from "./LandingPage.copy";
+import { PublicHeader } from "./PublicHeader";
 
 export function LandingPage() {
   return (

--- a/src/components/home/PublicHeader.spec.tsx
+++ b/src/components/home/PublicHeader.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { PublicHeader } from "./PublicHeader";
 import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";
 

--- a/src/components/home/PublicHeader.tsx
+++ b/src/components/home/PublicHeader.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+
 import { PUBLIC_HEADER_COPY } from "./PublicHeader.copy";
 
 export function PublicHeader() {

--- a/src/components/ledger-detail/LedgerDetailView.spec.tsx
+++ b/src/components/ledger-detail/LedgerDetailView.spec.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import { LedgerDetailView } from "./LedgerDetailView";
-import { LEDGER_DETAIL_COPY } from "./copy";
-import type { Ledger } from "@/lib/types";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import type { Ledger } from "@/lib/types";
+
+import { LEDGER_DETAIL_COPY } from "./copy";
+import { LedgerDetailView } from "./LedgerDetailView";
 
 afterEach(cleanup);
 

--- a/src/components/ledger-detail/LedgerDetailView.stories.tsx
+++ b/src/components/ledger-detail/LedgerDetailView.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
 import { LedgerDetailView } from "./LedgerDetailView";
 
 const mockLedger = {

--- a/src/components/ledger-detail/LedgerDetailView.tsx
+++ b/src/components/ledger-detail/LedgerDetailView.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import Link from "next/link";
-import type { Ledger, UpdateLedgerInput } from "@/lib/types";
-import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
-import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
-import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+
 import { LedgerTransactionListView } from "@/components/ledger-transactions";
 import { EditLedgerDialog } from "@/components/ledgers";
 import { SavingsGoalListView } from "@/components/savings-goals";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import type { Ledger, UpdateLedgerInput } from "@/lib/types";
+
 import { LEDGER_DETAIL_COPY } from "./copy";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/src/components/ledger-transactions/AddExpenseDialog.spec.tsx
+++ b/src/components/ledger-transactions/AddExpenseDialog.spec.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { AddExpenseDialog } from "./AddExpenseDialog";
 import { ADD_EXPENSE_DIALOG_COPY } from "./AddExpenseDialog.copy";
 

--- a/src/components/ledger-transactions/AddExpenseDialog.stories.tsx
+++ b/src/components/ledger-transactions/AddExpenseDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { AddExpenseDialog } from "./AddExpenseDialog";
 
 const meta: Meta<typeof AddExpenseDialog> = {

--- a/src/components/ledger-transactions/AddExpenseDialog.tsx
+++ b/src/components/ledger-transactions/AddExpenseDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useId } from "react";
+import { useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+
 import { ADD_EXPENSE_DIALOG_COPY } from "./AddExpenseDialog.copy";
 
 export interface AddExpenseInput {

--- a/src/components/ledger-transactions/EditTransactionDialog.spec.tsx
+++ b/src/components/ledger-transactions/EditTransactionDialog.spec.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import {
   EditTransactionDialog,
   EditTransactionDialogView,

--- a/src/components/ledger-transactions/EditTransactionDialog.stories.tsx
+++ b/src/components/ledger-transactions/EditTransactionDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { EditTransactionDialog } from "./EditTransactionDialog";
 
 const meta: Meta<typeof EditTransactionDialog> = {

--- a/src/components/ledger-transactions/EditTransactionDialog.tsx
+++ b/src/components/ledger-transactions/EditTransactionDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useId } from "react";
+import { useEffect, useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+
 import { EDIT_TRANSACTION_DIALOG_COPY } from "./EditTransactionDialog.copy";
 
 export type EditTransactionInput = Pick<

--- a/src/components/ledger-transactions/LedgerTransactionList.spec.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.spec.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { LedgerTransactionListView } from "./LedgerTransactionList";
-import { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
-import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
+import { LedgerTransactionListView } from "./LedgerTransactionList";
 
 afterEach(cleanup);
 

--- a/src/components/ledger-transactions/LedgerTransactionList.stories.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { LedgerTransactionListView } from "./LedgerTransactionList";
+
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { LedgerTransactionListView } from "./LedgerTransactionList";
 
 const meta: Meta<typeof LedgerTransactionListView> = {
   component: LedgerTransactionListView,

--- a/src/components/ledger-transactions/LedgerTransactionList.tsx
+++ b/src/components/ledger-transactions/LedgerTransactionList.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { Pencil, Trash2 } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
 import {
   AlertDialogBackdrop,
   AlertDialogClose,
@@ -14,8 +12,12 @@ import {
   AlertDialogRoot,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
 import { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/src/components/ledger-transactions/index.ts
+++ b/src/components/ledger-transactions/index.ts
@@ -1,17 +1,17 @@
-export { AddExpenseDialog } from "./AddExpenseDialog";
 export type {
   AddExpenseDialogProps,
   AddExpenseInput,
 } from "./AddExpenseDialog";
-export {
-  EditTransactionDialog,
-  EditTransactionDialogView,
-} from "./EditTransactionDialog";
+export { AddExpenseDialog } from "./AddExpenseDialog";
+export { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
 export type {
   EditTransactionDialogProps,
   EditTransactionDialogViewProps,
   EditTransactionInput,
 } from "./EditTransactionDialog";
-export { LedgerTransactionListView } from "./LedgerTransactionList";
+export {
+  EditTransactionDialog,
+  EditTransactionDialogView,
+} from "./EditTransactionDialog";
 export type { LedgerTransactionListViewProps } from "./LedgerTransactionList";
-export { LEDGER_TRANSACTION_LIST_COPY } from "./copy";
+export { LedgerTransactionListView } from "./LedgerTransactionList";

--- a/src/components/ledgers/AddDepositDialog.spec.tsx
+++ b/src/components/ledgers/AddDepositDialog.spec.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { AddDepositDialog, AddDepositDialogView } from "./AddDepositDialog";
 import { ADD_DEPOSIT_DIALOG_COPY } from "./AddDepositDialog.copy";
 

--- a/src/components/ledgers/AddDepositDialog.stories.tsx
+++ b/src/components/ledgers/AddDepositDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { AddDepositDialogView } from "./AddDepositDialog";
 import { ADD_DEPOSIT_DIALOG_COPY } from "./AddDepositDialog.copy";
 

--- a/src/components/ledgers/AddDepositDialog.tsx
+++ b/src/components/ledgers/AddDepositDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useId } from "react";
-import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,6 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+
 import { ADD_DEPOSIT_DIALOG_COPY } from "./AddDepositDialog.copy";
 
 type DepositInput = Omit<BudgetLedgerTransaction, "id" | "ledgerId" | "type">;

--- a/src/components/ledgers/CreateLedgerDialog.spec.tsx
+++ b/src/components/ledgers/CreateLedgerDialog.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { CreateLedgerDialog } from "./CreateLedgerDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { CREATE_LEDGER_DIALOG_COPY } from "./copy";
+import { CreateLedgerDialog } from "./CreateLedgerDialog";
 
 afterEach(cleanup);
 

--- a/src/components/ledgers/CreateLedgerDialog.stories.tsx
+++ b/src/components/ledgers/CreateLedgerDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { CreateLedgerDialog } from "./CreateLedgerDialog";
 
 const meta: Meta<typeof CreateLedgerDialog> = {

--- a/src/components/ledgers/CreateLedgerDialog.tsx
+++ b/src/components/ledgers/CreateLedgerDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useId } from "react";
-import type { CreateLedgerInput } from "@/lib/types";
+import { useId, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,6 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { CreateLedgerInput } from "@/lib/types";
+
 import { CREATE_LEDGER_DIALOG_COPY } from "./copy";
 
 export interface CreateLedgerDialogProps {

--- a/src/components/ledgers/EditLedgerDialog.spec.tsx
+++ b/src/components/ledgers/EditLedgerDialog.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { EditLedgerDialog } from "./EditLedgerDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { EDIT_LEDGER_DIALOG_COPY } from "./copy";
+import { EditLedgerDialog } from "./EditLedgerDialog";
 
 afterEach(cleanup);
 

--- a/src/components/ledgers/EditLedgerDialog.stories.tsx
+++ b/src/components/ledgers/EditLedgerDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { EditLedgerDialog } from "./EditLedgerDialog";
 
 const meta: Meta<typeof EditLedgerDialog> = {

--- a/src/components/ledgers/EditLedgerDialog.tsx
+++ b/src/components/ledgers/EditLedgerDialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { Pencil } from "lucide-react";
-import type { UpdateLedgerInput } from "@/lib/types";
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,6 +12,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import type { UpdateLedgerInput } from "@/lib/types";
+
 import { EDIT_LEDGER_DIALOG_COPY } from "./copy";
 
 export interface EditLedgerDialogProps {

--- a/src/components/ledgers/LedgerList.spec.tsx
+++ b/src/components/ledgers/LedgerList.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import { LedgerList } from "./LedgerList";
-import { LEDGERS_PAGE_COPY } from "./copy";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { Ledger } from "@/lib/types";
+
+import { LEDGERS_PAGE_COPY } from "./copy";
+import { LedgerList } from "./LedgerList";
 
 afterEach(cleanup);
 

--- a/src/components/ledgers/LedgerList.stories.tsx
+++ b/src/components/ledgers/LedgerList.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { LedgerList } from "./LedgerList";
 
 const meta: Meta<typeof LedgerList> = {

--- a/src/components/ledgers/LedgerList.tsx
+++ b/src/components/ledgers/LedgerList.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import type { Ledger, UpdateLedgerInput } from "@/lib/types";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card } from "@/components/ui/card";
 import { Bar } from "@/components/ui/bar";
-import { LedgerListItem } from "./LedgerListItem";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Ledger, UpdateLedgerInput } from "@/lib/types";
+
 import { LEDGERS_PAGE_COPY } from "./copy";
+import { LedgerListItem } from "./LedgerListItem";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",

--- a/src/components/ledgers/LedgerListItem.spec.tsx
+++ b/src/components/ledgers/LedgerListItem.spec.tsx
@@ -1,14 +1,16 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   within,
 } from "@testing-library/react";
-import { LedgerListItem, LedgerListItemView } from "./LedgerListItem";
-import { LEDGER_LIST_ITEM_COPY, LEDGERS_PAGE_COPY } from "./copy";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { Ledger } from "@/lib/types";
+
+import { LEDGER_LIST_ITEM_COPY, LEDGERS_PAGE_COPY } from "./copy";
+import { LedgerListItem, LedgerListItemView } from "./LedgerListItem";
 
 afterEach(cleanup);
 

--- a/src/components/ledgers/LedgerListItem.stories.tsx
+++ b/src/components/ledgers/LedgerListItem.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { LedgerListItemView } from "./LedgerListItem";
 
 const sampleLedger = {

--- a/src/components/ledgers/LedgerListItem.tsx
+++ b/src/components/ledgers/LedgerListItem.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { MoreHorizontal } from "lucide-react";
-import type { Ledger, UpdateLedgerInput } from "@/lib/types";
-import { Button } from "@/components/ui/button";
-import { Bar } from "@/components/ui/bar";
+import { useState } from "react";
+
 import {
   AlertDialogBackdrop,
   AlertDialogClose,
@@ -14,16 +12,20 @@ import {
   AlertDialogRoot,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Bar } from "@/components/ui/bar";
+import { Button } from "@/components/ui/button";
 import {
-  DropdownMenuRoot,
-  DropdownMenuTrigger,
+  DropdownMenuItem,
+  DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
-  DropdownMenuPopup,
-  DropdownMenuItem,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { EditLedgerDialog } from "./EditLedgerDialog";
+import type { Ledger, UpdateLedgerInput } from "@/lib/types";
+
 import { LEDGER_LIST_ITEM_COPY, LEDGERS_PAGE_COPY } from "./copy";
+import { EditLedgerDialog } from "./EditLedgerDialog";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",

--- a/src/components/ledgers/NewLedgerDialog.spec.tsx
+++ b/src/components/ledgers/NewLedgerDialog.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { NewLedgerDialog, NewLedgerDialogView } from "./NewLedgerDialog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { NEW_LEDGER_DIALOG_COPY } from "./copy";
+import { NewLedgerDialog, NewLedgerDialogView } from "./NewLedgerDialog";
 
 afterEach(cleanup);
 

--- a/src/components/ledgers/NewLedgerDialog.stories.tsx
+++ b/src/components/ledgers/NewLedgerDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { NewLedgerDialogView } from "./NewLedgerDialog";
 
 const meta: Meta<typeof NewLedgerDialogView> = {

--- a/src/components/ledgers/NewLedgerDialog.tsx
+++ b/src/components/ledgers/NewLedgerDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   DialogBackdrop,
@@ -10,6 +11,7 @@ import {
   DialogRoot,
   DialogTitle,
 } from "@/components/ui/dialog";
+
 import { NEW_LEDGER_DIALOG_COPY } from "./copy";
 
 export interface NewLedgerDialogViewProps {

--- a/src/components/ledgers/index.ts
+++ b/src/components/ledgers/index.ts
@@ -1,19 +1,9 @@
-export { AddDepositDialog, AddDepositDialogView } from "./AddDepositDialog";
 export type {
   AddDepositDialogProps,
   AddDepositDialogViewProps,
 } from "./AddDepositDialog";
+export { AddDepositDialog, AddDepositDialogView } from "./AddDepositDialog";
 export { ADD_DEPOSIT_DIALOG_COPY } from "./AddDepositDialog.copy";
-export { CreateLedgerDialog } from "./CreateLedgerDialog";
-export { EditLedgerDialog } from "./EditLedgerDialog";
-export { LedgerList } from "./LedgerList";
-export { LedgerListItem, LedgerListItemView } from "./LedgerListItem";
-export type { LedgerListItemViewProps } from "./LedgerListItem";
-export { NewLedgerDialog, NewLedgerDialogView } from "./NewLedgerDialog";
-export type {
-  NewLedgerDialogProps,
-  NewLedgerDialogViewProps,
-} from "./NewLedgerDialog";
 export {
   CREATE_LEDGER_DIALOG_COPY,
   EDIT_LEDGER_DIALOG_COPY,
@@ -21,3 +11,13 @@ export {
   LEDGERS_PAGE_COPY,
   NEW_LEDGER_DIALOG_COPY,
 } from "./copy";
+export { CreateLedgerDialog } from "./CreateLedgerDialog";
+export { EditLedgerDialog } from "./EditLedgerDialog";
+export { LedgerList } from "./LedgerList";
+export type { LedgerListItemViewProps } from "./LedgerListItem";
+export { LedgerListItem, LedgerListItemView } from "./LedgerListItem";
+export type {
+  NewLedgerDialogProps,
+  NewLedgerDialogViewProps,
+} from "./NewLedgerDialog";
+export { NewLedgerDialog, NewLedgerDialogView } from "./NewLedgerDialog";

--- a/src/components/profile/DisplayNameForm.tsx
+++ b/src/components/profile/DisplayNameForm.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { USER_PROFILE_COPY } from "./copy";
 
 export interface DisplayNameFormProps {

--- a/src/components/profile/EmailForm.tsx
+++ b/src/components/profile/EmailForm.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { USER_PROFILE_COPY } from "./copy";
 
 export interface EmailFormProps {

--- a/src/components/profile/PasswordForm.tsx
+++ b/src/components/profile/PasswordForm.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 import { USER_PROFILE_COPY } from "./copy";
 
 export interface PasswordFormProps {

--- a/src/components/profile/ProfileSettingsView.spec.tsx
+++ b/src/components/profile/ProfileSettingsView.spec.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { ProfileSettingsView } from "./ProfileSettingsView";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { PROFILE_SETTINGS_COPY } from "./copy";
+import { ProfileSettingsView } from "./ProfileSettingsView";
 
 afterEach(cleanup);
 

--- a/src/components/profile/ProfileSettingsView.stories.tsx
+++ b/src/components/profile/ProfileSettingsView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { ProfileSettingsView } from "./ProfileSettingsView";
 
 const meta: Meta<typeof ProfileSettingsView> = {

--- a/src/components/profile/ProfileSettingsView.tsx
+++ b/src/components/profile/ProfileSettingsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "@/components/ui/card";
+
 import { PROFILE_SETTINGS_COPY } from "./copy";
 
 export interface ProfileSettingsViewProps {

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import type { User } from "firebase/auth";
+import { useRouter } from "next/navigation";
+
 import {
+  signOut,
   updateDisplayName,
   updateEmail,
   updatePassword,
-  signOut,
 } from "@/services/auth";
+
 import { UserProfileView } from "./UserProfileView";
 
 interface UserProfileProps {

--- a/src/components/profile/UserProfileView.spec.tsx
+++ b/src/components/profile/UserProfileView.spec.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
+  cleanup,
+  fireEvent,
   render,
   screen,
-  fireEvent,
-  cleanup,
   waitFor,
 } from "@testing-library/react";
-import { UserProfileView } from "./UserProfileView";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { USER_PROFILE_COPY } from "./copy";
+import { UserProfileView } from "./UserProfileView";
 
 afterEach(cleanup);
 

--- a/src/components/profile/UserProfileView.stories.tsx
+++ b/src/components/profile/UserProfileView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { UserProfileView } from "./UserProfileView";
 
 const meta: Meta<typeof UserProfileView> = {

--- a/src/components/profile/UserProfileView.tsx
+++ b/src/components/profile/UserProfileView.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
+
 import { USER_PROFILE_COPY } from "./copy";
 import { DisplayNameForm } from "./DisplayNameForm";
 import { EmailForm } from "./EmailForm";

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,6 +1,6 @@
-export { ProfileSettingsView } from "./ProfileSettingsView";
-export type { ProfileSettingsViewProps } from "./ProfileSettingsView";
-export { UserProfile } from "./UserProfile";
-export { UserProfileView } from "./UserProfileView";
-export type { UserProfileViewProps } from "./UserProfileView";
 export { PROFILE_SETTINGS_COPY, USER_PROFILE_COPY } from "./copy";
+export type { ProfileSettingsViewProps } from "./ProfileSettingsView";
+export { ProfileSettingsView } from "./ProfileSettingsView";
+export { UserProfile } from "./UserProfile";
+export type { UserProfileViewProps } from "./UserProfileView";
+export { UserProfileView } from "./UserProfileView";

--- a/src/components/reconcile/ReconcileView.spec.tsx
+++ b/src/components/reconcile/ReconcileView.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { ReconcileView } from "./ReconcileView";
 import { RECONCILE_VIEW_COPY } from "./ReconcileView.copy";
 

--- a/src/components/reconcile/ReconcileView.stories.tsx
+++ b/src/components/reconcile/ReconcileView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { ReconcileView } from "./ReconcileView";
 
 const meta: Meta<typeof ReconcileView> = {

--- a/src/components/savings-goals/EditSavingsGoalDialog.spec.tsx
+++ b/src/components/savings-goals/EditSavingsGoalDialog.spec.tsx
@@ -1,14 +1,16 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
-import { EDIT_SAVINGS_GOAL_DIALOG_COPY } from "./copy";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { EDIT_SAVINGS_GOAL_DIALOG_COPY } from "./copy";
+import { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
 
 afterEach(cleanup);
 

--- a/src/components/savings-goals/EditSavingsGoalDialog.stories.tsx
+++ b/src/components/savings-goals/EditSavingsGoalDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
 
 const meta: Meta<typeof EditSavingsGoalDialog> = {

--- a/src/components/savings-goals/EditSavingsGoalDialog.tsx
+++ b/src/components/savings-goals/EditSavingsGoalDialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { Pencil } from "lucide-react";
-import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,6 +12,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
 import { EDIT_SAVINGS_GOAL_DIALOG_COPY } from "./copy";
 
 export interface EditSavingsGoalDialogProps {

--- a/src/components/savings-goals/NewSavingsGoalDialog-tests/NewSavingsGoalDialog.spec.tsx
+++ b/src/components/savings-goals/NewSavingsGoalDialog-tests/NewSavingsGoalDialog.spec.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { NewSavingsGoalDialog } from "../NewSavingsGoalDialog";
 import { NEW_SAVINGS_GOAL_DIALOG_COPY } from "../NewSavingsGoalDialog.copy";
 

--- a/src/components/savings-goals/NewSavingsGoalDialog-tests/NewSavingsGoalDialogView.spec.tsx
+++ b/src/components/savings-goals/NewSavingsGoalDialog-tests/NewSavingsGoalDialogView.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { NewSavingsGoalDialogView } from "../NewSavingsGoalDialog";
 import { NEW_SAVINGS_GOAL_DIALOG_COPY } from "../NewSavingsGoalDialog.copy";
 

--- a/src/components/savings-goals/NewSavingsGoalDialog.stories.tsx
+++ b/src/components/savings-goals/NewSavingsGoalDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { NewSavingsGoalDialogView } from "./NewSavingsGoalDialog";
 import { NEW_SAVINGS_GOAL_DIALOG_COPY } from "./NewSavingsGoalDialog.copy";
 

--- a/src/components/savings-goals/NewSavingsGoalDialog.tsx
+++ b/src/components/savings-goals/NewSavingsGoalDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   DialogBackdrop,
@@ -10,6 +11,7 @@ import {
   DialogRoot,
   DialogTitle,
 } from "@/components/ui/dialog";
+
 import { NEW_SAVINGS_GOAL_DIALOG_COPY } from "./NewSavingsGoalDialog.copy";
 
 export interface NewSavingsGoalDialogViewProps {

--- a/src/components/savings-goals/SavingsGoalList.spec.tsx
+++ b/src/components/savings-goals/SavingsGoalList.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import { SavingsGoalListView } from "./SavingsGoalList";
-import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import { SavingsGoalListView } from "./SavingsGoalList";
 
 afterEach(cleanup);
 

--- a/src/components/savings-goals/SavingsGoalList.stories.tsx
+++ b/src/components/savings-goals/SavingsGoalList.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { SavingsGoalListView } from "./SavingsGoalList";
 
 const meta: Meta<typeof SavingsGoalListView> = {

--- a/src/components/savings-goals/SavingsGoalList.tsx
+++ b/src/components/savings-goals/SavingsGoalList.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 import { Card } from "@/components/ui/card";
-import { SavingsGoalListItem } from "./SavingsGoalListItem";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
 import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import { SavingsGoalListItem } from "./SavingsGoalListItem";
 
 export interface SavingsGoalListViewProps {
   goals: BudgetLedgerSavingsGoal[];

--- a/src/components/savings-goals/SavingsGoalListItem.spec.tsx
+++ b/src/components/savings-goals/SavingsGoalListItem.spec.tsx
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { SAVINGS_GOAL_LIST_ITEM_COPY } from "./copy";
 import {
   SavingsGoalListItem,
   SavingsGoalListItemView,
 } from "./SavingsGoalListItem";
-import { SAVINGS_GOAL_LIST_ITEM_COPY } from "./copy";
-import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
 afterEach(cleanup);
 

--- a/src/components/savings-goals/SavingsGoalListItem.stories.tsx
+++ b/src/components/savings-goals/SavingsGoalListItem.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import { SavingsGoalListItemView } from "./SavingsGoalListItem";
 
 const meta: Meta<typeof SavingsGoalListItemView> = {

--- a/src/components/savings-goals/SavingsGoalListItem.tsx
+++ b/src/components/savings-goals/SavingsGoalListItem.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { ChevronDown, ChevronUp, MoreHorizontal } from "lucide-react";
 import { useState } from "react";
-import { ChevronUp, ChevronDown, MoreHorizontal } from "lucide-react";
-import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
-import { Button } from "@/components/ui/button";
+
 import {
   AlertDialogBackdrop,
   AlertDialogClose,
@@ -13,17 +12,20 @@ import {
   AlertDialogRoot,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Bar } from "@/components/ui/bar";
+import { Button } from "@/components/ui/button";
 import {
-  DropdownMenuRoot,
-  DropdownMenuTrigger,
+  DropdownMenuItem,
+  DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
-  DropdownMenuPopup,
-  DropdownMenuItem,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Bar } from "@/components/ui/bar";
-import { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
 import { SAVINGS_GOAL_LIST_COPY, SAVINGS_GOAL_LIST_ITEM_COPY } from "./copy";
+import { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",

--- a/src/components/savings-goals/SavingsGoalListView.spec.tsx
+++ b/src/components/savings-goals/SavingsGoalListView.spec.tsx
@@ -1,14 +1,16 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  render,
-  screen,
   cleanup,
   fireEvent,
+  render,
+  screen,
   waitFor,
 } from "@testing-library/react";
-import { SavingsGoalListView } from "./SavingsGoalList";
-import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { SAVINGS_GOAL_LIST_COPY } from "./copy";
+import { SavingsGoalListView } from "./SavingsGoalList";
 
 afterEach(cleanup);
 

--- a/src/components/savings-goals/index.ts
+++ b/src/components/savings-goals/index.ts
@@ -1,23 +1,23 @@
 export {
-  NewSavingsGoalDialog,
-  NewSavingsGoalDialogView,
-} from "./NewSavingsGoalDialog";
-export type {
-  NewSavingsGoalDialogProps,
-  NewSavingsGoalDialogViewProps,
-} from "./NewSavingsGoalDialog";
-export { NEW_SAVINGS_GOAL_DIALOG_COPY } from "./NewSavingsGoalDialog.copy";
-export { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
-export type { EditSavingsGoalDialogProps } from "./EditSavingsGoalDialog";
-export { SavingsGoalListView } from "./SavingsGoalList";
-export type { SavingsGoalListViewProps } from "./SavingsGoalList";
-export {
-  SavingsGoalListItem,
-  SavingsGoalListItemView,
-} from "./SavingsGoalListItem";
-export type { SavingsGoalListItemViewProps } from "./SavingsGoalListItem";
-export {
   EDIT_SAVINGS_GOAL_DIALOG_COPY,
   SAVINGS_GOAL_LIST_COPY,
   SAVINGS_GOAL_LIST_ITEM_COPY,
 } from "./copy";
+export type { EditSavingsGoalDialogProps } from "./EditSavingsGoalDialog";
+export { EditSavingsGoalDialog } from "./EditSavingsGoalDialog";
+export type {
+  NewSavingsGoalDialogProps,
+  NewSavingsGoalDialogViewProps,
+} from "./NewSavingsGoalDialog";
+export {
+  NewSavingsGoalDialog,
+  NewSavingsGoalDialogView,
+} from "./NewSavingsGoalDialog";
+export { NEW_SAVINGS_GOAL_DIALOG_COPY } from "./NewSavingsGoalDialog.copy";
+export type { SavingsGoalListViewProps } from "./SavingsGoalList";
+export { SavingsGoalListView } from "./SavingsGoalList";
+export type { SavingsGoalListItemViewProps } from "./SavingsGoalListItem";
+export {
+  SavingsGoalListItem,
+  SavingsGoalListItemView,
+} from "./SavingsGoalListItem";

--- a/src/firebase-rules.spec.ts
+++ b/src/firebase-rules.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
+import { describe, expect, it } from "vitest";
 
 const rulesPath = resolve(
   import.meta.dirname,

--- a/src/hooks/use-annuities.spec.ts
+++ b/src/hooks/use-annuities.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { useAnnuities } from "./use-annuities";
 
 const mockUnsubscribe = vi.fn();

--- a/src/hooks/use-annuities.ts
+++ b/src/hooks/use-annuities.ts
@@ -1,12 +1,13 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToAnnuity,
-  type FirebaseAnnuity,
   type Annuity,
+  type FirebaseAnnuity,
+  firebaseToAnnuity,
 } from "@/lib/firebase/schema/annuities";
 
 export function useAnnuities(uid: string) {

--- a/src/hooks/use-auth.spec.ts
+++ b/src/hooks/use-auth.spec.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { renderHook, cleanup } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 import { createElement } from "react";
-import { AuthContext } from "@/components/auth";
-import { useAuth } from "./use-auth";
+import { afterEach, describe, expect, it } from "vitest";
+
 import type { AuthContextValue } from "@/components/auth";
+import { AuthContext } from "@/components/auth";
+
+import { useAuth } from "./use-auth";
 
 afterEach(cleanup);
 

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+
 import { AuthContext, type AuthContextValue } from "@/components/auth";
 
 export function useAuth(): AuthContextValue {

--- a/src/hooks/use-create-deposit.ts
+++ b/src/hooks/use-create-deposit.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+
 import {
-  BudgetLedgerTransactionType,
   type BudgetLedgerTransaction,
+  BudgetLedgerTransactionType,
 } from "@/lib/firebase/schema/budget-ledger-transactions";
 import { createTransaction } from "@/services/transactions";
 

--- a/src/hooks/use-create-ledger.spec.ts
+++ b/src/hooks/use-create-ledger.spec.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useCreateLedger } from "./use-create-ledger";
-import * as ledgersService from "@/services/ledgers";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { Ledger } from "@/lib/types";
+import * as ledgersService from "@/services/ledgers";
+
+import { useCreateLedger } from "./use-create-ledger";
 
 afterEach(() => {
   cleanup();

--- a/src/hooks/use-create-ledger.ts
+++ b/src/hooks/use-create-ledger.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import type { CreateLedgerInput } from "@/lib/types";
 import { createLedger } from "@/services/ledgers";
 

--- a/src/hooks/use-create-transaction.ts
+++ b/src/hooks/use-create-transaction.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { createTransaction } from "@/services/transactions";
-import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
 import type { AddExpenseInput } from "@/components/ledger-transactions/AddExpenseDialog";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { createTransaction } from "@/services/transactions";
 
 export function useCreateTransaction(uid: string, ledgerId: string) {
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/hooks/use-delete-ledger.spec.ts
+++ b/src/hooks/use-delete-ledger.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useDeleteLedger } from "./use-delete-ledger";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import * as ledgersService from "@/services/ledgers";
+
+import { useDeleteLedger } from "./use-delete-ledger";
 
 afterEach(() => {
   cleanup();

--- a/src/hooks/use-delete-ledger.ts
+++ b/src/hooks/use-delete-ledger.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { deleteLedger } from "@/services/ledgers";
 
 export function useDeleteLedger(uid: string) {

--- a/src/hooks/use-delete-savings-goal.ts
+++ b/src/hooks/use-delete-savings-goal.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+
 import { deleteSavingsGoalAndReorder } from "@/services/savings-goals";
 
 export function useDeleteSavingsGoal(uid: string, ledgerId: string) {

--- a/src/hooks/use-delete-transaction.spec.ts
+++ b/src/hooks/use-delete-transaction.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useDeleteTransaction } from "./use-delete-transaction";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import * as transactionsService from "@/services/transactions";
+
+import { useDeleteTransaction } from "./use-delete-transaction";
 
 afterEach(() => {
   cleanup();

--- a/src/hooks/use-delete-transaction.ts
+++ b/src/hooks/use-delete-transaction.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+
 import { deleteTransaction } from "@/services/transactions";
 
 export function useDeleteTransaction(uid: string, ledgerId: string) {

--- a/src/hooks/use-example.spec.ts
+++ b/src/hooks/use-example.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("hooks project smoke test", () => {
   it("runs in happy-dom environment", () => {

--- a/src/hooks/use-ledgers-subscription.spec.ts
+++ b/src/hooks/use-ledgers-subscription.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { useLedgersSubscription } from "./use-ledgers-subscription";
 
 const mockUnsubscribe = vi.fn();

--- a/src/hooks/use-ledgers-subscription.ts
+++ b/src/hooks/use-ledgers-subscription.ts
@@ -1,12 +1,13 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToBudgetLedger,
-  type FirebaseBudgetLedger,
   type BudgetLedger,
+  type FirebaseBudgetLedger,
+  firebaseToBudgetLedger,
 } from "@/lib/firebase/schema/budget-ledgers";
 
 export function useLedgersSubscription(uid: string) {

--- a/src/hooks/use-ledgers.spec.ts
+++ b/src/hooks/use-ledgers.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { createElement } from "react";
-import { useLedgers } from "./use-ledgers";
-import * as ledgersService from "@/services/ledgers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { Ledger } from "@/lib/types";
+import * as ledgersService from "@/services/ledgers";
+
+import { useLedgers } from "./use-ledgers";
 
 afterEach(() => {
   cleanup();

--- a/src/hooks/use-ledgers.ts
+++ b/src/hooks/use-ledgers.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+
 import type { Ledger } from "@/lib/types";
 import { getLedgers } from "@/services/ledgers";
 

--- a/src/hooks/use-reconciliation-accounts.spec.ts
+++ b/src/hooks/use-reconciliation-accounts.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
-import { useReconciliationAccounts } from "./use-reconciliation-accounts";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
+import { useReconciliationAccounts } from "./use-reconciliation-accounts";
 
 const mockUnsubscribe = vi.fn();
 const mockOnValue = vi.fn();

--- a/src/hooks/use-reconciliation-accounts.ts
+++ b/src/hooks/use-reconciliation-accounts.ts
@@ -1,11 +1,12 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToReconciliationAccount,
   type FirebaseReconciliationAccount,
+  firebaseToReconciliationAccount,
   type ReconciliationAccount,
 } from "@/lib/firebase/schema/reconciliation-accounts";
 

--- a/src/hooks/use-reconciliation-expenses.spec.ts
+++ b/src/hooks/use-reconciliation-expenses.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
-import { useReconciliationExpenses } from "./use-reconciliation-expenses";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
+
+import { useReconciliationExpenses } from "./use-reconciliation-expenses";
 
 const mockUnsubscribe = vi.fn();
 const mockOnValue = vi.fn();

--- a/src/hooks/use-reconciliation-expenses.ts
+++ b/src/hooks/use-reconciliation-expenses.ts
@@ -1,11 +1,12 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToReconciliationExpense,
   type FirebaseReconciliationExpense,
+  firebaseToReconciliationExpense,
   type ReconciliationExpense,
 } from "@/lib/firebase/schema/reconciliation-expenses";
 

--- a/src/hooks/use-savings-goal.ts
+++ b/src/hooks/use-savings-goal.ts
@@ -1,12 +1,13 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToBudgetLedgerSavingsGoal,
-  type FirebaseBudgetLedgerSavingsGoal,
   type BudgetLedgerSavingsGoal,
+  type FirebaseBudgetLedgerSavingsGoal,
+  firebaseToBudgetLedgerSavingsGoal,
 } from "@/lib/firebase/schema/savings-goals";
 
 interface UseSavingsGoalResult {

--- a/src/hooks/use-savings-goals.spec.ts
+++ b/src/hooks/use-savings-goals.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup, act } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { useSavingsGoals } from "./use-savings-goals";
 
 const mockUnsubscribe = vi.fn();

--- a/src/hooks/use-savings-goals.ts
+++ b/src/hooks/use-savings-goals.ts
@@ -1,12 +1,13 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToBudgetLedgerSavingsGoal,
-  type FirebaseBudgetLedgerSavingsGoal,
   type BudgetLedgerSavingsGoal,
+  type FirebaseBudgetLedgerSavingsGoal,
+  firebaseToBudgetLedgerSavingsGoal,
 } from "@/lib/firebase/schema/savings-goals";
 
 export function useSavingsGoals(uid: string, ledgerId: string) {

--- a/src/hooks/use-transactions.spec.ts
+++ b/src/hooks/use-transactions.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
-import { useTransactions } from "./use-transactions";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { useTransactions } from "./use-transactions";
 
 const mockUnsubscribe = vi.fn();
 const mockOnValue = vi.fn();

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -1,12 +1,13 @@
 "use client";
 
+import { getDatabase, onValue, ref } from "firebase/database";
 import { useEffect, useState } from "react";
-import { getDatabase, ref, onValue } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToBudgetLedgerTransaction,
-  type FirebaseBudgetLedgerTransaction,
   type BudgetLedgerTransaction,
+  type FirebaseBudgetLedgerTransaction,
+  firebaseToBudgetLedgerTransaction,
 } from "@/lib/firebase/schema/budget-ledger-transactions";
 
 export function useTransactions(uid: string, ledgerId: string) {

--- a/src/hooks/use-update-savings-goal.spec.ts
+++ b/src/hooks/use-update-savings-goal.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, act, cleanup } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { useUpdateSavingsGoal } from "./use-update-savings-goal";
 
 const mockUpdateSavingsGoal = vi.fn();

--- a/src/hooks/use-update-savings-goal.ts
+++ b/src/hooks/use-update-savings-goal.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { updateSavingsGoal, getSavingsGoals } from "@/services/savings-goals";
+
+import { getSavingsGoals, updateSavingsGoal } from "@/services/savings-goals";
 
 export function useUpdateSavingsGoal(uid: string, ledgerId: string) {
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/hooks/use-update-transaction.spec.ts
+++ b/src/hooks/use-update-transaction.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useUpdateTransaction } from "./use-update-transaction";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import * as transactionsService from "@/services/transactions";
+
+import { useUpdateTransaction } from "./use-update-transaction";
 
 afterEach(() => {
   cleanup();

--- a/src/hooks/use-update-transaction.ts
+++ b/src/hooks/use-update-transaction.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
 import { updateTransaction } from "@/services/transactions";
 

--- a/src/lib/annuity-math.spec.ts
+++ b/src/lib/annuity-math.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { calculateMonthlyPayment } from "./annuity-math";
 
 describe("calculateMonthlyPayment", () => {

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -1,5 +1,5 @@
-import { initializeApp, getApps, cert, type App } from "firebase-admin/app";
-import { getAuth, type Auth } from "firebase-admin/auth";
+import { type App, cert, getApps, initializeApp } from "firebase-admin/app";
+import { type Auth, getAuth } from "firebase-admin/auth";
 
 export function getAdminApp(): App {
   const existing = getApps().find((a) => a.name === "[DEFAULT]");

--- a/src/lib/firebase/client.ts
+++ b/src/lib/firebase/client.ts
@@ -1,5 +1,5 @@
-import { initializeApp, getApps, type FirebaseApp } from "firebase/app";
-import { getAuth, type Auth } from "firebase/auth";
+import { type FirebaseApp, getApps, initializeApp } from "firebase/app";
+import { type Auth, getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env["NEXT_PUBLIC_FIREBASE_API_KEY"],

--- a/src/lib/firebase/schema/annuities.spec.ts
+++ b/src/lib/firebase/schema/annuities.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { annuityToFirebase, firebaseToAnnuity } from "./annuities";
 
 describe("annuityToFirebase", () => {

--- a/src/lib/firebase/schema/budget-ledger-transactions.spec.ts
+++ b/src/lib/firebase/schema/budget-ledger-transactions.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  BudgetLedgerTransactionType,
   budgetLedgerTransactionToFirebase,
+  BudgetLedgerTransactionType,
   firebaseToBudgetLedgerTransaction,
 } from "./budget-ledger-transactions";
 

--- a/src/lib/firebase/schema/budget-ledgers.spec.ts
+++ b/src/lib/firebase/schema/budget-ledgers.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
   budgetLedgerToFirebase,
   firebaseToBudgetLedger,

--- a/src/lib/firebase/schema/index.ts
+++ b/src/lib/firebase/schema/index.ts
@@ -1,6 +1,6 @@
 export * from "./annuities";
-export * from "./budget-ledgers";
 export * from "./budget-ledger-transactions";
+export * from "./budget-ledgers";
 export * from "./reconciliation-accounts";
 export * from "./reconciliation-expenses";
 export * from "./savings-goals";

--- a/src/lib/firebase/schema/reconciliation-accounts.spec.ts
+++ b/src/lib/firebase/schema/reconciliation-accounts.spec.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
+  firebaseToReconciliationAccount,
   ReconciliationAccountTier,
   reconciliationAccountToFirebase,
-  firebaseToReconciliationAccount,
 } from "./reconciliation-accounts";
 
 describe("reconciliationAccountToFirebase", () => {

--- a/src/lib/firebase/schema/reconciliation-expenses.spec.ts
+++ b/src/lib/firebase/schema/reconciliation-expenses.spec.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  ReconciliationExpenseType,
-  reconciliationExpenseToFirebase,
   firebaseToReconciliationExpense,
+  reconciliationExpenseToFirebase,
+  ReconciliationExpenseType,
 } from "./reconciliation-expenses";
 
 describe("reconciliationExpenseToFirebase", () => {

--- a/src/lib/firebase/schema/savings-goals.spec.ts
+++ b/src/lib/firebase/schema/savings-goals.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
   budgetLedgerSavingsGoalToFirebase,
   firebaseToBudgetLedgerSavingsGoal,

--- a/src/lib/sentry-init.spec.ts
+++ b/src/lib/sentry-init.spec.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@sentry/nextjs", () => ({
   init: vi.fn(),

--- a/src/lib/sentry-release.spec.ts
+++ b/src/lib/sentry-release.spec.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 
 afterEach(() => {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,1 +1,1 @@
-export type { Ledger, CreateLedgerInput, UpdateLedgerInput } from "./ledger";
+export type { CreateLedgerInput, Ledger, UpdateLedgerInput } from "./ledger";

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("node project smoke test", () => {
   it("runs in node environment", () => {

--- a/src/middleware.spec.ts
+++ b/src/middleware.spec.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
-import { middleware, config } from "./middleware";
+
+import { config, middleware } from "./middleware";
 
 function makeSessionCookie(): string {
   const now = Math.floor(Date.now() / 1000);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
 
 const FIREBASE_JWKS_URL =

--- a/src/scripts/validate-config.spec.ts
+++ b/src/scripts/validate-config.spec.ts
@@ -1,13 +1,14 @@
+import { spawnSync } from "node:child_process";
 import {
-  mkdtempSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 const SCRIPT_PATH = join(process.cwd(), "scripts", "validate-config.mjs");

--- a/src/services/annuities.spec.ts
+++ b/src/services/annuities.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("firebase/database", () => ({
   getDatabase: vi.fn(),
@@ -15,19 +15,20 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
+
 import {
-  getAnnuities,
   createAnnuity,
-  updateAnnuity,
   deleteAnnuity,
+  getAnnuities,
+  updateAnnuity,
 } from "./annuities";
 
 const mockDb = { type: "mock-db" };

--- a/src/services/annuities.ts
+++ b/src/services/annuities.ts
@@ -1,18 +1,19 @@
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  annuityToFirebase,
-  firebaseToAnnuity,
-  type FirebaseAnnuity,
   type Annuity,
+  annuityToFirebase,
+  type FirebaseAnnuity,
+  firebaseToAnnuity,
 } from "@/lib/firebase/schema/annuities";
 
 function db() {

--- a/src/services/auth.spec.ts
+++ b/src/services/auth.spec.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import {
-  signIn,
-  signUp,
   sendPasswordReset,
+  signIn,
   signOut,
+  signUp,
   updateDisplayName,
   updateEmail as serviceUpdateEmail,
   updatePassword as serviceUpdatePassword,
@@ -28,15 +29,16 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  reauthenticateWithCredential,
   sendPasswordResetEmail,
+  signInWithEmailAndPassword,
   signOut as firebaseSignOut,
-  updateProfile as firebaseUpdateProfile,
   updateEmail as firebaseUpdateEmail,
   updatePassword as firebaseUpdatePassword,
-  reauthenticateWithCredential,
+  updateProfile as firebaseUpdateProfile,
 } from "firebase/auth";
+
 import { getClientAuth } from "@/lib/firebase/client";
 
 describe("auth service", () => {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,15 +1,16 @@
 import {
-  signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  EmailAuthProvider,
+  reauthenticateWithCredential,
   sendPasswordResetEmail,
+  signInWithEmailAndPassword,
   signOut as firebaseSignOut,
-  updateProfile as firebaseUpdateProfile,
   updateEmail as firebaseUpdateEmail,
   updatePassword as firebaseUpdatePassword,
-  reauthenticateWithCredential,
-  EmailAuthProvider,
+  updateProfile as firebaseUpdateProfile,
   type User,
 } from "firebase/auth";
+
 import { getClientAuth } from "@/lib/firebase/client";
 
 export async function signIn(email: string, password: string) {

--- a/src/services/ledgers.ts
+++ b/src/services/ledgers.ts
@@ -1,9 +1,10 @@
-import { getDatabase, ref, get, set, update, push } from "firebase/database";
+import { get, getDatabase, push, ref, set, update } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  firebaseToBudgetLedger,
   budgetLedgerToFirebase,
   type FirebaseBudgetLedger,
+  firebaseToBudgetLedger,
 } from "@/lib/firebase/schema/budget-ledgers";
 import type { CreateLedgerInput, Ledger, UpdateLedgerInput } from "@/lib/types";
 

--- a/src/services/reconciliation-accounts.spec.ts
+++ b/src/services/reconciliation-accounts.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("firebase/database", () => ({
   getDatabase: vi.fn(),
@@ -15,21 +15,23 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
-import {
-  getReconciliationAccounts,
-  createReconciliationAccount,
-  updateReconciliationAccount,
-  deleteReconciliationAccount,
-} from "./reconciliation-accounts";
+
 import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+
+import {
+  createReconciliationAccount,
+  deleteReconciliationAccount,
+  getReconciliationAccounts,
+  updateReconciliationAccount,
+} from "./reconciliation-accounts";
 
 const mockDb = { type: "mock-db" };
 const mockRef = { type: "mock-ref" };

--- a/src/services/reconciliation-accounts.ts
+++ b/src/services/reconciliation-accounts.ts
@@ -1,18 +1,19 @@
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  reconciliationAccountToFirebase,
-  firebaseToReconciliationAccount,
   type FirebaseReconciliationAccount,
+  firebaseToReconciliationAccount,
   type ReconciliationAccount,
+  reconciliationAccountToFirebase,
 } from "@/lib/firebase/schema/reconciliation-accounts";
 
 function db() {

--- a/src/services/reconciliation-expenses.spec.ts
+++ b/src/services/reconciliation-expenses.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("firebase/database", () => ({
   getDatabase: vi.fn(),
@@ -15,21 +15,23 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
-import {
-  getReconciliationExpenses,
-  createReconciliationExpense,
-  updateReconciliationExpense,
-  deleteReconciliationExpense,
-} from "./reconciliation-expenses";
+
 import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
+
+import {
+  createReconciliationExpense,
+  deleteReconciliationExpense,
+  getReconciliationExpenses,
+  updateReconciliationExpense,
+} from "./reconciliation-expenses";
 
 const mockDb = { type: "mock-db" };
 const mockRef = { type: "mock-ref" };

--- a/src/services/reconciliation-expenses.ts
+++ b/src/services/reconciliation-expenses.ts
@@ -1,18 +1,19 @@
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  reconciliationExpenseToFirebase,
-  firebaseToReconciliationExpense,
   type FirebaseReconciliationExpense,
+  firebaseToReconciliationExpense,
   type ReconciliationExpense,
+  reconciliationExpenseToFirebase,
 } from "@/lib/firebase/schema/reconciliation-expenses";
 
 function db() {

--- a/src/services/savings-goals.spec.ts
+++ b/src/services/savings-goals.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("firebase/database", () => ({
   getDatabase: vi.fn(),
@@ -15,19 +15,20 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  getDatabase,
-  ref,
   get,
+  getDatabase,
+  push,
+  ref,
+  remove,
   set,
   update,
-  push,
-  remove,
 } from "firebase/database";
+
 import {
-  getSavingsGoals,
   createSavingsGoal,
-  updateSavingsGoal,
   deleteSavingsGoal,
+  getSavingsGoals,
+  updateSavingsGoal,
 } from "./savings-goals";
 
 const mockDb = { type: "mock-db" };

--- a/src/services/savings-goals.ts
+++ b/src/services/savings-goals.ts
@@ -1,19 +1,20 @@
 import {
-  getDatabase,
-  ref,
   get,
-  set,
-  update,
+  getDatabase,
   push,
+  ref,
   remove,
   runTransaction,
+  set,
+  update,
 } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  budgetLedgerSavingsGoalToFirebase,
-  firebaseToBudgetLedgerSavingsGoal,
-  type FirebaseBudgetLedgerSavingsGoal,
   type BudgetLedgerSavingsGoal,
+  budgetLedgerSavingsGoalToFirebase,
+  type FirebaseBudgetLedgerSavingsGoal,
+  firebaseToBudgetLedgerSavingsGoal,
 } from "@/lib/firebase/schema/savings-goals";
 
 function db() {

--- a/src/services/transactions.spec.ts
+++ b/src/services/transactions.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("firebase/database", () => ({
   getDatabase: vi.fn(),
@@ -15,21 +15,23 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 import {
-  getDatabase,
-  ref,
   get,
-  set,
+  getDatabase,
   push,
+  ref,
   remove,
+  set,
   update,
 } from "firebase/database";
+
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
 import {
-  getTransactions,
   createTransaction,
   deleteTransaction,
+  getTransactions,
   updateTransaction,
 } from "./transactions";
-import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
 
 const mockDb = { type: "mock-db" };
 const mockRef = { type: "mock-ref" };

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -1,18 +1,19 @@
 import {
-  getDatabase,
-  ref,
   get,
-  set,
+  getDatabase,
   push,
+  ref,
   remove,
+  set,
   update,
 } from "firebase/database";
+
 import { getClientApp } from "@/lib/firebase/client";
 import {
-  budgetLedgerTransactionToFirebase,
-  firebaseToBudgetLedgerTransaction,
-  type FirebaseBudgetLedgerTransaction,
   type BudgetLedgerTransaction,
+  budgetLedgerTransactionToFirebase,
+  type FirebaseBudgetLedgerTransaction,
+  firebaseToBudgetLedgerTransaction,
 } from "@/lib/firebase/schema/budget-ledger-transactions";
 
 function db() {

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from "react-redux";
-import type { RootState, AppDispatch } from "./index";
+
+import type { AppDispatch, RootState } from "./index";
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { store } from "./index";
 
 const EXPECTED_INITIAL_STATE = { app: {} };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+
 import { appSlice } from "./app-slice";
 
 export const store = configureStore({


### PR DESCRIPTION
Adds `eslint-plugin-simple-import-sort` and applies it across the codebase, then documents the broader alphabetization conventions in AGENTS.md and CONTRIBUTING.md.

The plugin enforces two things automatically: import statement order (sorted by module path within groups) and named re-export order in barrel files. Both rules are auto-fixable — running `pnpm lint --fix` keeps imports tidy without manual effort, and the pre-commit hook does this on every commit.

The existing AGENTS.md convention for enum members and `as const` objects ("keep in alphabetical order to minimize merge conflicts") is preserved and expanded into a unified **Alphabetical ordering** section that covers all three cases: imports (ESLint-enforced), enum/const members (convention-enforced, reviewer-flagged), and barrel re-exports (ESLint-enforced). CONTRIBUTING.md is updated to mention import sorting in both the pre-commit hooks section and the code standards summary.

Applying the rule to the existing codebase (`pnpm lint --fix`) reordered imports in 172 source files. No logic was changed — all 742 tests continue to pass.

---
*Created by Claude Sonnet 4.6*