### PR TITLE
feat(reconcile): surface adjusted investment recommendation after monthly contributions

### DIFF
--- a/src/lib/reconciliation/investment-recommendation.spec.ts
+++ b/src/lib/reconciliation/investment-recommendation.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateAdjustedInvestmentRecommendation } from "./investment-recommendation";
+
+describe("calculateAdjustedInvestmentRecommendation — remaining amount to invest", () => {
+  it("returns gross minus already-invested when already-invested is less than gross", () => {
+    expect(
+      calculateAdjustedInvestmentRecommendation({
+        alreadyInvestedThisMonth: 300,
+        grossRecommendation: 1200,
+      }),
+    ).toBe(900);
+  });
+
+  it("returns zero when already-invested equals the gross recommendation", () => {
+    expect(
+      calculateAdjustedInvestmentRecommendation({
+        alreadyInvestedThisMonth: 1200,
+        grossRecommendation: 1200,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns zero when already-invested exceeds the gross recommendation", () => {
+    expect(
+      calculateAdjustedInvestmentRecommendation({
+        alreadyInvestedThisMonth: 1500,
+        grossRecommendation: 1200,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns the full gross recommendation when nothing has been invested yet", () => {
+    expect(
+      calculateAdjustedInvestmentRecommendation({
+        alreadyInvestedThisMonth: 0,
+        grossRecommendation: 800,
+      }),
+    ).toBe(800);
+  });
+
+  it("returns zero when the gross recommendation is zero", () => {
+    expect(
+      calculateAdjustedInvestmentRecommendation({
+        alreadyInvestedThisMonth: 0,
+        grossRecommendation: 0,
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/lib/reconciliation/investment-recommendation.ts
+++ b/src/lib/reconciliation/investment-recommendation.ts
@@ -1,0 +1,18 @@
+export interface AdjustedInvestmentRecommendationInputs {
+  alreadyInvestedThisMonth: number;
+  grossRecommendation: number;
+}
+
+/**
+ * Returns how much of the gross investment recommendation still needs to be
+ * invested this month, after subtracting contributions already made.
+ *
+ * Never returns a negative value — if more has been invested than recommended,
+ * the adjusted recommendation is 0 (not a signal to withdraw).
+ */
+export function calculateAdjustedInvestmentRecommendation({
+  alreadyInvestedThisMonth,
+  grossRecommendation,
+}: AdjustedInvestmentRecommendationInputs): number {
+  return Math.max(0, grossRecommendation - alreadyInvestedThisMonth);
+}


### PR DESCRIPTION
Adds `calculateAdjustedInvestmentRecommendation`, a single-purpose pure utility that subtracts already-invested-this-month contributions from the gross investment recommendation to produce the amount still remaining to invest. If more has already been invested than the gross recommendation the result is clamped to zero — exceeding the recommendation is not a signal to withdraw.

## Acceptance Criteria
- [x] Returns gross − already-invested when already-invested < gross
- [x] Returns 0 when already-invested equals the gross recommendation
- [x] Returns 0 when already-invested exceeds the gross recommendation (never negative)
- [x] Returns the full gross recommendation when nothing has been invested yet

## Tests
5 tests added, all passing.

Closes #193

---
*Created by Claude Sonnet 4.5*