### PR TITLE
refactor(goal-purchase): deduplicate currencyFormatter into src/lib/formatters.ts

### DIFF
--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -5,13 +5,9 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { currencyFormatter } from "@/lib/formatters";
 
 import { GOAL_PURCHASE_FORM_COPY } from "./copy";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-});
 
 export interface GoalPurchaseFormProps {
   ledgerName: string;

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -3,16 +3,12 @@
 import Link from "next/link";
 
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { currencyFormatter } from "@/lib/formatters";
 
 import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
 import { GoalPurchaseForm } from "./GoalPurchaseForm";
 import { GoalPurchaseWarning } from "./GoalPurchaseWarning";
 import { GoalSiblingProjections } from "./GoalSiblingProjections";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-});
 
 export interface GoalPurchaseViewProps {
   goal: BudgetLedgerSavingsGoal;

--- a/src/lib/formatters.spec.ts
+++ b/src/lib/formatters.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { currencyFormatter } from "./formatters";
+
+describe("currencyFormatter — shared USD formatter", () => {
+  it("formats a whole dollar amount in en-US USD style", () => {
+    expect(currencyFormatter.format(1000)).toBe("$1,000.00");
+  });
+
+  it("formats a decimal amount correctly", () => {
+    expect(currencyFormatter.format(10000.5)).toBe("$10,000.50");
+  });
+
+  it("formats zero correctly", () => {
+    expect(currencyFormatter.format(0)).toBe("$0.00");
+  });
+});

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,4 @@
+export const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});


### PR DESCRIPTION
Extracts the identical `Intl.NumberFormat` instance that both `GoalPurchaseForm` and `GoalPurchaseView` declared at module scope into a single shared export at `src/lib/formatters.ts`. Both components now import `currencyFormatter` from the shared location.

A spec file is added alongside the formatter to verify the formatting output for common cases ($0, whole dollars, decimals).

## Acceptance Criteria
- [x] `currencyFormatter` consolidated into a single shared utility
- [x] Both components updated to import from the shared location
- [x] Tests added for the shared formatter

## Tests
3 tests added, all passing.

Closes #153

---
*Created by Claude Sonnet 4.5*