### PR TITLE
feat(reconcile): expense deduction utility for cash-first deduction order

### DIFF
--- a/src/lib/reconciliation/expense-deduction.spec.ts
+++ b/src/lib/reconciliation/expense-deduction.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { applyExpenseDeduction } from "./expense-deduction";
+
+describe("applyExpenseDeduction — cash covers the expense", () => {
+  it("deducts entirely from cash when cash is sufficient", () => {
+    const result = applyExpenseDeduction({
+      cashBalance: 500,
+      expenseAmount: 200,
+      investmentBalance: 300,
+    });
+    expect(result.cashBalance).toBe(300);
+    expect(result.investmentBalance).toBe(300);
+  });
+
+  it("reduces cash to zero when the expense exactly matches the cash balance", () => {
+    const result = applyExpenseDeduction({
+      cashBalance: 400,
+      expenseAmount: 400,
+      investmentBalance: 100,
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(100);
+  });
+});
+
+describe("applyExpenseDeduction — expense exceeds cash", () => {
+  it("exhausts cash and deducts the remainder from investment", () => {
+    const result = applyExpenseDeduction({
+      cashBalance: 200,
+      expenseAmount: 350,
+      investmentBalance: 500,
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(350);
+  });
+
+  it("deducts entirely from investment when cash balance is zero", () => {
+    const result = applyExpenseDeduction({
+      cashBalance: 0,
+      expenseAmount: 150,
+      investmentBalance: 600,
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(450);
+  });
+});

--- a/src/lib/reconciliation/expense-deduction.ts
+++ b/src/lib/reconciliation/expense-deduction.ts
@@ -1,0 +1,30 @@
+export interface ExpenseDeductionInput {
+  cashBalance: number;
+  expenseAmount: number;
+  investmentBalance: number;
+}
+
+export interface ExpenseDeductionResult {
+  cashBalance: number;
+  investmentBalance: number;
+}
+
+/**
+ * Applies an expense deduction to a ledger's cash/investment balance split.
+ *
+ * Expenses draw from the cash portion first. When cash is exhausted, any
+ * remaining expense amount deducts from the investment portion.
+ */
+export function applyExpenseDeduction({
+  cashBalance,
+  expenseAmount,
+  investmentBalance,
+}: ExpenseDeductionInput): ExpenseDeductionResult {
+  const cashDeduction = Math.min(expenseAmount, cashBalance);
+  const investmentDeduction = expenseAmount - cashDeduction;
+
+  return {
+    cashBalance: cashBalance - cashDeduction,
+    investmentBalance: investmentBalance - investmentDeduction,
+  };
+}


### PR DESCRIPTION
Adds `applyExpenseDeduction`, a pure utility that applies a single expense to a ledger's cash/investment balance split. Expenses deduct from the cash portion first; when cash is exhausted, the remaining amount deducts from the investment portion.

This is the expense-side counterpart to `applyDepositSplit` (#216). Together these two utilities provide the building blocks for computing a ledger's running cash/investment balance from its full transaction history.

## Acceptance Criteria
- [x] Expenses deduct from the cash portion first
- [x] When cash is exhausted, the remaining expense amount deducts from investment
- [x] When cash balance is zero, the entire expense deducts from investment
- [x] When cash covers the full expense, investment balance is unchanged

## Tests
4 tests added, all passing.

Closes #217

---
*Created by Claude Sonnet 4.5*