### PR TITLE
feat(investments): monthly aggregation summary view

### DIFF
--- a/src/components/investments/MonthlyAggregationSummaryView.spec.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.spec.tsx
@@ -1,0 +1,127 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  LEDGER_INVESTMENT_TABLE_COPY,
+  MONTHLY_AGGREGATION_SUMMARY_COPY,
+} from "./copy";
+import { MonthlyAggregationSummaryView } from "./MonthlyAggregationSummaryView";
+
+afterEach(cleanup);
+
+const baseRows = [
+  {
+    cashBalance: 4200,
+    investmentBalance: 12000,
+    ledgerName: "Primary",
+    netBuySell: 800,
+  },
+  {
+    cashBalance: 1600,
+    investmentBalance: 8400,
+    ledgerName: "Travel Fund",
+    netBuySell: -360,
+  },
+];
+
+describe("MonthlyAggregationSummaryView — column headers", () => {
+  it("renders the Ledger column header", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(
+      screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.columnLedger),
+    ).toBeDefined();
+  });
+
+  it("renders the Cash column header", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(
+      screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.columnCash),
+    ).toBeDefined();
+  });
+
+  it("renders the Invested column header", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(
+      screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.columnInvested),
+    ).toBeDefined();
+  });
+
+  it("renders the Net buy / sell column header", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(
+      screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.columnNetBuySell),
+    ).toBeDefined();
+  });
+});
+
+describe("MonthlyAggregationSummaryView — row data", () => {
+  it("renders a ledger name", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(screen.getByText("Primary")).toBeDefined();
+  });
+
+  it("renders the cash balance formatted as currency", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(screen.getByText("$4,200.00")).toBeDefined();
+  });
+
+  it("renders the investment balance formatted as currency", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(screen.getByText("$12,000.00")).toBeDefined();
+  });
+
+  it("renders a positive net buy/sell formatted as currency", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(screen.getByText("$800.00")).toBeDefined();
+  });
+
+  it("renders a negative net buy/sell formatted as currency", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={2} />,
+    );
+    expect(screen.getByText("-$360.00")).toBeDefined();
+  });
+});
+
+describe("MonthlyAggregationSummaryView — view all link", () => {
+  it("renders the view all link with total ledger count", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={14} />,
+    );
+    expect(
+      screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(14)),
+    ).toBeDefined();
+  });
+});
+
+describe("MonthlyAggregationSummaryView — empty state", () => {
+  it("renders the empty state message when rows is empty", () => {
+    render(<MonthlyAggregationSummaryView rows={[]} totalLedgerCount={0} />);
+    expect(
+      screen.getByText(MONTHLY_AGGREGATION_SUMMARY_COPY.noLedgerData),
+    ).toBeDefined();
+  });
+
+  it("does not render table headers when rows is empty", () => {
+    render(<MonthlyAggregationSummaryView rows={[]} totalLedgerCount={0} />);
+    expect(
+      screen.queryByText(LEDGER_INVESTMENT_TABLE_COPY.columnLedger),
+    ).toBeNull();
+  });
+});

--- a/src/components/investments/MonthlyAggregationSummaryView.spec.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.spec.tsx
@@ -13,12 +13,14 @@ const baseRows = [
   {
     cashBalance: 4200,
     investmentBalance: 12000,
+    ledgerId: "ledger-primary",
     ledgerName: "Primary",
     netBuySell: 800,
   },
   {
     cashBalance: 1600,
     investmentBalance: 8400,
+    ledgerId: "ledger-travel-fund",
     ledgerName: "Travel Fund",
     netBuySell: -360,
   },
@@ -100,13 +102,26 @@ describe("MonthlyAggregationSummaryView — row data", () => {
 });
 
 describe("MonthlyAggregationSummaryView — view all link", () => {
-  it("renders the view all link with total ledger count", () => {
+  it("renders the view all link with total ledger count when onViewAll is provided", () => {
     render(
-      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={14} />,
+      <MonthlyAggregationSummaryView
+        rows={baseRows}
+        totalLedgerCount={14}
+        onViewAll={() => undefined}
+      />,
     );
     expect(
       screen.getByText(LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(14)),
     ).toBeDefined();
+  });
+
+  it("does not render the view all link when onViewAll is not provided", () => {
+    render(
+      <MonthlyAggregationSummaryView rows={baseRows} totalLedgerCount={14} />,
+    );
+    expect(
+      screen.queryByText(LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(14)),
+    ).toBeNull();
   });
 });
 

--- a/src/components/investments/MonthlyAggregationSummaryView.stories.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { MonthlyAggregationSummaryView } from "./MonthlyAggregationSummaryView";
+
+const meta: Meta<typeof MonthlyAggregationSummaryView> = {
+  component: MonthlyAggregationSummaryView,
+  title: "Investments/MonthlyAggregationSummaryView",
+};
+
+export default meta;
+type Story = StoryObj<typeof MonthlyAggregationSummaryView>;
+
+export const Empty: Story = {
+  args: {
+    rows: [],
+    totalLedgerCount: 0,
+  },
+};
+
+export const WithRows: Story = {
+  args: {
+    rows: [
+      {
+        cashBalance: 4200,
+        investmentBalance: 12000,
+        ledgerName: "Primary",
+        netBuySell: 800,
+      },
+      {
+        cashBalance: 1600,
+        investmentBalance: 8400,
+        ledgerName: "Travel Fund",
+        netBuySell: -360,
+      },
+      {
+        cashBalance: 900,
+        investmentBalance: 3500,
+        ledgerName: "Emergency",
+        netBuySell: 0,
+      },
+    ],
+    totalLedgerCount: 14,
+  },
+};

--- a/src/components/investments/MonthlyAggregationSummaryView.stories.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.stories.tsx
@@ -23,18 +23,21 @@ export const WithRows: Story = {
       {
         cashBalance: 4200,
         investmentBalance: 12000,
+        ledgerId: "ledger-primary",
         ledgerName: "Primary",
         netBuySell: 800,
       },
       {
         cashBalance: 1600,
         investmentBalance: 8400,
+        ledgerId: "ledger-travel-fund",
         ledgerName: "Travel Fund",
         netBuySell: -360,
       },
       {
         cashBalance: 900,
         investmentBalance: 3500,
+        ledgerId: "ledger-emergency",
         ledgerName: "Emergency",
         netBuySell: 0,
       },

--- a/src/components/investments/MonthlyAggregationSummaryView.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.tsx
@@ -15,16 +15,19 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 export interface LedgerAggregationRow {
   cashBalance: number;
   investmentBalance: number;
+  ledgerId: string;
   ledgerName: string;
   netBuySell: number;
 }
 
 export interface MonthlyAggregationSummaryViewProps {
+  onViewAll?: () => void;
   rows: LedgerAggregationRow[];
   totalLedgerCount: number;
 }
 
 export function MonthlyAggregationSummaryView({
+  onViewAll,
   rows,
   totalLedgerCount,
 }: MonthlyAggregationSummaryViewProps) {
@@ -61,7 +64,7 @@ export function MonthlyAggregationSummaryView({
               </thead>
               <tbody>
                 {rows.map((row) => (
-                  <tr key={row.ledgerName} className="border-b last:border-b-0">
+                  <tr key={row.ledgerId} className="border-b last:border-b-0">
                     <td className="px-4 py-2 font-medium">{row.ledgerName}</td>
                     <td className="px-4 py-2 text-right font-mono">
                       {currencyFormatter.format(row.cashBalance)}
@@ -82,14 +85,17 @@ export function MonthlyAggregationSummaryView({
                 ))}
               </tbody>
             </table>
-            <div className="border-t px-4 py-2 text-right">
-              <button
-                type="button"
-                className="text-xs text-primary hover:underline"
-              >
-                {LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(totalLedgerCount)}
-              </button>
-            </div>
+            {onViewAll !== undefined && (
+              <div className="border-t px-4 py-2 text-right">
+                <button
+                  type="button"
+                  className="text-xs text-primary hover:underline"
+                  onClick={onViewAll}
+                >
+                  {LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(totalLedgerCount)}
+                </button>
+              </div>
+            )}
           </>
         )}
       </CardContent>

--- a/src/components/investments/MonthlyAggregationSummaryView.tsx
+++ b/src/components/investments/MonthlyAggregationSummaryView.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  LEDGER_INVESTMENT_TABLE_COPY,
+  MONTHLY_AGGREGATION_SUMMARY_COPY,
+} from "./copy";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+export interface LedgerAggregationRow {
+  cashBalance: number;
+  investmentBalance: number;
+  ledgerName: string;
+  netBuySell: number;
+}
+
+export interface MonthlyAggregationSummaryViewProps {
+  rows: LedgerAggregationRow[];
+  totalLedgerCount: number;
+}
+
+export function MonthlyAggregationSummaryView({
+  rows,
+  totalLedgerCount,
+}: MonthlyAggregationSummaryViewProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-semibold">
+          {LEDGER_INVESTMENT_TABLE_COPY.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {rows.length === 0 ? (
+          <p className="px-4 pb-4 text-sm text-muted-foreground">
+            {MONTHLY_AGGREGATION_SUMMARY_COPY.noLedgerData}
+          </p>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs text-muted-foreground">
+                  <th className="px-4 py-2 font-medium">
+                    {LEDGER_INVESTMENT_TABLE_COPY.columnLedger}
+                  </th>
+                  <th className="px-4 py-2 text-right font-medium">
+                    {LEDGER_INVESTMENT_TABLE_COPY.columnCash}
+                  </th>
+                  <th className="px-4 py-2 text-right font-medium">
+                    {LEDGER_INVESTMENT_TABLE_COPY.columnInvested}
+                  </th>
+                  <th className="px-4 py-2 text-right font-medium">
+                    {LEDGER_INVESTMENT_TABLE_COPY.columnNetBuySell}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.ledgerName} className="border-b last:border-b-0">
+                    <td className="px-4 py-2 font-medium">{row.ledgerName}</td>
+                    <td className="px-4 py-2 text-right font-mono">
+                      {currencyFormatter.format(row.cashBalance)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono">
+                      {currencyFormatter.format(row.investmentBalance)}
+                    </td>
+                    <td
+                      className={`px-4 py-2 text-right font-mono ${
+                        row.netBuySell >= 0
+                          ? "text-green-600 dark:text-green-400"
+                          : "text-red-600 dark:text-red-400"
+                      }`}
+                    >
+                      {currencyFormatter.format(row.netBuySell)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="border-t px-4 py-2 text-right">
+              <button
+                type="button"
+                className="text-xs text-primary hover:underline"
+              >
+                {LEDGER_INVESTMENT_TABLE_COPY.viewAllLink(totalLedgerCount)}
+              </button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/investments/copy.ts
+++ b/src/components/investments/copy.ts
@@ -51,3 +51,7 @@ export const LEDGER_INVESTMENT_TABLE_COPY = {
   title: "Per-ledger investment portion",
   viewAllLink: (count: number) => `View all ${String(count)}`,
 } as const;
+
+export const MONTHLY_AGGREGATION_SUMMARY_COPY = {
+  noLedgerData: "No ledger data available.",
+} as const;

--- a/src/components/investments/index.ts
+++ b/src/components/investments/index.ts
@@ -1,4 +1,9 @@
 export type { InvestmentsViewProps } from "./InvestmentsView";
 export { InvestmentsView } from "./InvestmentsView";
+export type {
+  LedgerAggregationRow,
+  MonthlyAggregationSummaryViewProps,
+} from "./MonthlyAggregationSummaryView";
+export { MonthlyAggregationSummaryView } from "./MonthlyAggregationSummaryView";
 export type { PostureCardProps } from "./PostureCard";
 export { PostureCard } from "./PostureCard";


### PR DESCRIPTION
Adds `MonthlyAggregationSummaryView`, a presentational component that renders the per-ledger monthly investment aggregation table. Each row shows a ledger's cash balance, investment balance, and net buy/sell target for the month, formatted as currency. Positive net amounts are shown in green, negative in red.

The component is UAT-exempt — it is a pure presentational component that only renders the data it receives as props (no live Firebase calls, no user mutations). Storybook stories cover the populated and empty states.

## Acceptance Criteria
- [x] Component accepts per-ledger aggregation data (ledger name, cash balance, investment balance, net buy/sell) as numeric props
- [x] Currency values are formatted as `$X,XXX.XX`
- [x] Positive net buy/sell rendered in green, negative in red
- [x] Empty state shown when no rows are provided
- [x] Storybook stories cover populated and empty states

## Tests
12 tests added, all passing.

Closes #214

---
*Created by Claude Sonnet 4.5*