### PR TITLE
feat(reconcile): calculate target balance per account tier

### DIFF
--- a/src/lib/reconciliation/tier-targets.spec.ts
+++ b/src/lib/reconciliation/tier-targets.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
+
+import { calculateTierTargets } from "./tier-targets";
+
+function makeAccount(
+  id: string,
+  tier: ReconciliationAccountTier,
+  targetFloat?: number,
+) {
+  return { id, name: `Account ${id}`, tier, targetFloat };
+}
+
+function makeExpense(
+  id: string,
+  type: ReconciliationExpenseType,
+  typicalAmount: number,
+) {
+  return { id, name: `Expense ${id}`, type, typicalAmount };
+}
+
+describe("calculateTierTargets — short-term target", () => {
+  it("includes the targetFloat of all short-term accounts", () => {
+    const result = calculateTierTargets({
+      accounts: [
+        makeAccount("a1", ReconciliationAccountTier.ShortTerm, 1000),
+        makeAccount("a2", ReconciliationAccountTier.ShortTerm, 500),
+      ],
+      expenseAmounts: {},
+      expenses: [],
+      totalCash: 10000,
+    });
+    expect(result.shortTerm).toBe(1500);
+  });
+
+  it("adds StatementBalance expense amounts to the short-term target", () => {
+    const result = calculateTierTargets({
+      accounts: [makeAccount("a1", ReconciliationAccountTier.ShortTerm, 0)],
+      expenseAmounts: { e1: 120, e2: 80 },
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.StatementBalance, 100),
+        makeExpense("e2", ReconciliationExpenseType.StatementBalance, 90),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.shortTerm).toBe(200);
+  });
+
+  it("falls back to typicalAmount when expenseAmount is undefined for StatementBalance", () => {
+    const result = calculateTierTargets({
+      accounts: [],
+      expenseAmounts: {},
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.StatementBalance, 150),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.shortTerm).toBe(150);
+  });
+
+  it("does not include RunningBalance expenses in the short-term target", () => {
+    const result = calculateTierTargets({
+      accounts: [],
+      expenseAmounts: { e1: 500 },
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.RunningBalance, 500),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.shortTerm).toBe(0);
+  });
+
+  it("treats a missing targetFloat on a short-term account as zero", () => {
+    const result = calculateTierTargets({
+      accounts: [makeAccount("a1", ReconciliationAccountTier.ShortTerm)],
+      expenseAmounts: {},
+      expenses: [],
+      totalCash: 10000,
+    });
+    expect(result.shortTerm).toBe(0);
+  });
+});
+
+describe("calculateTierTargets — reserve target", () => {
+  it("includes the targetFloat of all reserve accounts", () => {
+    const result = calculateTierTargets({
+      accounts: [
+        makeAccount("a1", ReconciliationAccountTier.Reserve, 3000),
+        makeAccount("a2", ReconciliationAccountTier.Reserve, 2000),
+      ],
+      expenseAmounts: {},
+      expenses: [],
+      totalCash: 10000,
+    });
+    expect(result.reserve).toBe(5000);
+  });
+
+  it("adds RunningBalance expense amounts to the reserve target", () => {
+    const result = calculateTierTargets({
+      accounts: [makeAccount("a1", ReconciliationAccountTier.Reserve, 0)],
+      expenseAmounts: { e1: 800, e2: 400 },
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.RunningBalance, 850),
+        makeExpense("e2", ReconciliationExpenseType.RunningBalance, 420),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.reserve).toBe(1200);
+  });
+
+  it("falls back to typicalAmount when expenseAmount is undefined for RunningBalance", () => {
+    const result = calculateTierTargets({
+      accounts: [],
+      expenseAmounts: {},
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.RunningBalance, 600),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.reserve).toBe(600);
+  });
+
+  it("does not include StatementBalance expenses in the reserve target", () => {
+    const result = calculateTierTargets({
+      accounts: [],
+      expenseAmounts: { e1: 120 },
+      expenses: [
+        makeExpense("e1", ReconciliationExpenseType.StatementBalance, 120),
+      ],
+      totalCash: 10000,
+    });
+    expect(result.reserve).toBe(0);
+  });
+});
+
+describe("calculateTierTargets — long-term target", () => {
+  it("is totalCash minus short-term and reserve targets", () => {
+    const result = calculateTierTargets({
+      accounts: [
+        makeAccount("a1", ReconciliationAccountTier.ShortTerm, 1000),
+        makeAccount("a2", ReconciliationAccountTier.Reserve, 3000),
+      ],
+      expenseAmounts: {},
+      expenses: [],
+      totalCash: 10000,
+    });
+    expect(result.longTerm).toBe(6000);
+  });
+
+  it("is the full totalCash when no short-term or reserve accounts or expenses exist", () => {
+    const result = calculateTierTargets({
+      accounts: [],
+      expenseAmounts: {},
+      expenses: [],
+      totalCash: 5000,
+    });
+    expect(result.longTerm).toBe(5000);
+  });
+});

--- a/src/lib/reconciliation/tier-targets.ts
+++ b/src/lib/reconciliation/tier-targets.ts
@@ -1,0 +1,58 @@
+import {
+  ReconciliationAccount,
+  ReconciliationAccountTier,
+} from "@/lib/firebase/schema/reconciliation-accounts";
+import {
+  ReconciliationExpense,
+  ReconciliationExpenseType,
+} from "@/lib/firebase/schema/reconciliation-expenses";
+
+export interface TierTargetInputs {
+  accounts: ReconciliationAccount[];
+  expenseAmounts: Record<string, number | undefined>;
+  expenses: ReconciliationExpense[];
+  totalCash: number;
+}
+
+export interface TierTargets {
+  longTerm: number;
+  reserve: number;
+  shortTerm: number;
+}
+
+/**
+ * Calculates the target balance for each cash account tier:
+ *  - Short-term: sum of ShortTerm account targetFloats + StatementBalance expense amounts
+ *  - Reserve: sum of Reserve account targetFloats + RunningBalance expense amounts
+ *  - Long-term: totalCash − shortTerm − reserve (the remainder)
+ *
+ * For expenses, uses the entered expenseAmount when available, falling back to typicalAmount.
+ */
+export function calculateTierTargets({
+  accounts,
+  expenseAmounts,
+  expenses,
+  totalCash,
+}: TierTargetInputs): TierTargets {
+  const shortTermFloat = accounts
+    .filter((a) => a.tier === ReconciliationAccountTier.ShortTerm)
+    .reduce((sum, a) => sum + (a.targetFloat ?? 0), 0);
+
+  const reserveFloat = accounts
+    .filter((a) => a.tier === ReconciliationAccountTier.Reserve)
+    .reduce((sum, a) => sum + (a.targetFloat ?? 0), 0);
+
+  const statementBillsTotal = expenses
+    .filter((e) => e.type === ReconciliationExpenseType.StatementBalance)
+    .reduce((sum, e) => sum + (expenseAmounts[e.id] ?? e.typicalAmount), 0);
+
+  const runningBillsTotal = expenses
+    .filter((e) => e.type === ReconciliationExpenseType.RunningBalance)
+    .reduce((sum, e) => sum + (expenseAmounts[e.id] ?? e.typicalAmount), 0);
+
+  const shortTerm = shortTermFloat + statementBillsTotal;
+  const reserve = reserveFloat + runningBillsTotal;
+  const longTerm = totalCash - shortTerm - reserve;
+
+  return { longTerm, reserve, shortTerm };
+}


### PR DESCRIPTION
Adds `calculateTierTargets`, a pure utility function in `src/lib/reconciliation/` that computes how much cash should live in each account tier based on the account configuration and entered expense amounts.

The short-term target covers the sum of ShortTerm account float targets plus all `StatementBalance` expense amounts (bills to pay now). The reserve target covers Reserve account floats plus `RunningBalance` expenses (upcoming projected bills). The long-term target is the remainder of total cash after the first two tiers are funded. Expense amounts fall back to `typicalAmount` when not yet entered.

## Acceptance Criteria
- [x] Short-term target = sum of ShortTerm `targetFloat` + `StatementBalance` expense amounts
- [x] Reserve target = sum of Reserve `targetFloat` + `RunningBalance` expense amounts
- [x] Long-term target = totalCash − short-term − reserve (the remainder)
- [x] Falls back to `typicalAmount` when no user-entered amount is provided for an expense
- [x] Accounts without `targetFloat` contribute 0 to their tier's float total

## Tests
11 tests added, all passing.

Closes #191

---
*Created by Claude Sonnet 4.5*