### PR TITLE
chore(hooks): remove dead code in useCreateTransaction and todayIso

### DIFF
--- a/src/components/ledger-transactions/AddExpenseDialog.tsx
+++ b/src/components/ledger-transactions/AddExpenseDialog.tsx
@@ -27,7 +27,7 @@ export interface AddExpenseDialogProps {
 }
 
 function todayIso(): string {
-  return new Date().toISOString().split("T")[0] ?? "";
+  return new Date().toISOString().slice(0, 10);
 }
 
 export function AddExpenseDialog({

--- a/src/hooks/use-create-transaction.spec.ts
+++ b/src/hooks/use-create-transaction.spec.ts
@@ -1,4 +1,4 @@
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
@@ -29,10 +29,12 @@ describe("useCreateTransaction", () => {
         useCreateTransaction("uid-123", "ledger-abc"),
       );
 
-      await result.current.addExpense({
-        date: new Date("2024-03-15T00:00:00"),
-        amount: 42.5,
-        description: "Groceries",
+      await act(async () => {
+        await result.current.addExpense({
+          date: new Date("2024-03-15T00:00:00"),
+          amount: 42.5,
+          description: "Groceries",
+        });
       });
 
       expect(spy).toHaveBeenCalledWith("uid-123", "ledger-abc", {
@@ -44,30 +46,25 @@ describe("useCreateTransaction", () => {
     });
   });
 
-  describe("unreachable null-guard is removed (uid and ledgerId are string, not string | undefined)", () => {
-    it("does not throw and calls createTransaction even when uid is an empty string", async () => {
-      const spy = vi
-        .spyOn(transactionsService, "createTransaction")
-        .mockResolvedValue({
-          id: "tx-id",
-          ledgerId: "ledger-abc",
-          type: BudgetLedgerTransactionType.Expense,
-          date: new Date("2024-03-15T00:00:00"),
-          amount: 10,
-          description: "Test",
-        });
+  describe("throws when uid is empty", () => {
+    it("throws and does not call createTransaction when uid is an empty string", async () => {
+      const spy = vi.spyOn(transactionsService, "createTransaction");
 
       const { result } = renderHook(() =>
         useCreateTransaction("", "ledger-abc"),
       );
 
-      await result.current.addExpense({
-        date: new Date("2024-03-15T00:00:00"),
-        amount: 10,
-        description: "Test",
-      });
+      await expect(
+        act(async () => {
+          await result.current.addExpense({
+            date: new Date("2024-03-15T00:00:00"),
+            amount: 10,
+            description: "Test",
+          });
+        }),
+      ).rejects.toThrow("Cannot create transaction: missing uid or ledgerId");
 
-      expect(spy).toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/use-create-transaction.spec.ts
+++ b/src/hooks/use-create-transaction.spec.ts
@@ -1,0 +1,73 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import * as transactionsService from "@/services/transactions";
+
+import { useCreateTransaction } from "./use-create-transaction";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useCreateTransaction", () => {
+  describe("calls createTransaction with the uid, ledgerId, and expense data", () => {
+    it("passes uid, ledgerId, and formatted expense to createTransaction", async () => {
+      const spy = vi
+        .spyOn(transactionsService, "createTransaction")
+        .mockResolvedValue({
+          id: "tx-id",
+          ledgerId: "ledger-abc",
+          type: BudgetLedgerTransactionType.Expense,
+          date: new Date("2024-03-15T00:00:00"),
+          amount: 42.5,
+          description: "Groceries",
+        });
+
+      const { result } = renderHook(() =>
+        useCreateTransaction("uid-123", "ledger-abc"),
+      );
+
+      await result.current.addExpense({
+        date: new Date("2024-03-15T00:00:00"),
+        amount: 42.5,
+        description: "Groceries",
+      });
+
+      expect(spy).toHaveBeenCalledWith("uid-123", "ledger-abc", {
+        type: BudgetLedgerTransactionType.Expense,
+        date: new Date("2024-03-15T00:00:00"),
+        amount: 42.5,
+        description: "Groceries",
+      });
+    });
+  });
+
+  describe("unreachable null-guard is removed (uid and ledgerId are string, not string | undefined)", () => {
+    it("does not throw and calls createTransaction even when uid is an empty string", async () => {
+      const spy = vi
+        .spyOn(transactionsService, "createTransaction")
+        .mockResolvedValue({
+          id: "tx-id",
+          ledgerId: "ledger-abc",
+          type: BudgetLedgerTransactionType.Expense,
+          date: new Date("2024-03-15T00:00:00"),
+          amount: 10,
+          description: "Test",
+        });
+
+      const { result } = renderHook(() =>
+        useCreateTransaction("", "ledger-abc"),
+      );
+
+      await result.current.addExpense({
+        date: new Date("2024-03-15T00:00:00"),
+        amount: 10,
+        description: "Test",
+      });
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/use-create-transaction.ts
+++ b/src/hooks/use-create-transaction.ts
@@ -10,6 +10,11 @@ export function useCreateTransaction(uid: string, ledgerId: string) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const addExpense = async (data: AddExpenseInput): Promise<void> => {
+    if (!uid || !ledgerId) {
+      throw new Error(
+        "Cannot create transaction: missing uid or ledgerId",
+      );
+    }
     setIsSubmitting(true);
     try {
       await createTransaction(uid, ledgerId, {

--- a/src/hooks/use-create-transaction.ts
+++ b/src/hooks/use-create-transaction.ts
@@ -10,9 +10,6 @@ export function useCreateTransaction(uid: string, ledgerId: string) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const addExpense = async (data: AddExpenseInput): Promise<void> => {
-    if (!uid || !ledgerId) {
-      throw new Error("Cannot create transaction: missing uid or ledgerId");
-    }
     setIsSubmitting(true);
     try {
       await createTransaction(uid, ledgerId, {

--- a/src/hooks/use-create-transaction.ts
+++ b/src/hooks/use-create-transaction.ts
@@ -11,9 +11,7 @@ export function useCreateTransaction(uid: string, ledgerId: string) {
 
   const addExpense = async (data: AddExpenseInput): Promise<void> => {
     if (!uid || !ledgerId) {
-      throw new Error(
-        "Cannot create transaction: missing uid or ledgerId",
-      );
+      throw new Error("Cannot create transaction: missing uid or ledgerId");
     }
     setIsSubmitting(true);
     try {


### PR DESCRIPTION
Removes two pieces of dead code identified in #115.

In `useCreateTransaction`, the `if (!uid || !ledgerId)` guard was originally removed as dead code (both parameters are typed as `string`, not `string | undefined`, so the falsy check could never trigger). After review feedback, the guard has been **restored** with a runtime `throw` so that callers passing empty strings get a clear error rather than a silent no-op. A spec is added that verifies `addExpense` throws and `createTransaction` is **not** called when an empty string uid is provided.

In `todayIso` (inside `AddExpenseDialog`), the `split("T")[0] ?? ""` fallback was unreachable because `toISOString()` always produces a string containing `"T"`. The implementation is replaced with `slice(0, 10)`, which is type-safe under `noUncheckedIndexedAccess` and avoids both the dead fallback and the banned non-null assertion.

Closes #115

---
*Created by Claude Sonnet 4.6*