### PR TITLE
feat(annuities): add Principal metadata row to AnnuityCard

### DIFF
--- a/src/components/annuities/AnnuityCard.spec.tsx
+++ b/src/components/annuities/AnnuityCard.spec.tsx
@@ -116,6 +116,48 @@ describe("AnnuityCard — selection state", () => {
   });
 });
 
+describe("AnnuityCard — principal row", () => {
+  it("shows the principal label for a PVDerived annuity with presentValue", () => {
+    render(
+      <AnnuityCard
+        annuity={makeAnnuity({
+          monthlyMode: AnnuityMonthlyMode.PVDerived,
+          presentValue: 200000,
+          annualRatePercent: 6,
+          durationMonths: 360,
+          startDate: new Date("2099-01-01T00:00:00.000Z"),
+        })}
+      />,
+    );
+    expect(screen.getByText(ANNUITY_CARD_COPY.principalLabel)).toBeDefined();
+  });
+
+  it("shows the computed principal balance for a future-dated PVDerived annuity", () => {
+    // startDate in 2099 → monthsElapsed = 0 → principal = presentValue = $200,000.00
+    render(
+      <AnnuityCard
+        annuity={makeAnnuity({
+          monthlyMode: AnnuityMonthlyMode.PVDerived,
+          presentValue: 200000,
+          annualRatePercent: 6,
+          durationMonths: 360,
+          startDate: new Date("2099-01-01T00:00:00.000Z"),
+        })}
+      />,
+    );
+    expect(screen.getByText("$200,000.00")).toBeDefined();
+  });
+
+  it("does not render the principal row for flat-mode annuities", () => {
+    render(
+      <AnnuityCard
+        annuity={makeAnnuity({ monthlyMode: AnnuityMonthlyMode.Flat })}
+      />,
+    );
+    expect(screen.queryByText(ANNUITY_CARD_COPY.principalLabel)).toBeNull();
+  });
+});
+
 describe("AnnuityCard — edit action", () => {
   it("renders an edit button when onEdit is provided", () => {
     render(

--- a/src/components/annuities/AnnuityCard.spec.tsx
+++ b/src/components/annuities/AnnuityCard.spec.tsx
@@ -148,10 +148,14 @@ describe("AnnuityCard — principal row", () => {
     expect(screen.getByText("$200,000.00")).toBeDefined();
   });
 
-  it("does not render the principal row for flat-mode annuities", () => {
+  it("does not render the principal row for flat-mode annuities even when presentValue is set", () => {
     render(
       <AnnuityCard
-        annuity={makeAnnuity({ monthlyMode: AnnuityMonthlyMode.Flat })}
+        annuity={makeAnnuity({
+          monthlyMode: AnnuityMonthlyMode.Flat,
+          presentValue: 200000,
+          annualRatePercent: 6,
+        })}
       />,
     );
     expect(screen.queryByText(ANNUITY_CARD_COPY.principalLabel)).toBeNull();

--- a/src/components/annuities/AnnuityCard.stories.tsx
+++ b/src/components/annuities/AnnuityCard.stories.tsx
@@ -76,6 +76,9 @@ export const WithPrincipal: Story = {
   args: {
     annuity: {
       ...baseAnnuity,
+      // Far-future startDate pins monthsElapsed=0 so the displayed
+      // principal ($350,000.00) stays stable for screenshot regression.
+      startDate: new Date("2099-01-01"),
       annualRatePercent: 6,
       presentValue: 350000,
     },

--- a/src/components/annuities/AnnuityCard.stories.tsx
+++ b/src/components/annuities/AnnuityCard.stories.tsx
@@ -71,3 +71,13 @@ export const WithActionsSelected: Story = {
     onDelete: () => {},
   },
 };
+
+export const WithPrincipal: Story = {
+  args: {
+    annuity: {
+      ...baseAnnuity,
+      annualRatePercent: 6,
+      presentValue: 350000,
+    },
+  },
+};

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { calculateRemainingPrincipal } from "@/lib/annuity-math";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
 import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
@@ -47,6 +48,20 @@ export function AnnuityCard({
         )
       : ANNUITY_CARD_COPY.termRemainingIndefinite;
 
+  const principalBalance =
+    annuity.presentValue !== undefined &&
+    annuity.annualRatePercent !== undefined &&
+    annuity.durationMonths !== undefined
+      ? calculateRemainingPrincipal({
+          annualRatePercent: annuity.annualRatePercent,
+          durationMonths: annuity.durationMonths,
+          monthsElapsed:
+            annuity.durationMonths -
+            monthsRemaining(annuity.startDate, annuity.durationMonths),
+          presentValue: annuity.presentValue,
+        })
+      : undefined;
+
   return (
     <div
       className={`relative w-full rounded-lg border bg-card text-card-foreground shadow-sm ${
@@ -78,6 +93,16 @@ export function AnnuityCard({
             </dt>
             <dd className="font-mono font-medium">{termDisplay}</dd>
           </div>
+          {principalBalance !== undefined && (
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">
+                {ANNUITY_CARD_COPY.principalLabel}
+              </dt>
+              <dd className="font-mono font-medium">
+                {currencyFormatter.format(principalBalance)}
+              </dd>
+            </div>
+          )}
         </dl>
       </button>
 

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -41,24 +41,25 @@ export function AnnuityCard({
       ? ANNUITY_CARD_COPY.monthlyModePVDerivedSublabel
       : ANNUITY_CARD_COPY.monthlyModeFlatSublabel;
 
-  const termDisplay =
+  const remaining =
     annuity.durationMonths !== undefined
-      ? ANNUITY_CARD_COPY.termRemainingMonths(
-          monthsRemaining(annuity.startDate, annuity.durationMonths),
-        )
+      ? monthsRemaining(annuity.startDate, annuity.durationMonths)
+      : undefined;
+
+  const termDisplay =
+    remaining !== undefined
+      ? ANNUITY_CARD_COPY.termRemainingMonths(remaining)
       : ANNUITY_CARD_COPY.termRemainingIndefinite;
 
   const principalBalance =
     annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
     annuity.presentValue !== undefined &&
     annuity.annualRatePercent !== undefined &&
-    annuity.durationMonths !== undefined
+    remaining !== undefined
       ? calculateRemainingPrincipal({
           annualRatePercent: annuity.annualRatePercent,
           durationMonths: annuity.durationMonths,
-          monthsElapsed:
-            annuity.durationMonths -
-            monthsRemaining(annuity.startDate, annuity.durationMonths),
+          monthsElapsed: annuity.durationMonths - remaining,
           presentValue: annuity.presentValue,
         })
       : undefined;

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -55,6 +55,7 @@ export function AnnuityCard({
     annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
     annuity.presentValue !== undefined &&
     annuity.annualRatePercent !== undefined &&
+    annuity.durationMonths !== undefined &&
     remaining !== undefined
       ? calculateRemainingPrincipal({
           annualRatePercent: annuity.annualRatePercent,

--- a/src/components/annuities/AnnuityCard.tsx
+++ b/src/components/annuities/AnnuityCard.tsx
@@ -49,6 +49,7 @@ export function AnnuityCard({
       : ANNUITY_CARD_COPY.termRemainingIndefinite;
 
   const principalBalance =
+    annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
     annuity.presentValue !== undefined &&
     annuity.annualRatePercent !== undefined &&
     annuity.durationMonths !== undefined

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -18,6 +18,7 @@ export const ANNUITY_CARD_COPY = {
   paymentHistoryEmpty: "No payment history yet.",
   paymentHistoryTitle: (annuityName: string) =>
     `${annuityName} · payment history`,
+  principalLabel: "Principal",
   selectAriaLabel: (name: string) => `Select ${name}`,
   termRemainingIndefinite: "Ongoing",
   termRemainingLabel: "Term remaining",


### PR DESCRIPTION
Adds a "Principal" metadata row to `AnnuityCard` for PVDerived annuities. The row displays the current running balance computed by `calculateRemainingPrincipal`, using `presentValue`, `annualRatePercent`, `durationMonths`, and months elapsed from `startDate`. Flat-mode annuities (no `presentValue`) show no Principal row.

The months-elapsed calculation reuses the existing `monthsRemaining` helper so elapsed is clamped to `[0, durationMonths]`, avoiding the negative-balance edge case tracked in #186. A `WithPrincipal` Storybook story is added to demonstrate the row visually.

## Acceptance Criteria
- [x] `AnnuityCard` renders a "Principal" row for PVDerived annuities with `presentValue` and `annualRatePercent`
- [x] The displayed balance is computed via `calculateRemainingPrincipal` and formatted as currency
- [x] The Principal row is absent for flat-mode annuities
- [x] Stories and tests updated to cover the new row

## Tests
3 tests added, all passing (1044 total, 0 regressions).

Closes #154

---
*Created by Claude Sonnet 4.5*