### PR TITLE
feat(annuities): record monthly annuity payments/receipts

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useAccounts } from "./use-accounts";
 export { useAllSavingsGoals } from "./use-all-savings-goals";
 export { useAnnuities } from "./use-annuities";
+export { useAnnuityPayments } from "./use-annuity-payments";
 export { useAuth } from "./use-auth";
 export { useDeleteAnnuity } from "./use-delete-annuity";
 export { useDeleteSavingsGoal } from "./use-delete-savings-goal";

--- a/src/hooks/use-annuity-payments.spec.ts
+++ b/src/hooks/use-annuity-payments.spec.ts
@@ -1,0 +1,119 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useAnnuityPayments } from "./use-annuity-payments";
+
+const mockUnsubscribe = vi.fn();
+const mockOnValue = vi.fn();
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(() => ({ type: "mock-db" })),
+  ref: vi.fn(() => ({ type: "mock-ref" })),
+  onValue: (
+    ...args: Parameters<typeof mockOnValue>
+  ): ReturnType<typeof mockOnValue> => mockOnValue(...args),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useAnnuityPayments — empty guard", () => {
+  it("does not subscribe when uid is empty", () => {
+    renderHook(() => useAnnuityPayments("", "ann-1"));
+    expect(mockOnValue).not.toHaveBeenCalled();
+  });
+
+  it("does not subscribe when annuityId is empty", () => {
+    renderHook(() => useAnnuityPayments("uid-1", ""));
+    expect(mockOnValue).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty array when uid is empty", () => {
+    const { result } = renderHook(() => useAnnuityPayments("", "ann-1"));
+    expect(result.current.payments).toEqual([]);
+  });
+
+  it("returns an empty array when annuityId is empty", () => {
+    const { result } = renderHook(() => useAnnuityPayments("uid-1", ""));
+    expect(result.current.payments).toEqual([]);
+  });
+});
+
+describe("useAnnuityPayments — subscription", () => {
+  it("returns empty array when snapshot has no data", async () => {
+    mockOnValue.mockImplementation(
+      (_ref: unknown, callback: (snap: unknown) => void) => {
+        callback({ exists: () => false });
+        return mockUnsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useAnnuityPayments("uid-1", "ann-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.payments).toEqual([]);
+  });
+
+  it("maps snapshot data to AnnuityPayment objects", async () => {
+    mockOnValue.mockImplementation(
+      (_ref: unknown, callback: (snap: unknown) => void) => {
+        callback({
+          exists: () => true,
+          val: () => ({
+            "pay-1": {
+              amount: 250,
+              date: "2024-03-01T00:00:00.000Z",
+            },
+          }),
+        });
+        return mockUnsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useAnnuityPayments("uid-1", "ann-1"));
+
+    await waitFor(() => {
+      expect(result.current.payments).toHaveLength(1);
+    });
+
+    expect(result.current.payments[0]).toMatchObject({
+      id: "pay-1",
+      annuityId: "ann-1",
+      amount: 250,
+    });
+    expect(result.current.payments[0]!.date).toBeInstanceOf(Date);
+  });
+
+  it("unsubscribes on unmount", () => {
+    mockOnValue.mockReturnValue(mockUnsubscribe);
+    const { unmount } = renderHook(() => useAnnuityPayments("uid-1", "ann-1"));
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it("sets error when onValue calls the error callback", async () => {
+    mockOnValue.mockImplementation(
+      (_ref: unknown, _cb: unknown, errCb: (err: Error) => void) => {
+        errCb(new Error("permission denied"));
+        return mockUnsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useAnnuityPayments("uid-1", "ann-1"));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+
+    expect(result.current.error!.message).toBe("permission denied");
+  });
+});

--- a/src/hooks/use-annuity-payments.ts
+++ b/src/hooks/use-annuity-payments.ts
@@ -17,10 +17,14 @@ export function useAnnuityPayments(uid: string, annuityId: string) {
 
   useEffect(() => {
     if (!uid || !annuityId) {
+      setError(undefined);
       setPayments([]);
       setIsLoading(false);
       return;
     }
+
+    setError(undefined);
+    setIsLoading(true);
 
     const db = getDatabase(getClientApp());
     const paymentsRef = ref(db, `users/${uid}/annuityPayments/${annuityId}`);

--- a/src/hooks/use-annuity-payments.ts
+++ b/src/hooks/use-annuity-payments.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { getDatabase, onValue, ref } from "firebase/database";
+import { useEffect, useState } from "react";
+
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  type AnnuityPayment,
+  type FirebaseAnnuityPayment,
+  firebaseToAnnuityPayment,
+} from "@/lib/firebase/schema/annuity-payments";
+
+export function useAnnuityPayments(uid: string, annuityId: string) {
+  const [payments, setPayments] = useState<AnnuityPayment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid || !annuityId) {
+      setPayments([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const db = getDatabase(getClientApp());
+    const paymentsRef = ref(db, `users/${uid}/annuityPayments/${annuityId}`);
+
+    const unsubscribe = onValue(
+      paymentsRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setPayments([]);
+        } else {
+          const data = snapshot.val() as Record<string, FirebaseAnnuityPayment>;
+          setPayments(
+            Object.entries(data).map(([id, entry]) =>
+              firebaseToAnnuityPayment(id, annuityId, entry),
+            ),
+          );
+        }
+        setIsLoading(false);
+      },
+      (err) => {
+        setError(err);
+        setIsLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [uid, annuityId]);
+
+  return { payments, isLoading, error };
+}

--- a/src/lib/firebase/schema/annuity-payments.spec.ts
+++ b/src/lib/firebase/schema/annuity-payments.spec.ts
@@ -9,7 +9,6 @@ describe("annuityPaymentToFirebase", () => {
   it("serializes date to ISO string", () => {
     const date = new Date("2024-03-15T12:00:00.000Z");
     const result = annuityPaymentToFirebase({
-      annuityId: "ann-1",
       amount: 250,
       date,
     });
@@ -18,7 +17,6 @@ describe("annuityPaymentToFirebase", () => {
 
   it("preserves amount", () => {
     const result = annuityPaymentToFirebase({
-      annuityId: "ann-1",
       amount: 500.75,
       date: new Date("2024-03-01T00:00:00.000Z"),
     });
@@ -27,7 +25,6 @@ describe("annuityPaymentToFirebase", () => {
 
   it("includes notes when provided", () => {
     const result = annuityPaymentToFirebase({
-      annuityId: "ann-1",
       amount: 100,
       date: new Date("2024-03-01T00:00:00.000Z"),
       notes: "Extra payment",
@@ -37,7 +34,6 @@ describe("annuityPaymentToFirebase", () => {
 
   it("omits notes when not provided", () => {
     const result = annuityPaymentToFirebase({
-      annuityId: "ann-1",
       amount: 100,
       date: new Date("2024-03-01T00:00:00.000Z"),
     });
@@ -91,7 +87,6 @@ describe("firebaseToAnnuityPayment", () => {
   it("round-trips date through serialization", () => {
     const date = new Date("2024-09-20T08:30:00.000Z");
     const firebase = annuityPaymentToFirebase({
-      annuityId: "ann-1",
       amount: 200,
       date,
     });

--- a/src/lib/firebase/schema/annuity-payments.spec.ts
+++ b/src/lib/firebase/schema/annuity-payments.spec.ts
@@ -37,7 +37,7 @@ describe("annuityPaymentToFirebase", () => {
       amount: 100,
       date: new Date("2024-03-01T00:00:00.000Z"),
     });
-    expect(result.notes).toBeUndefined();
+    expect(result).not.toHaveProperty("notes");
   });
 });
 

--- a/src/lib/firebase/schema/annuity-payments.spec.ts
+++ b/src/lib/firebase/schema/annuity-payments.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  annuityPaymentToFirebase,
+  firebaseToAnnuityPayment,
+} from "./annuity-payments";
+
+describe("annuityPaymentToFirebase", () => {
+  it("serializes date to ISO string", () => {
+    const date = new Date("2024-03-15T12:00:00.000Z");
+    const result = annuityPaymentToFirebase({
+      annuityId: "ann-1",
+      amount: 250,
+      date,
+    });
+    expect(result.date).toBe("2024-03-15T12:00:00.000Z");
+  });
+
+  it("preserves amount", () => {
+    const result = annuityPaymentToFirebase({
+      annuityId: "ann-1",
+      amount: 500.75,
+      date: new Date("2024-03-01T00:00:00.000Z"),
+    });
+    expect(result.amount).toBe(500.75);
+  });
+
+  it("includes notes when provided", () => {
+    const result = annuityPaymentToFirebase({
+      annuityId: "ann-1",
+      amount: 100,
+      date: new Date("2024-03-01T00:00:00.000Z"),
+      notes: "Extra payment",
+    });
+    expect(result.notes).toBe("Extra payment");
+  });
+
+  it("omits notes when not provided", () => {
+    const result = annuityPaymentToFirebase({
+      annuityId: "ann-1",
+      amount: 100,
+      date: new Date("2024-03-01T00:00:00.000Z"),
+    });
+    expect(result.notes).toBeUndefined();
+  });
+});
+
+describe("firebaseToAnnuityPayment", () => {
+  it("sets id and annuityId from parameters", () => {
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", {
+      amount: 250,
+      date: "2024-03-15T12:00:00.000Z",
+    });
+    expect(result.id).toBe("pay-1");
+    expect(result.annuityId).toBe("ann-1");
+  });
+
+  it("parses ISO date string to Date object", () => {
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", {
+      amount: 250,
+      date: "2024-06-01T00:00:00.000Z",
+    });
+    expect(result.date).toEqual(new Date("2024-06-01T00:00:00.000Z"));
+  });
+
+  it("preserves amount", () => {
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", {
+      amount: 350.5,
+      date: "2024-03-15T00:00:00.000Z",
+    });
+    expect(result.amount).toBe(350.5);
+  });
+
+  it("preserves optional notes", () => {
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", {
+      amount: 100,
+      date: "2024-03-15T00:00:00.000Z",
+      notes: "Early payment",
+    });
+    expect(result.notes).toBe("Early payment");
+  });
+
+  it("leaves notes as undefined when absent", () => {
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", {
+      amount: 100,
+      date: "2024-03-15T00:00:00.000Z",
+    });
+    expect(result.notes).toBeUndefined();
+  });
+
+  it("round-trips date through serialization", () => {
+    const date = new Date("2024-09-20T08:30:00.000Z");
+    const firebase = annuityPaymentToFirebase({
+      annuityId: "ann-1",
+      amount: 200,
+      date,
+    });
+    const result = firebaseToAnnuityPayment("pay-1", "ann-1", firebase);
+    expect(result.date.toISOString()).toBe(date.toISOString());
+  });
+});

--- a/src/lib/firebase/schema/annuity-payments.ts
+++ b/src/lib/firebase/schema/annuity-payments.ts
@@ -18,7 +18,7 @@ export function annuityPaymentToFirebase(
   return {
     amount: payment.amount,
     date: payment.date.toISOString(),
-    notes: payment.notes,
+    ...(payment.notes !== undefined && { notes: payment.notes }),
   };
 }
 

--- a/src/lib/firebase/schema/annuity-payments.ts
+++ b/src/lib/firebase/schema/annuity-payments.ts
@@ -13,7 +13,7 @@ export interface AnnuityPayment {
 }
 
 export function annuityPaymentToFirebase(
-  payment: Omit<AnnuityPayment, "id">,
+  payment: Omit<AnnuityPayment, "id" | "annuityId">,
 ): FirebaseAnnuityPayment {
   return {
     amount: payment.amount,

--- a/src/lib/firebase/schema/annuity-payments.ts
+++ b/src/lib/firebase/schema/annuity-payments.ts
@@ -1,0 +1,37 @@
+export interface FirebaseAnnuityPayment {
+  amount: number;
+  date: string;
+  notes?: string;
+}
+
+export interface AnnuityPayment {
+  id: string;
+  annuityId: string;
+  amount: number;
+  date: Date;
+  notes?: string;
+}
+
+export function annuityPaymentToFirebase(
+  payment: Omit<AnnuityPayment, "id">,
+): FirebaseAnnuityPayment {
+  return {
+    amount: payment.amount,
+    date: payment.date.toISOString(),
+    notes: payment.notes,
+  };
+}
+
+export function firebaseToAnnuityPayment(
+  id: string,
+  annuityId: string,
+  data: FirebaseAnnuityPayment,
+): AnnuityPayment {
+  return {
+    id,
+    annuityId,
+    amount: data.amount,
+    date: new Date(data.date),
+    notes: data.notes,
+  };
+}

--- a/src/lib/firebase/schema/index.ts
+++ b/src/lib/firebase/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./accounts";
 export * from "./annuities";
+export * from "./annuity-payments";
 export * from "./budget-ledger-transactions";
 export * from "./budget-ledgers";
 export * from "./investments";

--- a/src/services/annuity-payments.spec.ts
+++ b/src/services/annuity-payments.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  ref: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  push: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import { get, getDatabase, push, ref, remove, set } from "firebase/database";
+
+import {
+  createAnnuityPayment,
+  deleteAnnuityPayment,
+  getAnnuityPayments,
+} from "./annuity-payments";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getAnnuityPayments", () => {
+  it("returns an empty array when no data exists", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    const result = await getAnnuityPayments("uid-1", "ann-1");
+    expect(result).toEqual([]);
+  });
+
+  it("queries the correct firebase path", async () => {
+    vi.mocked(get).mockResolvedValue({ exists: () => false } as never);
+    await getAnnuityPayments("uid-1", "ann-1");
+    expect(ref).toHaveBeenCalledWith(
+      mockDb,
+      "users/uid-1/annuityPayments/ann-1",
+    );
+  });
+
+  it("returns mapped payments when data exists", async () => {
+    vi.mocked(get).mockResolvedValue({
+      exists: () => true,
+      val: () => ({
+        "pay-1": {
+          amount: 250,
+          date: "2024-03-01T00:00:00.000Z",
+        },
+      }),
+    } as never);
+
+    const result = await getAnnuityPayments("uid-1", "ann-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "pay-1",
+      annuityId: "ann-1",
+      amount: 250,
+    });
+    expect(result[0]!.date).toBeInstanceOf(Date);
+  });
+});
+
+describe("createAnnuityPayment", () => {
+  it("pushes to firebase and returns the new payment", async () => {
+    const newRef = { key: "pay-new", type: "new-ref" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    const date = new Date("2024-03-01T00:00:00.000Z");
+    const result = await createAnnuityPayment("uid-1", "ann-1", {
+      amount: 300,
+      date,
+    });
+
+    expect(push).toHaveBeenCalledWith(mockRef);
+    expect(result.id).toBe("pay-new");
+    expect(result.annuityId).toBe("ann-1");
+    expect(result.amount).toBe(300);
+  });
+
+  it("queries the correct firebase path for the collection", async () => {
+    const newRef = { key: "pay-new" };
+    vi.mocked(push).mockReturnValue(newRef as never);
+    vi.mocked(set).mockResolvedValue(undefined);
+
+    await createAnnuityPayment("uid-1", "ann-1", {
+      amount: 100,
+      date: new Date(),
+    });
+
+    expect(ref).toHaveBeenCalledWith(
+      mockDb,
+      "users/uid-1/annuityPayments/ann-1",
+    );
+  });
+
+  it("throws when the new ref has no key", async () => {
+    vi.mocked(push).mockReturnValue({ key: null } as never);
+    await expect(
+      createAnnuityPayment("uid-1", "ann-1", {
+        amount: 100,
+        date: new Date(),
+      }),
+    ).rejects.toThrow("Failed to generate annuity payment key");
+  });
+});
+
+describe("deleteAnnuityPayment", () => {
+  it("calls remove on the correct ref", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteAnnuityPayment("uid-1", "ann-1", "pay-1");
+    expect(remove).toHaveBeenCalledWith(mockRef);
+  });
+
+  it("uses the correct firebase path for the payment", async () => {
+    vi.mocked(remove).mockResolvedValue(undefined);
+    await deleteAnnuityPayment("uid-1", "ann-1", "pay-1");
+    expect(ref).toHaveBeenCalledWith(
+      mockDb,
+      "users/uid-1/annuityPayments/ann-1/pay-1",
+    );
+  });
+});

--- a/src/services/annuity-payments.ts
+++ b/src/services/annuity-payments.ts
@@ -43,7 +43,7 @@ export async function createAnnuityPayment(
   if (!newRef.key) {
     throw new Error("Failed to generate annuity payment key");
   }
-  await set(newRef, annuityPaymentToFirebase({ annuityId, ...data }));
+  await set(newRef, annuityPaymentToFirebase(data));
   return { id: newRef.key, annuityId, ...data };
 }
 

--- a/src/services/annuity-payments.ts
+++ b/src/services/annuity-payments.ts
@@ -1,0 +1,56 @@
+import { get, getDatabase, push, ref, remove, set } from "firebase/database";
+
+import { getClientApp } from "@/lib/firebase/client";
+import {
+  type AnnuityPayment,
+  annuityPaymentToFirebase,
+  type FirebaseAnnuityPayment,
+  firebaseToAnnuityPayment,
+} from "@/lib/firebase/schema/annuity-payments";
+
+function db() {
+  return getDatabase(getClientApp());
+}
+
+function annuityPaymentsRef(uid: string, annuityId: string) {
+  return ref(db(), `users/${uid}/annuityPayments/${annuityId}`);
+}
+
+function annuityPaymentRef(uid: string, annuityId: string, id: string) {
+  return ref(db(), `users/${uid}/annuityPayments/${annuityId}/${id}`);
+}
+
+export async function getAnnuityPayments(
+  uid: string,
+  annuityId: string,
+): Promise<AnnuityPayment[]> {
+  const snapshot = await get(annuityPaymentsRef(uid, annuityId));
+  if (!snapshot.exists()) {
+    return [];
+  }
+  const data = snapshot.val() as Record<string, FirebaseAnnuityPayment>;
+  return Object.entries(data).map(([id, entry]) =>
+    firebaseToAnnuityPayment(id, annuityId, entry),
+  );
+}
+
+export async function createAnnuityPayment(
+  uid: string,
+  annuityId: string,
+  data: Omit<AnnuityPayment, "id" | "annuityId">,
+): Promise<AnnuityPayment> {
+  const newRef = push(annuityPaymentsRef(uid, annuityId));
+  if (!newRef.key) {
+    throw new Error("Failed to generate annuity payment key");
+  }
+  await set(newRef, annuityPaymentToFirebase({ annuityId, ...data }));
+  return { id: newRef.key, annuityId, ...data };
+}
+
+export async function deleteAnnuityPayment(
+  uid: string,
+  annuityId: string,
+  id: string,
+): Promise<void> {
+  await remove(annuityPaymentRef(uid, annuityId, id));
+}


### PR DESCRIPTION
Adds the data layer for recording actual monthly annuity payments: a Firebase schema (`AnnuityPayment` / `FirebaseAnnuityPayment`) with `annuityPaymentToFirebase` / `firebaseToAnnuityPayment` conversion functions, a service module (`createAnnuityPayment`, `getAnnuityPayments`, `deleteAnnuityPayment`) storing payments under `users/{uid}/annuityPayments/{annuityId}/`, and a `useAnnuityPayments(uid, annuityId)` hook for real-time subscription. Payments are additive (new Firebase path, no existing data affected).

The storage path mirrors the budget-ledger-transactions pattern: annuityId is a path segment rather than a stored field. The hook follows the same `onValue` subscription shape as `useAnnuities`.

## Acceptance Criteria
- [x] Schema defines `AnnuityPayment` and `FirebaseAnnuityPayment` types with conversion functions that handle date string ↔ Date
- [x] `createAnnuityPayment` stores a payment under `users/{uid}/annuityPayments/{annuityId}/` and returns it with its generated id
- [x] `getAnnuityPayments` retrieves all payments for an annuity, returning `[]` when none exist
- [x] `deleteAnnuityPayment` removes a specific payment record
- [x] `useAnnuityPayments(uid, annuityId)` hook provides real-time payment data with `isLoading` / `error` states

## Tests
26 tests added, all passing.

Closes #196

---
*Created by Claude Sonnet 4.5*