### PR TITLE
test(reconcile): add above-cap ledger test for calculateLedgerDeposits

### DIFF
--- a/src/lib/reconciliation/ledger-deposits.spec.ts
+++ b/src/lib/reconciliation/ledger-deposits.spec.ts
@@ -27,6 +27,14 @@ describe("calculateLedgerDeposits — single ledger", () => {
     expect(deposits).toEqual([]);
   });
 
+  it("excludes a ledger whose balance exceeds its cap", () => {
+    const deposits = calculateLedgerDeposits({
+      ledgers: [{ cashBalance: 1200, cashCap: 1000, id: "ledger-1" }],
+      unallocatedCash: 500,
+    });
+    expect(deposits).toEqual([]);
+  });
+
   it("excludes a ledger without a cashCap", () => {
     const deposits = calculateLedgerDeposits({
       ledgers: [{ cashBalance: 0, cashCap: undefined, id: "ledger-1" }],


### PR DESCRIPTION
Adds a test for the `cashBalance > cashCap` case in `calculateLedgerDeposits`. The implementation correctly handles this via `Math.max(0, ledger.cashCap - ledger.cashBalance)`, which produces `needed = 0` and skips the ledger — but the existing test suite only covered `cashBalance === cashCap`. This test makes the guard explicit so a future refactor that removes `Math.max` would be caught.

Closes #223

---
*Created by Claude Sonnet 4.5*