### PR TITLE
feat(reconcile): investment margin calculation

### DIFF
--- a/src/lib/reconciliation/investment-margin.spec.ts
+++ b/src/lib/reconciliation/investment-margin.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateInvestmentMargin } from "./investment-margin";
+
+describe("calculateInvestmentMargin — empty inputs", () => {
+  it("returns zero margin when both account snapshots and ledger portions are empty", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [],
+      ledgerInvestmentPortions: [],
+    });
+    expect(result.margin).toBe(0);
+  });
+});
+
+describe("calculateInvestmentMargin — accounts only", () => {
+  it("returns a positive margin equal to total account balances when there are no ledger portions", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [
+        { accountId: "acct-1", balance: 5000 },
+        { accountId: "acct-2", balance: 3000 },
+      ],
+      ledgerInvestmentPortions: [],
+    });
+    expect(result.margin).toBe(8000);
+  });
+});
+
+describe("calculateInvestmentMargin — ledger portions only", () => {
+  it("returns a negative margin equal to total ledger portions when there are no account balances", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [],
+      ledgerInvestmentPortions: [
+        { ledgerId: "ledger-1", investmentBalance: 2000 },
+        { ledgerId: "ledger-2", investmentBalance: 1500 },
+      ],
+    });
+    expect(result.margin).toBe(-3500);
+  });
+});
+
+describe("calculateInvestmentMargin — mixed", () => {
+  it("returns zero when total account balances exactly match total ledger portions", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [{ accountId: "acct-1", balance: 4000 }],
+      ledgerInvestmentPortions: [
+        { ledgerId: "ledger-1", investmentBalance: 2500 },
+        { ledgerId: "ledger-2", investmentBalance: 1500 },
+      ],
+    });
+    expect(result.margin).toBe(0);
+  });
+
+  it("returns a positive margin when accounts exceed ledger portions", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [{ accountId: "acct-1", balance: 6000 }],
+      ledgerInvestmentPortions: [
+        { ledgerId: "ledger-1", investmentBalance: 4000 },
+      ],
+    });
+    expect(result.margin).toBe(2000);
+  });
+
+  it("returns a negative margin when ledger portions exceed account balances", () => {
+    const result = calculateInvestmentMargin({
+      accountSnapshots: [{ accountId: "acct-1", balance: 3000 }],
+      ledgerInvestmentPortions: [
+        { ledgerId: "ledger-1", investmentBalance: 5000 },
+      ],
+    });
+    expect(result.margin).toBe(-2000);
+  });
+});

--- a/src/lib/reconciliation/investment-margin.ts
+++ b/src/lib/reconciliation/investment-margin.ts
@@ -1,0 +1,42 @@
+export interface AccountSnapshot {
+  accountId: string;
+  balance: number;
+}
+
+export interface LedgerInvestmentPortion {
+  investmentBalance: number;
+  ledgerId: string;
+}
+
+export interface InvestmentMarginInput {
+  accountSnapshots: AccountSnapshot[];
+  ledgerInvestmentPortions: LedgerInvestmentPortion[];
+}
+
+export interface InvestmentMarginResult {
+  margin: number;
+}
+
+/**
+ * Calculates the investment margin: the difference between the sum of actual
+ * investment account balance snapshots and the sum of theoretical investment
+ * portions implied by budget ledger balances.
+ *
+ * A positive margin means actual investments exceed the theoretical amount
+ * (user is ahead of target). A negative margin means actual investments fall
+ * short of the theoretical amount (user is behind target).
+ */
+export function calculateInvestmentMargin({
+  accountSnapshots,
+  ledgerInvestmentPortions,
+}: InvestmentMarginInput): InvestmentMarginResult {
+  const totalAccountBalance = accountSnapshots.reduce(
+    (sum, s) => sum + s.balance,
+    0,
+  );
+  const totalLedgerPortions = ledgerInvestmentPortions.reduce(
+    (sum, l) => sum + l.investmentBalance,
+    0,
+  );
+  return { margin: totalAccountBalance - totalLedgerPortions };
+}


### PR DESCRIPTION
Adds `calculateInvestmentMargin`, a pure utility that computes the difference between the sum of actual investment account balance snapshots and the sum of theoretical investment portions implied by budget ledger balances.

A positive margin means actual investments exceed the theoretical amount (user is ahead of target). A negative margin means actual investments fall short of the theoretical amount (user is behind target). This margin feeds downstream into the posture-adjusted investment recommendation (#210).

## Acceptance Criteria
- [x] Returns zero margin when both inputs are empty
- [x] Returns a positive margin equal to total account balances when there are no ledger portions
- [x] Returns a negative margin equal to total ledger portions when there are no account balances
- [x] Returns zero when accounts exactly match ledger portions
- [x] Returns positive margin when accounts exceed ledger portions
- [x] Returns negative margin when ledger portions exceed accounts

## Tests
6 tests added, all passing.

Closes #208

---
*Created by Claude Sonnet 4.6*