### PR TITLE
feat(reconcile): per-ledger monthly net investment target calculation

### DIFF
--- a/src/lib/reconciliation/monthly-investment-target.spec.ts
+++ b/src/lib/reconciliation/monthly-investment-target.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BudgetLedgerTransaction,
+  BudgetLedgerTransactionType,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { calculateMonthlyInvestmentTarget } from "./monthly-investment-target";
+
+function makeDeposit(amount: number, daysAgo = 0): BudgetLedgerTransaction {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return {
+    id: `deposit-${String(amount)}-${String(daysAgo)}`,
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Deposit,
+    date,
+    amount,
+    description: "deposit",
+  };
+}
+
+function makeExpense(amount: number, daysAgo = 0): BudgetLedgerTransaction {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return {
+    id: `expense-${String(amount)}-${String(daysAgo)}`,
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Expense,
+    date,
+    amount,
+    description: "expense",
+  };
+}
+
+describe("calculateMonthlyInvestmentTarget — no transactions", () => {
+  it("returns zero net when there are no transactions", () => {
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 200,
+      startingInvestmentBalance: 500,
+      transactions: [],
+    });
+    expect(result.netInvestmentTarget).toBe(0);
+  });
+});
+
+describe("calculateMonthlyInvestmentTarget — deposits only", () => {
+  it("returns zero net when deposits stay within the cash cap", () => {
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 0,
+      startingInvestmentBalance: 300,
+      transactions: [makeDeposit(400)],
+    });
+    expect(result.netInvestmentTarget).toBe(0);
+  });
+
+  it("returns positive net equal to overflow when deposits exceed the cap", () => {
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 0,
+      startingInvestmentBalance: 0,
+      transactions: [makeDeposit(1400)],
+    });
+    expect(result.netInvestmentTarget).toBe(400);
+  });
+
+  it("returns zero net when there is no cash cap (all deposits go to cash)", () => {
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: undefined,
+      startingCashBalance: 0,
+      startingInvestmentBalance: 150,
+      transactions: [makeDeposit(600)],
+    });
+    expect(result.netInvestmentTarget).toBe(0);
+  });
+
+  it("accounts for existing cash balance when computing cap overflow", () => {
+    // Cash is already 800 of 1000 cap; a 400 deposit puts 200 to cash and 200 to investment
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 800,
+      startingInvestmentBalance: 0,
+      transactions: [makeDeposit(400)],
+    });
+    expect(result.netInvestmentTarget).toBe(200);
+  });
+});
+
+describe("calculateMonthlyInvestmentTarget — expenses only", () => {
+  it("returns zero net when expenses are covered by cash", () => {
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 500,
+      startingInvestmentBalance: 300,
+      transactions: [makeExpense(200)],
+    });
+    expect(result.netInvestmentTarget).toBe(0);
+  });
+
+  it("returns negative net when expenses draw from investment", () => {
+    // Cash covers 100; remaining 150 drawn from investment
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 100,
+      startingInvestmentBalance: 400,
+      transactions: [makeExpense(250)],
+    });
+    expect(result.netInvestmentTarget).toBe(-150);
+  });
+});
+
+describe("calculateMonthlyInvestmentTarget — mixed transactions", () => {
+  it("returns net combining investment gains and draws across transactions", () => {
+    // Deposit 1500 from 0 cash (1000 to cash at cap, 500 to investment)
+    // Then expense 300 (covered by cash, no investment draw)
+    // Net investment = +500
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 0,
+      startingInvestmentBalance: 0,
+      transactions: [makeDeposit(1500, 2), makeExpense(300, 1)],
+    });
+    expect(result.netInvestmentTarget).toBe(500);
+  });
+});

--- a/src/lib/reconciliation/monthly-investment-target.spec.ts
+++ b/src/lib/reconciliation/monthly-investment-target.spec.ts
@@ -109,6 +109,18 @@ describe("calculateMonthlyInvestmentTarget — expenses only", () => {
     });
     expect(result.netInvestmentTarget).toBe(-150);
   });
+
+  it("clamps investment balance to zero when expense exceeds all available funds", () => {
+    // 50 cash + 200 investment = 250 total; expense of 400 exhausts everything
+    // Net investment target = 0 - 200 = -200 (full starting investment drawn and clamped)
+    const result = calculateMonthlyInvestmentTarget({
+      cashCap: 1000,
+      startingCashBalance: 50,
+      startingInvestmentBalance: 200,
+      transactions: [makeExpense(400)],
+    });
+    expect(result.netInvestmentTarget).toBe(-200);
+  });
 });
 
 describe("calculateMonthlyInvestmentTarget — mixed transactions", () => {

--- a/src/lib/reconciliation/monthly-investment-target.ts
+++ b/src/lib/reconciliation/monthly-investment-target.ts
@@ -1,0 +1,82 @@
+import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+
+import { applyDepositSplit } from "./deposit-split";
+import { applyExpenseDeduction } from "./expense-deduction";
+
+export interface MonthlyInvestmentTargetInput {
+  cashCap: number | undefined;
+  startingCashBalance: number;
+  startingInvestmentBalance: number;
+  transactions: BudgetLedgerTransaction[];
+}
+
+export interface MonthlyInvestmentTargetResult {
+  netInvestmentTarget: number;
+}
+
+/**
+ * Computes the net investment buy/sell target for a single ledger over a
+ * given period by replaying its transactions from the provided starting balances.
+ *
+ * A positive result means the investment portion grew (buy signal); a negative
+ * result means the investment portion shrank (sell signal). The caller is
+ * responsible for passing only the transactions that fall within the period of
+ * interest (e.g. a single calendar month).
+ *
+ * Deposit overflow: deposits fill cash up to the cap; any remainder goes to
+ * investment. Expense shortfall: expenses draw from cash first; when cash is
+ * exhausted the remainder deducts from investment. Balances are clamped to zero.
+ */
+export function calculateMonthlyInvestmentTarget({
+  cashCap,
+  startingCashBalance,
+  startingInvestmentBalance,
+  transactions,
+}: MonthlyInvestmentTargetInput): MonthlyInvestmentTargetResult {
+  const sorted = [...transactions].sort((a, b) => {
+    const dateDiff = a.date.getTime() - b.date.getTime();
+    if (dateDiff !== 0) return dateDiff;
+    if (
+      a.type === BudgetLedgerTransactionType.Deposit &&
+      b.type === BudgetLedgerTransactionType.Expense
+    )
+      return -1;
+    if (
+      a.type === BudgetLedgerTransactionType.Expense &&
+      b.type === BudgetLedgerTransactionType.Deposit
+    )
+      return 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const ending = sorted.reduce(
+    (balance, tx) => {
+      if (tx.type === BudgetLedgerTransactionType.Deposit) {
+        return applyDepositSplit({
+          cashBalance: balance.cashBalance,
+          cashCap,
+          depositAmount: tx.amount,
+          investmentBalance: balance.investmentBalance,
+        });
+      }
+      const next = applyExpenseDeduction({
+        cashBalance: balance.cashBalance,
+        expenseAmount: tx.amount,
+        investmentBalance: balance.investmentBalance,
+      });
+      return {
+        cashBalance: Math.max(0, next.cashBalance),
+        investmentBalance: Math.max(0, next.investmentBalance),
+      };
+    },
+    {
+      cashBalance: startingCashBalance,
+      investmentBalance: startingInvestmentBalance,
+    },
+  );
+
+  return {
+    netInvestmentTarget: ending.investmentBalance - startingInvestmentBalance,
+  };
+}


### PR DESCRIPTION
Adds `calculateMonthlyInvestmentTarget`, a pure utility that computes the net investment buy or sell signal for a single budget ledger over a given period.

The function accepts the ledger's starting cash and investment balances, its cash cap, and the period's transactions. It replays transactions in chronological order (deposits before expenses on the same day for consistent tie-breaking) using the existing `applyDepositSplit` and `applyExpenseDeduction` primitives. The delta between ending and starting investment balance is the net target: positive means more was allocated to investment (buy signal), negative means investment was drawn down (sell signal).

## Acceptance Criteria
- [x] Returns 0 when there are no transactions
- [x] Returns 0 when deposits stay within the cash cap (all goes to cash)
- [x] Returns positive net equal to cap overflow when deposits exceed the cap
- [x] Returns 0 when expenses are covered by cash (no investment drawn)
- [x] Returns negative net when expenses draw from investment
- [x] Correctly handles non-zero starting balances (computes a delta, not absolute)

## Tests
8 tests added, all passing.

Closes #212

---
*Created by Claude Sonnet 4.6*