### PR TITLE
fix(app-shell): replace hardcoded avatar initials with dynamic user value

### DIFF
--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -236,3 +236,53 @@ describe("AppShellNavView — children render", () => {
     expect(screen.getByTestId("shell-child").textContent).toBe("hello shell");
   });
 });
+
+describe("AppShellNavView — avatar initials", () => {
+  it("renders the provided avatarInitials in the desktop avatar button", () => {
+    render(
+      <AppShellNavView pathname="/reconcile" avatarInitials="JD">
+        content
+      </AppShellNavView>,
+    );
+    const buttons = screen
+      .getAllByRole("button", { name: APP_SHELL_COPY.userMenuLabel })
+      .filter((el) => el.textContent === "JD");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("renders the provided avatarInitials in the mobile avatar button", () => {
+    render(
+      <AppShellNavView pathname="/reconcile" avatarInitials="AB">
+        content
+      </AppShellNavView>,
+    );
+    const buttons = screen
+      .getAllByRole("button", { name: APP_SHELL_COPY.userMenuLabel })
+      .filter((el) => el.textContent === "AB");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("renders the fallback placeholder when no avatarInitials prop is given", () => {
+    render(<AppShellNavView pathname="/reconcile">content</AppShellNavView>);
+    const buttons = screen.getAllByRole("button", {
+      name: APP_SHELL_COPY.userMenuLabel,
+    });
+    buttons.forEach((btn) => {
+      expect(btn.textContent).toBe(APP_SHELL_COPY.avatarFallback);
+    });
+  });
+
+  it("does not render the hardcoded RM string", () => {
+    render(
+      <AppShellNavView pathname="/reconcile" avatarInitials="JD">
+        content
+      </AppShellNavView>,
+    );
+    const buttons = screen.getAllByRole("button", {
+      name: APP_SHELL_COPY.userMenuLabel,
+    });
+    buttons.forEach((btn) => {
+      expect(btn.textContent).not.toBe("RM");
+    });
+  });
+});

--- a/src/components/app-shell/AppShellNav.spec.tsx
+++ b/src/components/app-shell/AppShellNav.spec.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { AppShellNavView } from "./AppShellNav";
+import { AppShellNavView, deriveInitials } from "./AppShellNav";
 import { APP_SHELL_COPY } from "./copy";
 
 afterEach(cleanup);
@@ -223,6 +223,28 @@ describe("AppShellNavView — More tab active-route styling", () => {
       name: APP_SHELL_COPY.moreLabel,
     });
     expect(moreBtn.getAttribute("aria-current")).not.toBe("page");
+  });
+});
+
+describe("deriveInitials", () => {
+  it("extracts first and last initials from a two-part display name", () => {
+    expect(deriveInitials("Reed Martz", null)).toBe("RM");
+  });
+
+  it("extracts a single initial from a one-word display name", () => {
+    expect(deriveInitials("Reed", null)).toBe("R");
+  });
+
+  it("returns undefined for a whitespace-only display name", () => {
+    expect(deriveInitials("  ", null)).toBeUndefined();
+  });
+
+  it("falls back to the first letter of email when displayName is null", () => {
+    expect(deriveInitials(null, "reed@example.com")).toBe("R");
+  });
+
+  it("returns undefined when both displayName and email are null", () => {
+    expect(deriveInitials(null, null)).toBeUndefined();
   });
 });
 

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -203,7 +203,7 @@ export interface AppShellNavProps {
   children: React.ReactNode;
 }
 
-function deriveInitials(
+export function deriveInitials(
   displayName: string | null,
   email: string | null,
 ): string | undefined {
@@ -212,11 +212,11 @@ function deriveInitials(
     const first = parts[0]?.charAt(0) ?? "";
     const last = parts[parts.length - 1]?.charAt(0) ?? "";
     return parts.length >= 2
-      ? `${first}${last}`.toUpperCase()
-      : first.toUpperCase();
+      ? `${first}${last}`.toUpperCase() || undefined
+      : first.toUpperCase() || undefined;
   }
   if (email) {
-    return email.charAt(0).toUpperCase();
+    return email.charAt(0).toUpperCase() || undefined;
   }
   return undefined;
 }

--- a/src/components/app-shell/AppShellNav.tsx
+++ b/src/components/app-shell/AppShellNav.tsx
@@ -12,6 +12,7 @@ import {
   DialogPortal,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useAuth } from "@/hooks/use-auth";
 import { cn } from "@/lib/utils";
 
 import { APP_SHELL_COPY } from "./copy";
@@ -49,12 +50,18 @@ function isActiveRoute(pathname: string, href: string): boolean {
 }
 
 export interface AppShellNavViewProps {
-  pathname: string;
+  avatarInitials?: string;
   children: React.ReactNode;
+  pathname: string;
 }
 
-export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
+export function AppShellNavView({
+  avatarInitials,
+  children,
+  pathname,
+}: AppShellNavViewProps) {
   const [overflowOpen, setOverflowOpen] = useState(false);
+  const displayInitials = avatarInitials ?? APP_SHELL_COPY.avatarFallback;
   const moreActive = OVERFLOW_LINKS.some((link) =>
     isActiveRoute(pathname, link.href),
   );
@@ -93,7 +100,7 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
             aria-label={APP_SHELL_COPY.userMenuLabel}
             className="grid size-8 place-items-center rounded-full bg-muted text-xs font-medium"
           >
-            RM
+            {displayInitials}
           </button>
         </nav>
       </header>
@@ -117,7 +124,7 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
           aria-label={APP_SHELL_COPY.userMenuLabel}
           className="grid size-8 place-items-center rounded-full bg-muted text-xs font-medium"
         >
-          RM
+          {displayInitials}
         </button>
       </header>
 
@@ -192,7 +199,37 @@ export function AppShellNavView({ pathname, children }: AppShellNavViewProps) {
   );
 }
 
-export function AppShellNav({ children }: { children: React.ReactNode }) {
+export interface AppShellNavProps {
+  children: React.ReactNode;
+}
+
+function deriveInitials(
+  displayName: string | null,
+  email: string | null,
+): string | undefined {
+  if (displayName) {
+    const parts = displayName.trim().split(/\s+/);
+    const first = parts[0]?.charAt(0) ?? "";
+    const last = parts[parts.length - 1]?.charAt(0) ?? "";
+    return parts.length >= 2
+      ? `${first}${last}`.toUpperCase()
+      : first.toUpperCase();
+  }
+  if (email) {
+    return email.charAt(0).toUpperCase();
+  }
+  return undefined;
+}
+
+export function AppShellNav({ children }: AppShellNavProps) {
   const pathname = usePathname();
-  return <AppShellNavView pathname={pathname}>{children}</AppShellNavView>;
+  const { user } = useAuth();
+  const avatarInitials = user
+    ? deriveInitials(user.displayName, user.email)
+    : undefined;
+  return (
+    <AppShellNavView pathname={pathname} avatarInitials={avatarInitials}>
+      {children}
+    </AppShellNavView>
+  );
 }

--- a/src/components/app-shell/copy.ts
+++ b/src/components/app-shell/copy.ts
@@ -1,4 +1,5 @@
 export const APP_SHELL_COPY = {
+  avatarFallback: "?",
   brand: "Ledgerly",
   linkAccounts: "Accounts",
   linkAnnuities: "Annuities",


### PR DESCRIPTION
The avatar button in `AppShellNav` hardcoded `"RM"` as the initials in both the desktop and mobile nav headers, making the shell appear personalized to a specific user and violating the project convention that all user-facing strings live in `copy.ts`.

This PR removes the hardcoded string and replaces it with a dynamic value derived from the signed-in user's `displayName` or `email` via the existing `useAuth()` hook. A generic `"?"` placeholder (defined in `copy.ts` as `avatarFallback`) is shown when no user data is available. The `AppShellNavView` presentational component receives the derived initials as an `avatarInitials?: string` prop so it remains fully testable without auth context.

The `deriveInitials` helper extracts the first letter of the first and last name segments from `displayName`, or falls back to the first letter of `email`. Four new tests covering the dynamic prop, the fallback, and the absence of `"RM"` were added to `AppShellNav.spec.tsx`.

Closes #162

---
*Created by Claude Sonnet 4.6*