### PR TITLE
feat(reconcile): deposit split utility for cash/investment allocation

### DIFF
--- a/src/lib/reconciliation/deposit-split.spec.ts
+++ b/src/lib/reconciliation/deposit-split.spec.ts
@@ -13,6 +13,17 @@ describe("applyDepositSplit — no cash cap", () => {
     expect(result.cashBalance).toBe(600);
     expect(result.investmentBalance).toBe(0);
   });
+
+  it("preserves an existing investment balance when there is no cash cap", () => {
+    const result = applyDepositSplit({
+      cashBalance: 0,
+      cashCap: undefined,
+      depositAmount: 300,
+      investmentBalance: 150,
+    });
+    expect(result.cashBalance).toBe(300);
+    expect(result.investmentBalance).toBe(150);
+  });
 });
 
 describe("applyDepositSplit — cash below cap", () => {

--- a/src/lib/reconciliation/deposit-split.spec.ts
+++ b/src/lib/reconciliation/deposit-split.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { applyDepositSplit } from "./deposit-split";
+
+describe("applyDepositSplit — no cash cap", () => {
+  it("deposits entirely into cash when there is no cash cap", () => {
+    const result = applyDepositSplit({
+      cashBalance: 100,
+      cashCap: undefined,
+      depositAmount: 500,
+      investmentBalance: 0,
+    });
+    expect(result.cashBalance).toBe(600);
+    expect(result.investmentBalance).toBe(0);
+  });
+});
+
+describe("applyDepositSplit — cash below cap", () => {
+  it("deposits entirely into cash when the deposit fits within the remaining cap space", () => {
+    const result = applyDepositSplit({
+      cashBalance: 200,
+      cashCap: 1000,
+      depositAmount: 300,
+      investmentBalance: 0,
+    });
+    expect(result.cashBalance).toBe(500);
+    expect(result.investmentBalance).toBe(0);
+  });
+
+  it("fills cash to the cap and overflows the remainder into investment", () => {
+    const result = applyDepositSplit({
+      cashBalance: 700,
+      cashCap: 1000,
+      depositAmount: 500,
+      investmentBalance: 50,
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(250);
+  });
+
+  it("fills cash exactly to the cap with no overflow when the deposit matches the remaining space", () => {
+    const result = applyDepositSplit({
+      cashBalance: 600,
+      cashCap: 1000,
+      depositAmount: 400,
+      investmentBalance: 0,
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(0);
+  });
+});
+
+describe("applyDepositSplit — cash at or above cap", () => {
+  it("deposits entirely into investment when cash is already at the cap", () => {
+    const result = applyDepositSplit({
+      cashBalance: 1000,
+      cashCap: 1000,
+      depositAmount: 200,
+      investmentBalance: 100,
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(300);
+  });
+
+  it("deposits entirely into investment when cash already exceeds the cap", () => {
+    const result = applyDepositSplit({
+      cashBalance: 1200,
+      cashCap: 1000,
+      depositAmount: 150,
+      investmentBalance: 0,
+    });
+    expect(result.cashBalance).toBe(1200);
+    expect(result.investmentBalance).toBe(150);
+  });
+});

--- a/src/lib/reconciliation/deposit-split.ts
+++ b/src/lib/reconciliation/deposit-split.ts
@@ -1,0 +1,38 @@
+export interface DepositSplitInput {
+  cashBalance: number;
+  cashCap: number | undefined;
+  depositAmount: number;
+  investmentBalance: number;
+}
+
+export interface DepositSplitResult {
+  cashBalance: number;
+  investmentBalance: number;
+}
+
+/**
+ * Applies a deposit to a ledger's cash/investment balance split.
+ *
+ * When a cash cap is defined, deposits fill the cash portion up to the cap;
+ * any remainder overflows into the investment portion. When no cap is set,
+ * the entire deposit goes into cash.
+ */
+export function applyDepositSplit({
+  cashBalance,
+  cashCap,
+  depositAmount,
+  investmentBalance,
+}: DepositSplitInput): DepositSplitResult {
+  if (cashCap === undefined) {
+    return { cashBalance: cashBalance + depositAmount, investmentBalance };
+  }
+
+  const cashSpace = Math.max(0, cashCap - cashBalance);
+  const cashPortion = Math.min(depositAmount, cashSpace);
+  const investmentPortion = depositAmount - cashPortion;
+
+  return {
+    cashBalance: cashBalance + cashPortion,
+    investmentBalance: investmentBalance + investmentPortion,
+  };
+}


### PR DESCRIPTION
Adds `applyDepositSplit`, a pure utility that applies a single deposit to a ledger's cash/investment balance split. Deposits fill the cash portion up to the cash cap; any remainder overflows into the investment portion. When no cap is configured, the entire deposit accumulates in cash.

This is the foundational allocation logic for the cash/investment split feature. The expense deduction counterpart (cash-first deduction order) and the full balance computation from transaction history are follow-on steps.

## Acceptance Criteria
- [x] Deposits up to the remaining cash cap space go into the cash portion
- [x] Deposit amounts above the cap overflow into the investment portion
- [x] When cash is already at or above the cap, the entire deposit goes to investment
- [x] When no cash cap is set, the entire deposit goes to cash

## Tests
6 tests added, all passing.

Closes #216

---
*Created by Claude Sonnet 4.5*