### PR TITLE
feat(reconcile): aggregate per-ledger investment targets by account

### DIFF
--- a/src/lib/reconciliation/aggregate-investment-targets.spec.ts
+++ b/src/lib/reconciliation/aggregate-investment-targets.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateMonthlyInvestmentTargets } from "./aggregate-investment-targets";
+
+describe("aggregateMonthlyInvestmentTargets — no targets", () => {
+  it("returns an empty array when there are no ledger targets", () => {
+    const result = aggregateMonthlyInvestmentTargets([]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("aggregateMonthlyInvestmentTargets — single account", () => {
+  it("returns a single transaction for a single ledger target", () => {
+    const result = aggregateMonthlyInvestmentTargets([
+      { accountId: "acct-1", netInvestmentTarget: 400 },
+    ]);
+    expect(result).toEqual([
+      { accountId: "acct-1", netTransactionAmount: 400 },
+    ]);
+  });
+
+  it("sums multiple ledger targets belonging to the same account", () => {
+    const result = aggregateMonthlyInvestmentTargets([
+      { accountId: "acct-1", netInvestmentTarget: 300 },
+      { accountId: "acct-1", netInvestmentTarget: 200 },
+    ]);
+    expect(result).toEqual([
+      { accountId: "acct-1", netTransactionAmount: 500 },
+    ]);
+  });
+
+  it("produces a net result when targets include both positive and negative values", () => {
+    // Buy signal +500, sell signal -150 → net buy of 350
+    const result = aggregateMonthlyInvestmentTargets([
+      { accountId: "acct-1", netInvestmentTarget: 500 },
+      { accountId: "acct-1", netInvestmentTarget: -150 },
+    ]);
+    expect(result).toEqual([
+      { accountId: "acct-1", netTransactionAmount: 350 },
+    ]);
+  });
+});
+
+describe("aggregateMonthlyInvestmentTargets — multiple accounts", () => {
+  it("returns one transaction per account when ledgers map to different accounts", () => {
+    const result = aggregateMonthlyInvestmentTargets([
+      { accountId: "acct-1", netInvestmentTarget: 400 },
+      { accountId: "acct-2", netInvestmentTarget: 250 },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      accountId: "acct-1",
+      netTransactionAmount: 400,
+    });
+    expect(result).toContainEqual({
+      accountId: "acct-2",
+      netTransactionAmount: 250,
+    });
+  });
+
+  it("sums independently for each account when multiple ledgers share each account", () => {
+    const result = aggregateMonthlyInvestmentTargets([
+      { accountId: "acct-1", netInvestmentTarget: 300 },
+      { accountId: "acct-2", netInvestmentTarget: 100 },
+      { accountId: "acct-1", netInvestmentTarget: 200 },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      accountId: "acct-1",
+      netTransactionAmount: 500,
+    });
+    expect(result).toContainEqual({
+      accountId: "acct-2",
+      netTransactionAmount: 100,
+    });
+  });
+});

--- a/src/lib/reconciliation/aggregate-investment-targets.ts
+++ b/src/lib/reconciliation/aggregate-investment-targets.ts
@@ -1,0 +1,35 @@
+export interface LedgerAccountTarget {
+  accountId: string;
+  netInvestmentTarget: number;
+}
+
+export interface AccountMonthlyTransaction {
+  accountId: string;
+  netTransactionAmount: number;
+}
+
+/**
+ * Aggregates per-ledger monthly net investment targets into a single net
+ * transaction per investment account.
+ *
+ * Each entry in `targets` provides the net buy/sell signal (positive = buy,
+ * negative = sell) computed for one budget ledger and its associated investment
+ * account. This function groups entries by `accountId` and sums the targets,
+ * returning one `AccountMonthlyTransaction` per account.
+ */
+export function aggregateMonthlyInvestmentTargets(
+  targets: LedgerAccountTarget[],
+): AccountMonthlyTransaction[] {
+  const totals = new Map<string, number>();
+
+  for (const { accountId, netInvestmentTarget } of targets) {
+    totals.set(accountId, (totals.get(accountId) ?? 0) + netInvestmentTarget);
+  }
+
+  return Array.from(totals.entries()).map(
+    ([accountId, netTransactionAmount]) => ({
+      accountId,
+      netTransactionAmount,
+    }),
+  );
+}


### PR DESCRIPTION
Adds `aggregateMonthlyInvestmentTargets`, a pure utility that groups per-ledger net investment targets by investment account and sums them into a single net transaction per account.

The function accepts a list of `{ accountId, netInvestmentTarget }` entries — each representing one budget ledger's monthly net investment signal (as produced by `calculateMonthlyInvestmentTarget` from #212) and its associated investment account. It groups by `accountId` and sums the targets, returning one `AccountMonthlyTransaction` per account. The account-to-ledger mapping is the caller's responsibility, decoupling this aggregation utility from the not-yet-wired investment account schema.

## Acceptance Criteria
- [x] Returns an empty array when there are no ledger targets
- [x] Returns a single transaction for a single ledger target
- [x] Sums multiple ledger targets belonging to the same account
- [x] Returns one transaction per account when ledgers map to different accounts
- [x] Sums independently for each account when multiple ledgers share each account
- [x] Nets positive and negative targets for the same account

## Tests
6 tests added, all passing.

Closes #213

---
*Created by Claude Sonnet 4.6*