### PR TITLE
feat(ledgers): compute cash/investment balance from transaction history

### DIFF
--- a/src/app/(app)/ledgers/[id]/page.tsx
+++ b/src/app/(app)/ledgers/[id]/page.tsx
@@ -21,6 +21,7 @@ import { useTransactions } from "@/hooks/use-transactions";
 import { useUpdateSavingsGoal } from "@/hooks/use-update-savings-goal";
 import { useUpdateTransaction } from "@/hooks/use-update-transaction";
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { calculateLedgerBalance } from "@/lib/reconciliation/ledger-balance";
 import type { Ledger, UpdateLedgerInput } from "@/lib/types";
 import { updateLedger } from "@/services/ledgers";
 import { createSavingsGoal } from "@/services/savings-goals";
@@ -54,7 +55,13 @@ export default function LedgerDetailPage() {
 
   const budgetLedger = ledgers.find((l) => l.id === id);
   const ledger: Ledger | undefined = budgetLedger
-    ? { ...budgetLedger, cashBalance: 0, investmentBalance: 0 }
+    ? {
+        ...budgetLedger,
+        ...calculateLedgerBalance({
+          cashCap: budgetLedger.cashCap,
+          transactions,
+        }),
+      }
     : undefined;
   const isLoading = authLoading || ledgersLoading || txLoading;
 

--- a/src/lib/reconciliation/ledger-balance.spec.ts
+++ b/src/lib/reconciliation/ledger-balance.spec.ts
@@ -114,4 +114,16 @@ describe("calculateLedgerBalance — mixed transactions", () => {
     expect(result.cashBalance).toBe(1000);
     expect(result.investmentBalance).toBe(300);
   });
+
+  it("applies deposits before expenses on the same day so the deposit funds the expense", () => {
+    // Deposit 500 and spend 200 on the same day (daysAgo = 0).
+    // Even though the expense appears first in the array, the deposit must be
+    // processed first so the expense can be deducted from the resulting balance.
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeExpense(200, 0), makeDeposit(500, 0)],
+    });
+    expect(result.cashBalance).toBe(300);
+    expect(result.investmentBalance).toBe(0);
+  });
 });

--- a/src/lib/reconciliation/ledger-balance.spec.ts
+++ b/src/lib/reconciliation/ledger-balance.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BudgetLedgerTransaction,
+  BudgetLedgerTransactionType,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { calculateLedgerBalance } from "./ledger-balance";
+
+function makeDeposit(amount: number, daysAgo = 0): BudgetLedgerTransaction {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return {
+    id: `deposit-${String(amount)}-${String(daysAgo)}`,
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Deposit,
+    date,
+    amount,
+    description: "deposit",
+  };
+}
+
+function makeExpense(amount: number, daysAgo = 0): BudgetLedgerTransaction {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return {
+    id: `expense-${String(amount)}-${String(daysAgo)}`,
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Expense,
+    date,
+    amount,
+    description: "expense",
+  };
+}
+
+describe("calculateLedgerBalance — no transactions", () => {
+  it("returns zero balances when there are no transactions", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [],
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(0);
+  });
+});
+
+describe("calculateLedgerBalance — deposits only", () => {
+  it("accumulates deposits into cash when total is below the cap", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeDeposit(300), makeDeposit(200)],
+    });
+    expect(result.cashBalance).toBe(500);
+    expect(result.investmentBalance).toBe(0);
+  });
+
+  it("fills cash to the cap and overflows the remainder into investment", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeDeposit(800), makeDeposit(400)],
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(200);
+  });
+
+  it("accumulates all deposits into cash when there is no cash cap", () => {
+    const result = calculateLedgerBalance({
+      cashCap: undefined,
+      transactions: [makeDeposit(500), makeDeposit(300)],
+    });
+    expect(result.cashBalance).toBe(800);
+    expect(result.investmentBalance).toBe(0);
+  });
+});
+
+describe("calculateLedgerBalance — expenses only", () => {
+  it("returns zero balances when expenses are applied to a zero balance", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeExpense(200)],
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(0);
+  });
+});
+
+describe("calculateLedgerBalance — mixed transactions", () => {
+  it("deducts expenses from cash before investment", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeDeposit(1500, 3), makeExpense(300, 2)],
+    });
+    expect(result.cashBalance).toBe(700);
+    expect(result.investmentBalance).toBe(500);
+  });
+
+  it("draws from investment when an expense exceeds the cash balance", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeDeposit(1500, 3), makeExpense(1200, 2)],
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(300);
+  });
+
+  it("processes transactions in chronological order", () => {
+    // Deposit 500 on day 2 (older), deposit 800 on day 1 (newer)
+    // With cap 1000: first 500 fills cash, then 500 of 800 fills cash to cap,
+    // remaining 300 goes to investment.
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      transactions: [makeDeposit(800, 1), makeDeposit(500, 2)],
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(300);
+  });
+});

--- a/src/lib/reconciliation/ledger-balance.ts
+++ b/src/lib/reconciliation/ledger-balance.ts
@@ -26,9 +26,23 @@ export function calculateLedgerBalance({
   cashCap,
   transactions,
 }: LedgerBalanceInput): LedgerBalanceResult {
-  const sorted = [...transactions].sort(
-    (a, b) => a.date.getTime() - b.date.getTime(),
-  );
+  const sorted = [...transactions].sort((a, b) => {
+    const dateDiff = a.date.getTime() - b.date.getTime();
+    if (dateDiff !== 0) return dateDiff;
+    // Same day: deposits before expenses so same-day deposits can fund same-day expenses
+    if (
+      a.type === BudgetLedgerTransactionType.Deposit &&
+      b.type === BudgetLedgerTransactionType.Expense
+    )
+      return -1;
+    if (
+      a.type === BudgetLedgerTransactionType.Expense &&
+      b.type === BudgetLedgerTransactionType.Deposit
+    )
+      return 1;
+    // Same type, same day: stable ordering by id
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
 
   return sorted.reduce<LedgerBalanceResult>(
     (balance, tx) => {

--- a/src/lib/reconciliation/ledger-balance.ts
+++ b/src/lib/reconciliation/ledger-balance.ts
@@ -1,0 +1,55 @@
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { applyDepositSplit } from "./deposit-split";
+import { applyExpenseDeduction } from "./expense-deduction";
+
+export interface LedgerBalanceInput {
+  cashCap: number | undefined;
+  transactions: BudgetLedgerTransaction[];
+}
+
+export interface LedgerBalanceResult {
+  cashBalance: number;
+  investmentBalance: number;
+}
+
+/**
+ * Computes the cash and investment balance of a ledger by replaying its
+ * transactions in chronological order.
+ *
+ * Deposits fill the cash portion up to the cash cap; any amount above the cap
+ * overflows into the investment portion. Expenses deduct from cash first; when
+ * cash is exhausted, the remainder deducts from investment.
+ */
+export function calculateLedgerBalance({
+  cashCap,
+  transactions,
+}: LedgerBalanceInput): LedgerBalanceResult {
+  const sorted = [...transactions].sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+
+  return sorted.reduce<LedgerBalanceResult>(
+    (balance, tx) => {
+      if (tx.type === BudgetLedgerTransactionType.Deposit) {
+        return applyDepositSplit({
+          cashBalance: balance.cashBalance,
+          cashCap,
+          depositAmount: tx.amount,
+          investmentBalance: balance.investmentBalance,
+        });
+      }
+      const next = applyExpenseDeduction({
+        cashBalance: balance.cashBalance,
+        expenseAmount: tx.amount,
+        investmentBalance: balance.investmentBalance,
+      });
+      return {
+        cashBalance: Math.max(0, next.cashBalance),
+        investmentBalance: Math.max(0, next.investmentBalance),
+      };
+    },
+    { cashBalance: 0, investmentBalance: 0 },
+  );
+}


### PR DESCRIPTION
Adds `calculateLedgerBalance`, which replays a ledger's transactions in chronological order to produce live `cashBalance` and `investmentBalance` values. Deposits fill cash up to the `cashCap`; overflow goes to investment. Expenses deduct from cash first, then investment. Balances are clamped to zero so they never go negative.

Replaces the placeholder `cashBalance: 0 / investmentBalance: 0` in `LedgerDetailPage` with a computed split derived from the already-fetched `transactions` array. The split breakdown already rendered in `LedgerDetailView` (the "Cash / Investment" card with percentages and dollar amounts) now shows real values instead of zeros.

## Acceptance Criteria
- [x] `cashBalance` and `investmentBalance` on the ledger detail page are computed from transactions
- [x] Deposits fill cash up to the cap; any amount over the cap goes to investment
- [x] Expenses draw from cash first; when cash is exhausted the remainder draws from investment
- [x] The ledger detail "Cash / Investment" card reflects live computed balances

## Tests
8 tests added for `calculateLedgerBalance`, all passing. Full suite (1134 tests) passes.

Closes #215

---
*Created by Claude Sonnet 4.5*