### PR TITLE
feat(reconcile): posture-adjusted investment recommendation

### DIFF
--- a/src/lib/reconciliation/posture-recommendation.spec.ts
+++ b/src/lib/reconciliation/posture-recommendation.spec.ts
@@ -172,3 +172,35 @@ describe("applyPostureAdjustment — Conservative posture", () => {
     ).toBe(-300);
   });
 });
+
+describe("applyPostureAdjustment — zero base recommendation", () => {
+  it("returns zero for Aggressive posture regardless of margin", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 0,
+        margin: 500,
+        posture: Posture.Aggressive,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns zero for Balanced posture regardless of margin", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 0,
+        margin: -200,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns zero for Conservative posture regardless of margin", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 0,
+        margin: 300,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/lib/reconciliation/posture-recommendation.spec.ts
+++ b/src/lib/reconciliation/posture-recommendation.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { Posture } from "@/lib/firebase/schema/investments";
+
+import { applyPostureAdjustment } from "./posture-recommendation";
+
+describe("applyPostureAdjustment — Aggressive posture", () => {
+  it("returns buy recommendation unchanged when margin is positive", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: 200,
+        posture: Posture.Aggressive,
+      }),
+    ).toBe(500);
+  });
+
+  it("returns buy recommendation unchanged when margin is negative", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: -200,
+        posture: Posture.Aggressive,
+      }),
+    ).toBe(500);
+  });
+
+  it("returns sell recommendation unchanged when margin is negative", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: -100,
+        posture: Posture.Aggressive,
+      }),
+    ).toBe(-300);
+  });
+
+  it("returns sell recommendation unchanged when margin is positive", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: 100,
+        posture: Posture.Aggressive,
+      }),
+    ).toBe(-300);
+  });
+});
+
+describe("applyPostureAdjustment — Balanced posture", () => {
+  it("reduces buy recommendation by positive margin", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: 200,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(300);
+  });
+
+  it("clamps buy recommendation to zero when margin exceeds it", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 150,
+        margin: 400,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(0);
+  });
+
+  it("leaves buy recommendation unchanged when margin is negative", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: -200,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(500);
+  });
+
+  it("leaves buy recommendation unchanged when margin is zero", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: 0,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(500);
+  });
+
+  it("reduces sell recommendation when margin is negative", () => {
+    // sell -300, margin -100: -300 - (-100) = -200 → min(0, -200) = -200
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: -100,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(-200);
+  });
+
+  it("clamps sell recommendation to zero when negative margin exceeds it", () => {
+    // sell -50, margin -200: -50 - (-200) = 150 → min(0, 150) = 0
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -50,
+        margin: -200,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(0);
+  });
+
+  it("leaves sell recommendation unchanged when margin is positive", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: 100,
+        posture: Posture.Balanced,
+      }),
+    ).toBe(-300);
+  });
+});
+
+describe("applyPostureAdjustment — Conservative posture", () => {
+  it("reduces buy recommendation by positive margin", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: 200,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(300);
+  });
+
+  it("clamps buy recommendation to zero when margin exceeds it", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 150,
+        margin: 400,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(0);
+  });
+
+  it("leaves buy recommendation unchanged when margin is negative", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: 500,
+        margin: -200,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(500);
+  });
+
+  it("leaves sell recommendation unchanged when margin is negative", () => {
+    // Conservative never offsets sells — always full sell amount
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: -100,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(-300);
+  });
+
+  it("leaves sell recommendation unchanged when margin is positive", () => {
+    expect(
+      applyPostureAdjustment({
+        baseRecommendation: -300,
+        margin: 100,
+        posture: Posture.Conservative,
+      }),
+    ).toBe(-300);
+  });
+});

--- a/src/lib/reconciliation/posture-recommendation.ts
+++ b/src/lib/reconciliation/posture-recommendation.ts
@@ -1,0 +1,42 @@
+import { Posture } from "@/lib/firebase/schema/investments";
+
+export interface PostureRecommendationInput {
+  baseRecommendation: number;
+  margin: number;
+  posture: Posture;
+}
+
+/**
+ * Adjusts a base monthly investment recommendation according to the user's
+ * selected reconciliation posture and the current investment margin.
+ *
+ * Posture rules:
+ * - Aggressive: always return the base recommendation unchanged.
+ * - Balanced: offset buy recommendations by positive margin (user is ahead);
+ *   offset sell recommendations by negative margin (user is behind).
+ * - Conservative: offset buy recommendations by positive margin;
+ *   sell recommendations are always returned at the full base amount.
+ *
+ * A positive return value signals a buy; a negative value signals a sell.
+ */
+export function applyPostureAdjustment({
+  baseRecommendation,
+  margin,
+  posture,
+}: PostureRecommendationInput): number {
+  if (posture === Posture.Aggressive) {
+    return baseRecommendation;
+  }
+
+  if (baseRecommendation > 0 && margin > 0) {
+    // Both Balanced and Conservative offset buy recommendations by positive margin
+    return Math.max(0, baseRecommendation - margin);
+  }
+
+  if (baseRecommendation < 0 && margin < 0 && posture === Posture.Balanced) {
+    // Only Balanced offsets sell recommendations by negative margin
+    return Math.min(0, baseRecommendation - margin);
+  }
+
+  return baseRecommendation;
+}


### PR DESCRIPTION
Adds `applyPostureAdjustment`, a pure utility that adjusts a base monthly investment recommendation according to the user's selected reconciliation posture and the current investment margin.

The three postures behave as follows: Aggressive always returns the base recommendation unchanged. Balanced offsets buy recommendations by positive margin (user is ahead, so buy less) and offsets sell recommendations by negative margin (user is behind, so sell less). Conservative offsets buy recommendations by positive margin but always returns the full sell amount regardless of margin.

The function feeds downstream into the final per-account investment recommendation (#211).

## Acceptance Criteria
- [x] Aggressive posture returns base recommendation unchanged for any margin
- [x] Balanced posture reduces buy recommendation by positive margin, floored at 0
- [x] Balanced posture leaves buy recommendation unchanged when margin is non-positive
- [x] Balanced posture reduces sell recommendation by negative margin, clamped at 0
- [x] Balanced posture leaves sell recommendation unchanged when margin is non-negative
- [x] Conservative posture reduces buy recommendation by positive margin, floored at 0
- [x] Conservative posture leaves sell recommendation unchanged regardless of margin

## Tests
16 tests added, all passing.

Closes #210

---
*Created by Claude Sonnet 4.7*