### PR TITLE
feat(reconcile): user setting for reconciliation posture

### DIFF
--- a/src/hooks/use-reconciliation-posture.spec.ts
+++ b/src/hooks/use-reconciliation-posture.spec.ts
@@ -1,0 +1,106 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Posture } from "@/lib/firebase/schema/investments";
+
+import { useReconciliationPosture } from "./use-reconciliation-posture";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useReconciliationPosture", () => {
+  describe("empty guard", () => {
+    it("does not subscribe when uid is empty", () => {
+      renderHook(() => useReconciliationPosture(""));
+      expect(mockOnValue).not.toHaveBeenCalled();
+    });
+
+    it("returns Posture.Balanced when uid is empty", () => {
+      const { result } = renderHook(() => useReconciliationPosture(""));
+      expect(result.current.posture).toBe(Posture.Balanced);
+    });
+
+    it("returns isLoading false when uid is empty", () => {
+      const { result } = renderHook(() => useReconciliationPosture(""));
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("subscription", () => {
+    it("returns Posture.Balanced when snapshot has no data", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({ exists: () => false });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationPosture("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.posture).toBe(Posture.Balanced);
+    });
+
+    it("returns the stored posture from Firebase", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, callback: (snap: unknown) => void) => {
+          callback({
+            exists: () => true,
+            val: () => ({ reconciliationPosture: "conservative" }),
+          });
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationPosture("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.posture).toBe(Posture.Conservative);
+      });
+    });
+
+    it("unsubscribes on unmount", () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+      const { unmount } = renderHook(() => useReconciliationPosture("uid-1"));
+      unmount();
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it("sets error when onValue calls the error callback", async () => {
+      mockOnValue.mockImplementation(
+        (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+          errCb(new Error("permission denied"));
+          return mockUnsubscribe;
+        },
+      );
+
+      const { result } = renderHook(() => useReconciliationPosture("uid-1"));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error!.message).toBe("permission denied");
+    });
+  });
+});

--- a/src/hooks/use-reconciliation-posture.spec.ts
+++ b/src/hooks/use-reconciliation-posture.spec.ts
@@ -47,7 +47,7 @@ describe("useReconciliationPosture", () => {
     it("returns Posture.Balanced when snapshot has no data", async () => {
       mockOnValue.mockImplementation(
         (_ref: unknown, callback: (snap: unknown) => void) => {
-          callback({ exists: () => false });
+          callback({ val: () => null });
           return mockUnsubscribe;
         },
       );
@@ -64,10 +64,7 @@ describe("useReconciliationPosture", () => {
     it("returns the stored posture from Firebase", async () => {
       mockOnValue.mockImplementation(
         (_ref: unknown, callback: (snap: unknown) => void) => {
-          callback({
-            exists: () => true,
-            val: () => ({ reconciliationPosture: "conservative" }),
-          });
+          callback({ val: () => Posture.Conservative });
           return mockUnsubscribe;
         },
       );

--- a/src/hooks/use-reconciliation-posture.spec.ts
+++ b/src/hooks/use-reconciliation-posture.spec.ts
@@ -83,6 +83,25 @@ describe("useReconciliationPosture", () => {
       expect(mockUnsubscribe).toHaveBeenCalled();
     });
 
+    it("re-subscribes when uid changes from one non-empty value to another", async () => {
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+
+      const { rerender } = renderHook(
+        ({ uid }: { uid: string }) => useReconciliationPosture(uid),
+        { initialProps: { uid: "user-1" } },
+      );
+
+      expect(mockOnValue).toHaveBeenCalledTimes(1);
+
+      rerender({ uid: "user-2" });
+
+      await waitFor(() => {
+        expect(mockOnValue).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
     it("sets error when onValue calls the error callback", async () => {
       mockOnValue.mockImplementation(
         (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {

--- a/src/hooks/use-reconciliation-posture.ts
+++ b/src/hooks/use-reconciliation-posture.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { getDatabase, onValue, ref } from "firebase/database";
+import { useEffect, useState } from "react";
+
+import { getClientApp } from "@/lib/firebase/client";
+import { Posture } from "@/lib/firebase/schema/investments";
+import {
+  firebaseToUserSettings,
+  type FirebaseUserSettings,
+} from "@/lib/firebase/schema/user-settings";
+
+export function useReconciliationPosture(uid: string) {
+  const [posture, setPosture] = useState<Posture>(Posture.Balanced);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setPosture(Posture.Balanced);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const settingsRef = ref(db, `users/${uid}/settings`);
+
+    const unsubscribe = onValue(
+      settingsRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setPosture(Posture.Balanced);
+        } else {
+          const data = snapshot.val() as FirebaseUserSettings;
+          setPosture(firebaseToUserSettings(data).reconciliationPosture);
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid]);
+
+  return { posture, isLoading, error };
+}

--- a/src/hooks/use-reconciliation-posture.ts
+++ b/src/hooks/use-reconciliation-posture.ts
@@ -29,9 +29,10 @@ export function useReconciliationPosture(uid: string) {
     const unsubscribe = onValue(
       postureRef,
       (snapshot) => {
+        const rawPosture = snapshot.val() as string | null;
         setPosture(
           firebaseToUserSettings({
-            reconciliationPosture: snapshot.val() as string | undefined,
+            reconciliationPosture: rawPosture ?? undefined,
           }).reconciliationPosture,
         );
         setIsLoading(false);

--- a/src/hooks/use-reconciliation-posture.ts
+++ b/src/hooks/use-reconciliation-posture.ts
@@ -5,35 +5,35 @@ import { useEffect, useState } from "react";
 
 import { getClientApp } from "@/lib/firebase/client";
 import { Posture } from "@/lib/firebase/schema/investments";
-import {
-  firebaseToUserSettings,
-  type FirebaseUserSettings,
-} from "@/lib/firebase/schema/user-settings";
+import { firebaseToUserSettings } from "@/lib/firebase/schema/user-settings";
 
 export function useReconciliationPosture(uid: string) {
   const [posture, setPosture] = useState<Posture>(Posture.Balanced);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!!uid);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
     if (!uid) {
       setPosture(Posture.Balanced);
+      setError(undefined);
       setIsLoading(false);
       return;
     }
 
+    setIsLoading(true);
+    setError(undefined);
+
     const db = getDatabase(getClientApp());
-    const settingsRef = ref(db, `users/${uid}/settings`);
+    const postureRef = ref(db, `users/${uid}/settings/reconciliationPosture`);
 
     const unsubscribe = onValue(
-      settingsRef,
+      postureRef,
       (snapshot) => {
-        if (!snapshot.exists()) {
-          setPosture(Posture.Balanced);
-        } else {
-          const data = snapshot.val() as FirebaseUserSettings;
-          setPosture(firebaseToUserSettings(data).reconciliationPosture);
-        }
+        setPosture(
+          firebaseToUserSettings({
+            reconciliationPosture: snapshot.val() as Posture | undefined,
+          }).reconciliationPosture,
+        );
         setIsLoading(false);
       },
       (err) => {

--- a/src/hooks/use-reconciliation-posture.ts
+++ b/src/hooks/use-reconciliation-posture.ts
@@ -31,7 +31,7 @@ export function useReconciliationPosture(uid: string) {
       (snapshot) => {
         setPosture(
           firebaseToUserSettings({
-            reconciliationPosture: snapshot.val() as Posture | undefined,
+            reconciliationPosture: snapshot.val() as string | undefined,
           }).reconciliationPosture,
         );
         setIsLoading(false);

--- a/src/hooks/use-update-reconciliation-posture.spec.ts
+++ b/src/hooks/use-update-reconciliation-posture.spec.ts
@@ -1,0 +1,76 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Posture } from "@/lib/firebase/schema/investments";
+
+import { useUpdateReconciliationPosture } from "./use-update-reconciliation-posture";
+
+const mockUpdateUserSettings = vi.fn();
+
+vi.mock("@/services/user-settings", () => ({
+  updateUserSettings: (...args: unknown[]): Promise<void> =>
+    mockUpdateUserSettings(...args) as Promise<void>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useUpdateReconciliationPosture", () => {
+  describe("setPosture", () => {
+    it("calls updateUserSettings with the provided posture", async () => {
+      mockUpdateUserSettings.mockResolvedValue(undefined);
+      const { result } = renderHook(() =>
+        useUpdateReconciliationPosture("uid-1"),
+      );
+
+      await act(async () => {
+        await result.current.setPosture(Posture.Conservative);
+      });
+
+      expect(mockUpdateUserSettings).toHaveBeenCalledWith("uid-1", {
+        reconciliationPosture: Posture.Conservative,
+      });
+    });
+
+    it("sets isSubmitting to true during update and false after", async () => {
+      let resolve!: () => void;
+      mockUpdateUserSettings.mockReturnValue(
+        new Promise<void>((r) => {
+          resolve = r;
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useUpdateReconciliationPosture("uid-1"),
+      );
+
+      let setPosturePromise!: Promise<void>;
+      act(() => {
+        setPosturePromise = result.current.setPosture(Posture.Aggressive);
+      });
+
+      expect(result.current.isSubmitting).toBe(true);
+
+      await act(async () => {
+        resolve();
+        await setPosturePromise;
+      });
+
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it("throws an error when uid is empty", async () => {
+      const { result } = renderHook(() => useUpdateReconciliationPosture(""));
+
+      await expect(
+        act(async () => {
+          await result.current.setPosture(Posture.Balanced);
+        }),
+      ).rejects.toThrow("Cannot update posture: user is not authenticated");
+
+      expect(mockUpdateUserSettings).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/use-update-reconciliation-posture.ts
+++ b/src/hooks/use-update-reconciliation-posture.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+
+import { Posture } from "@/lib/firebase/schema/investments";
+import { updateUserSettings } from "@/services/user-settings";
+
+export function useUpdateReconciliationPosture(uid: string) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const setPosture = async (posture: Posture): Promise<void> => {
+    if (!uid) {
+      throw new Error("Cannot update posture: user is not authenticated");
+    }
+    setIsSubmitting(true);
+    try {
+      await updateUserSettings(uid, { reconciliationPosture: posture });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { setPosture, isSubmitting };
+}

--- a/src/lib/firebase/schema/user-settings.spec.ts
+++ b/src/lib/firebase/schema/user-settings.spec.ts
@@ -10,27 +10,34 @@ import {
 describe("firebaseToUserSettings", () => {
   it("maps 'aggressive' to Posture.Aggressive", () => {
     const result = firebaseToUserSettings({
-      reconciliationPosture: "aggressive",
+      reconciliationPosture: Posture.Aggressive,
     });
     expect(result.reconciliationPosture).toBe(Posture.Aggressive);
   });
 
   it("maps 'balanced' to Posture.Balanced", () => {
     const result = firebaseToUserSettings({
-      reconciliationPosture: "balanced",
+      reconciliationPosture: Posture.Balanced,
     });
     expect(result.reconciliationPosture).toBe(Posture.Balanced);
   });
 
   it("maps 'conservative' to Posture.Conservative", () => {
     const result = firebaseToUserSettings({
-      reconciliationPosture: "conservative",
+      reconciliationPosture: Posture.Conservative,
     });
     expect(result.reconciliationPosture).toBe(Posture.Conservative);
   });
 
   it("defaults to Posture.Balanced when reconciliationPosture is absent", () => {
     const result = firebaseToUserSettings({});
+    expect(result.reconciliationPosture).toBe(Posture.Balanced);
+  });
+
+  it("defaults to Posture.Balanced when reconciliationPosture is an unknown string", () => {
+    const result = firebaseToUserSettings({
+      reconciliationPosture: "invalid-posture" as unknown as Posture,
+    });
     expect(result.reconciliationPosture).toBe(Posture.Balanced);
   });
 });

--- a/src/lib/firebase/schema/user-settings.spec.ts
+++ b/src/lib/firebase/schema/user-settings.spec.ts
@@ -36,7 +36,7 @@ describe("firebaseToUserSettings", () => {
 
   it("defaults to Posture.Balanced when reconciliationPosture is an unknown string", () => {
     const result = firebaseToUserSettings({
-      reconciliationPosture: "invalid-posture" as unknown as Posture,
+      reconciliationPosture: "invalid-posture",
     });
     expect(result.reconciliationPosture).toBe(Posture.Balanced);
   });

--- a/src/lib/firebase/schema/user-settings.spec.ts
+++ b/src/lib/firebase/schema/user-settings.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { Posture } from "@/lib/firebase/schema/investments";
+
+import {
+  firebaseToUserSettings,
+  userSettingsToFirebase,
+} from "./user-settings";
+
+describe("firebaseToUserSettings", () => {
+  it("maps 'aggressive' to Posture.Aggressive", () => {
+    const result = firebaseToUserSettings({
+      reconciliationPosture: "aggressive",
+    });
+    expect(result.reconciliationPosture).toBe(Posture.Aggressive);
+  });
+
+  it("maps 'balanced' to Posture.Balanced", () => {
+    const result = firebaseToUserSettings({
+      reconciliationPosture: "balanced",
+    });
+    expect(result.reconciliationPosture).toBe(Posture.Balanced);
+  });
+
+  it("maps 'conservative' to Posture.Conservative", () => {
+    const result = firebaseToUserSettings({
+      reconciliationPosture: "conservative",
+    });
+    expect(result.reconciliationPosture).toBe(Posture.Conservative);
+  });
+
+  it("defaults to Posture.Balanced when reconciliationPosture is absent", () => {
+    const result = firebaseToUserSettings({});
+    expect(result.reconciliationPosture).toBe(Posture.Balanced);
+  });
+});
+
+describe("userSettingsToFirebase", () => {
+  it("maps Posture.Aggressive to the 'aggressive' string", () => {
+    const result = userSettingsToFirebase({
+      reconciliationPosture: Posture.Aggressive,
+    });
+    expect(result.reconciliationPosture).toBe("aggressive");
+  });
+
+  it("maps Posture.Balanced to the 'balanced' string", () => {
+    const result = userSettingsToFirebase({
+      reconciliationPosture: Posture.Balanced,
+    });
+    expect(result.reconciliationPosture).toBe("balanced");
+  });
+
+  it("maps Posture.Conservative to the 'conservative' string", () => {
+    const result = userSettingsToFirebase({
+      reconciliationPosture: Posture.Conservative,
+    });
+    expect(result.reconciliationPosture).toBe("conservative");
+  });
+
+  it("omits reconciliationPosture from the result when not provided", () => {
+    const result = userSettingsToFirebase({});
+    expect(result).not.toHaveProperty("reconciliationPosture");
+  });
+});

--- a/src/lib/firebase/schema/user-settings.ts
+++ b/src/lib/firebase/schema/user-settings.ts
@@ -1,19 +1,24 @@
 import { Posture } from "@/lib/firebase/schema/investments";
 
 export interface FirebaseUserSettings {
-  reconciliationPosture?: string;
+  reconciliationPosture?: Posture | undefined;
 }
 
 export interface UserSettings {
   reconciliationPosture: Posture;
 }
 
+const VALID_POSTURES: ReadonlySet<string> = new Set(Object.values(Posture));
+
 export function firebaseToUserSettings(
   data: FirebaseUserSettings,
 ): UserSettings {
   return {
     reconciliationPosture:
-      (data.reconciliationPosture as Posture | undefined) ?? Posture.Balanced,
+      data.reconciliationPosture !== undefined &&
+      VALID_POSTURES.has(data.reconciliationPosture)
+        ? data.reconciliationPosture
+        : Posture.Balanced,
   };
 }
 

--- a/src/lib/firebase/schema/user-settings.ts
+++ b/src/lib/firebase/schema/user-settings.ts
@@ -1,0 +1,28 @@
+import { Posture } from "@/lib/firebase/schema/investments";
+
+export interface FirebaseUserSettings {
+  reconciliationPosture?: string;
+}
+
+export interface UserSettings {
+  reconciliationPosture: Posture;
+}
+
+export function firebaseToUserSettings(
+  data: FirebaseUserSettings,
+): UserSettings {
+  return {
+    reconciliationPosture:
+      (data.reconciliationPosture as Posture | undefined) ?? Posture.Balanced,
+  };
+}
+
+export function userSettingsToFirebase(
+  settings: Partial<UserSettings>,
+): FirebaseUserSettings {
+  return {
+    ...(settings.reconciliationPosture !== undefined
+      ? { reconciliationPosture: settings.reconciliationPosture }
+      : {}),
+  };
+}

--- a/src/lib/firebase/schema/user-settings.ts
+++ b/src/lib/firebase/schema/user-settings.ts
@@ -1,7 +1,7 @@
 import { Posture } from "@/lib/firebase/schema/investments";
 
 export interface FirebaseUserSettings {
-  reconciliationPosture?: string | undefined;
+  reconciliationPosture?: string;
 }
 
 export interface UserSettings {

--- a/src/lib/firebase/schema/user-settings.ts
+++ b/src/lib/firebase/schema/user-settings.ts
@@ -1,7 +1,7 @@
 import { Posture } from "@/lib/firebase/schema/investments";
 
 export interface FirebaseUserSettings {
-  reconciliationPosture?: Posture | undefined;
+  reconciliationPosture?: string | undefined;
 }
 
 export interface UserSettings {
@@ -17,7 +17,7 @@ export function firebaseToUserSettings(
     reconciliationPosture:
       data.reconciliationPosture !== undefined &&
       VALID_POSTURES.has(data.reconciliationPosture)
-        ? data.reconciliationPosture
+        ? (data.reconciliationPosture as Posture)
         : Posture.Balanced,
   };
 }

--- a/src/services/user-settings.ts
+++ b/src/services/user-settings.ts
@@ -1,0 +1,22 @@
+import { getDatabase, ref, update } from "firebase/database";
+
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  type UserSettings,
+  userSettingsToFirebase,
+} from "@/lib/firebase/schema/user-settings";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function userSettingsRef(uid: string) {
+  return ref(db(), `users/${uid}/settings`);
+}
+
+export async function updateUserSettings(
+  uid: string,
+  settings: Partial<UserSettings>,
+): Promise<void> {
+  await update(userSettingsRef(uid), userSettingsToFirebase(settings));
+}

--- a/src/services/user-settings.ts
+++ b/src/services/user-settings.ts
@@ -6,17 +6,12 @@ import {
   userSettingsToFirebase,
 } from "@/lib/firebase/schema/user-settings";
 
-function db() {
-  return getDatabase(getClientApp());
-}
-
-function userSettingsRef(uid: string) {
-  return ref(db(), `users/${uid}/settings`);
-}
-
 export async function updateUserSettings(
   uid: string,
   settings: Partial<UserSettings>,
 ): Promise<void> {
-  await update(userSettingsRef(uid), userSettingsToFirebase(settings));
+  await update(
+    ref(getDatabase(getClientApp()), `users/${uid}/settings`),
+    userSettingsToFirebase(settings),
+  );
 }


### PR DESCRIPTION
Adds Firebase schema, service layer, and React hooks for persisting and retrieving the user&#39;s reconciliation posture (Aggressive / Balanced / Conservative). The setting is stored at `users/{uid}/settings/reconciliationPosture` in Firebase Realtime DB and defaults to Balanced when absent.

Two hooks follow the established subscription/mutation patterns in the codebase: `useReconciliationPosture(uid)` subscribes to the setting in real time, and `useUpdateReconciliationPosture(uid)` provides a `setPosture` callback that writes through `updateUserSettings` in the service layer.

## Acceptance Criteria
- [x] Firebase schema defines `FirebaseUserSettings` and `UserSettings` types with mapper functions
- [x] `firebaseToUserSettings` defaults `reconciliationPosture` to Balanced when absent
- [x] `useReconciliationPosture` subscribes to the setting and returns the typed `Posture` enum value
- [x] `useReconciliationPosture` returns Balanced and skips subscription when uid is empty
- [x] `useReconciliationPosture` propagates Firebase errors to callers
- [x] `useUpdateReconciliationPosture` writes the posture via the service layer
- [x] `useUpdateReconciliationPosture` throws when uid is empty

## Tests
19 tests added, all passing.

Closes #209

---
*Created by Claude Sonnet 4.7*