### PR TITLE
feat(investments): allocation dashboard with current vs. target deviation display

### DIFF
--- a/src/components/investments/AllocationDashboardView.spec.tsx
+++ b/src/components/investments/AllocationDashboardView.spec.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AllocationDashboardView } from "./AllocationDashboardView";
+import { TARGET_ALLOCATION_COPY } from "./copy";
+
+afterEach(cleanup);
+
+const makeAccount = (
+  overrides?: Partial<{
+    id: string;
+    name: string;
+    currentPercent: number;
+    targetPercent: number;
+  }>,
+) => ({
+  id: "acc-1",
+  name: "Stocks",
+  currentPercent: 60,
+  targetPercent: 70,
+  ...overrides,
+});
+
+describe("AllocationDashboardView — empty state", () => {
+  it("renders the card title", () => {
+    const { getByText } = render(<AllocationDashboardView accounts={[]} />);
+    expect(getByText(TARGET_ALLOCATION_COPY.title)).toBeDefined();
+  });
+
+  it("renders the empty state message when no accounts provided", () => {
+    const { getByText } = render(<AllocationDashboardView accounts={[]} />);
+    expect(
+      getByText(TARGET_ALLOCATION_COPY.noAccountsConfigured),
+    ).toBeDefined();
+  });
+});
+
+describe("AllocationDashboardView — account names", () => {
+  it("renders each account name", () => {
+    const accounts = [
+      makeAccount({
+        id: "a",
+        name: "Stocks",
+        currentPercent: 60,
+        targetPercent: 60,
+      }),
+      makeAccount({
+        id: "b",
+        name: "Bonds",
+        currentPercent: 30,
+        targetPercent: 30,
+      }),
+    ];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText("Stocks")).toBeDefined();
+    expect(getByText("Bonds")).toBeDefined();
+  });
+});
+
+describe("AllocationDashboardView — current and target percentages", () => {
+  it("renders current and target percent for each account", () => {
+    const accounts = [makeAccount({ currentPercent: 65, targetPercent: 70 })];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText("65%")).toBeDefined();
+    expect(getByText("70%")).toBeDefined();
+  });
+});
+
+describe("AllocationDashboardView — deviation display", () => {
+  it("shows a negative deviation when account is under target", () => {
+    const accounts = [makeAccount({ currentPercent: 60, targetPercent: 70 })];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText("-10.0%")).toBeDefined();
+  });
+
+  it("shows a positive deviation when account is over target", () => {
+    const accounts = [makeAccount({ currentPercent: 75, targetPercent: 70 })];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText("+5.0%")).toBeDefined();
+  });
+
+  it("shows zero deviation when account is exactly at target", () => {
+    const accounts = [makeAccount({ currentPercent: 70, targetPercent: 70 })];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText("0.0%")).toBeDefined();
+  });
+});
+
+describe("AllocationDashboardView — footer note", () => {
+  it("renders the footer note when accounts are present", () => {
+    const accounts = [makeAccount()];
+    const { getByText } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    expect(getByText(TARGET_ALLOCATION_COPY.footerNote)).toBeDefined();
+  });
+
+  it("does not render the footer note when no accounts provided", () => {
+    const { queryByText } = render(<AllocationDashboardView accounts={[]} />);
+    expect(queryByText(TARGET_ALLOCATION_COPY.footerNote)).toBeNull();
+  });
+});
+
+describe("AllocationDashboardView — output shape", () => {
+  it("renders one row per account", () => {
+    const accounts = [
+      makeAccount({ id: "a", name: "Stocks" }),
+      makeAccount({ id: "b", name: "Bonds" }),
+      makeAccount({ id: "c", name: "International" }),
+    ];
+    const { getAllByRole } = render(
+      <AllocationDashboardView accounts={accounts} />,
+    );
+    // Each account row contains a progressbar
+    const bars = getAllByRole("progressbar");
+    expect(bars).toHaveLength(3);
+  });
+});

--- a/src/components/investments/AllocationDashboardView.spec.tsx
+++ b/src/components/investments/AllocationDashboardView.spec.tsx
@@ -6,7 +6,7 @@ import { TARGET_ALLOCATION_COPY } from "./copy";
 
 afterEach(cleanup);
 
-const makeAccount = (
+const makeInvestmentAccount = (
   overrides?: Partial<{
     id: string;
     name: string;
@@ -38,13 +38,13 @@ describe("AllocationDashboardView — empty state", () => {
 describe("AllocationDashboardView — account names", () => {
   it("renders each account name", () => {
     const accounts = [
-      makeAccount({
+      makeInvestmentAccount({
         id: "a",
         name: "Stocks",
         currentPercent: 60,
         targetPercent: 60,
       }),
-      makeAccount({
+      makeInvestmentAccount({
         id: "b",
         name: "Bonds",
         currentPercent: 30,
@@ -61,7 +61,9 @@ describe("AllocationDashboardView — account names", () => {
 
 describe("AllocationDashboardView — current and target percentages", () => {
   it("renders current and target percent for each account", () => {
-    const accounts = [makeAccount({ currentPercent: 65, targetPercent: 70 })];
+    const accounts = [
+      makeInvestmentAccount({ currentPercent: 65, targetPercent: 70 }),
+    ];
     const { getByText } = render(
       <AllocationDashboardView accounts={accounts} />,
     );
@@ -72,7 +74,9 @@ describe("AllocationDashboardView — current and target percentages", () => {
 
 describe("AllocationDashboardView — deviation display", () => {
   it("shows a negative deviation when account is under target", () => {
-    const accounts = [makeAccount({ currentPercent: 60, targetPercent: 70 })];
+    const accounts = [
+      makeInvestmentAccount({ currentPercent: 60, targetPercent: 70 }),
+    ];
     const { getByText } = render(
       <AllocationDashboardView accounts={accounts} />,
     );
@@ -80,7 +84,9 @@ describe("AllocationDashboardView — deviation display", () => {
   });
 
   it("shows a positive deviation when account is over target", () => {
-    const accounts = [makeAccount({ currentPercent: 75, targetPercent: 70 })];
+    const accounts = [
+      makeInvestmentAccount({ currentPercent: 75, targetPercent: 70 }),
+    ];
     const { getByText } = render(
       <AllocationDashboardView accounts={accounts} />,
     );
@@ -88,7 +94,9 @@ describe("AllocationDashboardView — deviation display", () => {
   });
 
   it("shows zero deviation when account is exactly at target", () => {
-    const accounts = [makeAccount({ currentPercent: 70, targetPercent: 70 })];
+    const accounts = [
+      makeInvestmentAccount({ currentPercent: 70, targetPercent: 70 }),
+    ];
     const { getByText } = render(
       <AllocationDashboardView accounts={accounts} />,
     );
@@ -98,7 +106,7 @@ describe("AllocationDashboardView — deviation display", () => {
 
 describe("AllocationDashboardView — footer note", () => {
   it("renders the footer note when accounts are present", () => {
-    const accounts = [makeAccount()];
+    const accounts = [makeInvestmentAccount()];
     const { getByText } = render(
       <AllocationDashboardView accounts={accounts} />,
     );
@@ -114,9 +122,9 @@ describe("AllocationDashboardView — footer note", () => {
 describe("AllocationDashboardView — output shape", () => {
   it("renders one row per account", () => {
     const accounts = [
-      makeAccount({ id: "a", name: "Stocks" }),
-      makeAccount({ id: "b", name: "Bonds" }),
-      makeAccount({ id: "c", name: "International" }),
+      makeInvestmentAccount({ id: "a", name: "Stocks" }),
+      makeInvestmentAccount({ id: "b", name: "Bonds" }),
+      makeInvestmentAccount({ id: "c", name: "International" }),
     ];
     const { getAllByRole } = render(
       <AllocationDashboardView accounts={accounts} />,

--- a/src/components/investments/AllocationDashboardView.stories.tsx
+++ b/src/components/investments/AllocationDashboardView.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { AllocationDashboardView } from "./AllocationDashboardView";
+
+const meta: Meta<typeof AllocationDashboardView> = {
+  component: AllocationDashboardView,
+  title: "Investments/AllocationDashboardView",
+};
+
+export default meta;
+type Story = StoryObj<typeof AllocationDashboardView>;
+
+export const Empty: Story = {
+  args: {
+    accounts: [],
+  },
+};
+
+export const AllAtTarget: Story = {
+  args: {
+    accounts: [
+      {
+        id: "acc-stocks",
+        name: "Stocks",
+        currentPercent: 60,
+        targetPercent: 60,
+      },
+      { id: "acc-bonds", name: "Bonds", currentPercent: 30, targetPercent: 30 },
+      {
+        id: "acc-intl",
+        name: "International",
+        currentPercent: 10,
+        targetPercent: 10,
+      },
+    ],
+  },
+};
+
+export const WithDeviations: Story = {
+  args: {
+    accounts: [
+      {
+        id: "acc-stocks",
+        name: "Stocks",
+        currentPercent: 65,
+        targetPercent: 60,
+      },
+      { id: "acc-bonds", name: "Bonds", currentPercent: 25, targetPercent: 30 },
+      {
+        id: "acc-intl",
+        name: "International",
+        currentPercent: 10,
+        targetPercent: 10,
+      },
+    ],
+  },
+};

--- a/src/components/investments/AllocationDashboardView.tsx
+++ b/src/components/investments/AllocationDashboardView.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Bar } from "@/components/ui/bar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { InvestmentAccount } from "@/lib/firebase/schema/investments";
+
+import { TARGET_ALLOCATION_COPY } from "./copy";
+
+export interface AllocationDashboardViewProps {
+  accounts: InvestmentAccount[];
+}
+
+export function AllocationDashboardView({
+  accounts,
+}: AllocationDashboardViewProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-semibold">
+          {TARGET_ALLOCATION_COPY.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {accounts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {TARGET_ALLOCATION_COPY.noAccountsConfigured}
+          </p>
+        ) : (
+          <>
+            {accounts.map((account) => {
+              const deviation = account.currentPercent - account.targetPercent;
+              const deviationText =
+                deviation > 0
+                  ? `+${deviation.toFixed(1)}%`
+                  : `${deviation.toFixed(1)}%`;
+              return (
+                <div key={account.id} className="flex flex-col gap-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{account.name}</span>
+                    <span
+                      className={`font-mono text-xs ${
+                        deviation > 0
+                          ? "text-orange-500"
+                          : deviation < 0
+                            ? "text-blue-600 dark:text-blue-400"
+                            : "text-muted-foreground"
+                      }`}
+                    >
+                      {deviationText}
+                    </span>
+                  </div>
+                  <div className="relative">
+                    <Bar
+                      value={account.currentPercent}
+                      aria-label={`${account.name} current allocation`}
+                    />
+                    <div
+                      className="absolute inset-y-0 w-0.5 bg-foreground/60"
+                      style={{ left: `${String(account.targetPercent)}%` }}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{account.currentPercent}%</span>
+                    <span>{account.targetPercent}%</span>
+                  </div>
+                </div>
+              );
+            })}
+            <p className="text-xs text-muted-foreground">
+              {TARGET_ALLOCATION_COPY.footerNote}
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/investments/index.ts
+++ b/src/components/investments/index.ts
@@ -1,3 +1,5 @@
+export type { AllocationDashboardViewProps } from "./AllocationDashboardView";
+export { AllocationDashboardView } from "./AllocationDashboardView";
 export type { InvestmentsViewProps } from "./InvestmentsView";
 export { InvestmentsView } from "./InvestmentsView";
 export type {


### PR DESCRIPTION
Adds `AllocationDashboardView`, a presentational component that renders each investment account's current allocation percentage, target percentage, and signed deviation from target. A visual bar shows the current fill with a target marker line overlay; accounts above target show an orange deviation, accounts below show blue.

The component uses the existing `Bar` UI primitive and `TARGET_ALLOCATION_COPY` constants already in `copy.ts`. It is UAT-exempt — a pure presentational component with no Firebase calls or user mutations. Storybook stories cover the empty, at-target, and with-deviations states.

## Acceptance Criteria
- [x] Renders each account's name, current %, target %, and signed deviation
- [x] Deviation shown with sign: +5.0% (over target), -10.0% (under target), 0.0% (at target)
- [x] Visual bar reflects current allocation; target marker overlaid at target %
- [x] Empty state shown when no accounts provided
- [x] Storybook stories cover populated and empty states

## Tests
10 tests added, all passing.

Closes #206

---
*Created by Claude Sonnet 4.5*