### PR TITLE
fix(app-shell): mobile bottom-nav More tab active route detection

### DIFF
--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -185,6 +185,34 @@ describe("AppShellNavView — More overflow", () => {
   });
 });
 
+describe("AppShellNavView — More tab active-route styling", () => {
+  it("marks the More button as active when pathname is an overflow destination like /profile", () => {
+    render(<AppShellNavView pathname="/profile">content</AppShellNavView>);
+    const moreBtn = screen.getByRole("button", {
+      name: APP_SHELL_COPY.moreLabel,
+    });
+    expect(moreBtn.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks the More button as active for nested paths under an overflow destination like /accounts/savings", () => {
+    render(
+      <AppShellNavView pathname="/accounts/savings">content</AppShellNavView>,
+    );
+    const moreBtn = screen.getByRole("button", {
+      name: APP_SHELL_COPY.moreLabel,
+    });
+    expect(moreBtn.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("does not mark the More button as active when pathname is a primary tab like /reconcile", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const moreBtn = screen.getByRole("button", {
+      name: APP_SHELL_COPY.moreLabel,
+    });
+    expect(moreBtn.getAttribute("aria-current")).not.toBe("page");
+  });
+});
+
 describe("AppShellNavView — children render", () => {
   it("renders the child content inside the shell", () => {
     render(

--- a/src/components/app-shell/AppShellNav.stories.tsx
+++ b/src/components/app-shell/AppShellNav.stories.tsx
@@ -52,3 +52,13 @@ export const Mobile: Story = {
     viewport: { defaultViewport: "mobile1" },
   },
 };
+
+export const MobileMoreActive: Story = {
+  args: {
+    pathname: "/profile",
+    children: placeholderChild,
+  },
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+};

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -55,6 +55,9 @@ export interface AppShellNavViewProps {
 
 export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
   const [overflowOpen, setOverflowOpen] = useState(false);
+  const moreActive = OVERFLOW_LINKS.some((link) =>
+    isActiveRoute(pathname, link.href),
+  );
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -142,10 +145,14 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
         })}
         <button
           type="button"
+          aria-current={moreActive ? "page" : undefined}
           onClick={() => {
             setOverflowOpen(true);
           }}
-          className="flex flex-1 items-center justify-center text-xs text-muted-foreground"
+          className={cn(
+            "flex flex-1 items-center justify-center text-xs",
+            moreActive ? "font-semibold" : "text-muted-foreground",
+          )}
         >
           {APP_SHELL_COPY.moreLabel}
         </button>


### PR DESCRIPTION
The mobile bottom-nav "More" button never showed as active when navigating to an overflow destination (/profile, /accounts, /annuities) because `MOBILE_TABS` doesn't include those routes. This meant users lost the active-route indicator entirely on overflow pages.

The fix computes `moreActive` by checking whether the current pathname matches any entry in `OVERFLOW_LINKS` (using the existing `isActiveRoute` helper), then applies `aria-current="page"` and `font-semibold` to the More button when active — mirroring the same pattern used by the primary tab links.

## Acceptance Criteria
- [x] More tab shows active styling when current route is an overflow destination (e.g., `/profile`, `/accounts`, `/annuities`)
- [x] More tab shows active styling for nested paths under overflow destinations (e.g., `/accounts/savings`)
- [x] More tab shows inactive styling when current route is a primary tab (e.g., `/reconcile`)

## Tests
3 tests added, all passing. Full suite: 876/876.

Closes #161

---
*Created by Claude Sonnet 4.5*