### PR TITLE
feat(annuities): implement payment history table and balance trend

### DIFF
--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -138,8 +138,11 @@ export default function AnnuitiesPage() {
 
           {selectedAnnuity !== undefined && (
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <AnnuityPaymentHistoryTable annuity={selectedAnnuity} />
-              <AnnuityBalanceTrend annuity={selectedAnnuity} />
+              <AnnuityPaymentHistoryTable
+                annuity={selectedAnnuity}
+                payments={[]}
+              />
+              <AnnuityBalanceTrend annuity={selectedAnnuity} payments={[]} />
             </div>
           )}
         </>

--- a/src/app/(app)/annuities/page.tsx
+++ b/src/app/(app)/annuities/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/annuities/copy";
 import { Button } from "@/components/ui/button";
 import { useAnnuities } from "@/hooks/use-annuities";
+import { useAnnuityPayments } from "@/hooks/use-annuity-payments";
 import { useAuth } from "@/hooks/use-auth";
 import { useDeleteAnnuity } from "@/hooks/use-delete-annuity";
 import { useUpdateAnnuity } from "@/hooks/use-update-annuity";
@@ -47,6 +48,13 @@ export default function AnnuitiesPage() {
     undefined,
   );
   const [deleteError, setDeleteError] = useState<string | undefined>(undefined);
+
+  const selectedAnnuityId =
+    (annuities.find((a) => a.id === selectedId) ?? annuities[0])?.id ?? "";
+  const { payments: selectedPayments } = useAnnuityPayments(
+    uid,
+    selectedAnnuityId,
+  );
 
   if (authLoading || !user) {
     return null;
@@ -140,9 +148,12 @@ export default function AnnuitiesPage() {
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <AnnuityPaymentHistoryTable
                 annuity={selectedAnnuity}
-                payments={[]}
+                payments={selectedPayments}
               />
-              <AnnuityBalanceTrend annuity={selectedAnnuity} payments={[]} />
+              <AnnuityBalanceTrend
+                annuity={selectedAnnuity}
+                payments={selectedPayments}
+              />
             </div>
           )}
         </>

--- a/src/components/annuities/AnnuityBalanceTrend.spec.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.spec.tsx
@@ -133,4 +133,59 @@ describe("AnnuityBalanceTrend", () => {
       expect(nowValue?.textContent).not.toBe("$10,000.00");
     });
   });
+
+  describe("renders payments-remaining count in the Payoff cell", () => {
+    it("shows the singular form when exactly 1 payment remains", () => {
+      render(
+        <AnnuityBalanceTrend
+          annuity={makeAnnuity({ durationMonths: 5 })}
+          payments={Array.from({ length: 4 }, (_, i) => ({
+            id: `p${String(i + 1)}`,
+            amount: 100,
+            date: new Date(`2024-0${String(i + 1)}-01T00:00:00.000Z`),
+          }))}
+        />,
+      );
+      const payoffLabel = screen.getByText(
+        ANNUITY_CARD_COPY.balanceTrendPayoffLabel,
+      );
+      expect(payoffLabel.nextElementSibling?.textContent).toBe(
+        ANNUITY_CARD_COPY.balanceTrendPaymentsRemainingCount(1),
+      );
+    });
+
+    it("shows the plural form when 2 or more payments remain", () => {
+      render(
+        <AnnuityBalanceTrend
+          annuity={makeAnnuity({ durationMonths: 10 })}
+          payments={Array.from({ length: 3 }, (_, i) => ({
+            id: `p${String(i + 1)}`,
+            amount: 100,
+            date: new Date(`2024-0${String(i + 1)}-01T00:00:00.000Z`),
+          }))}
+        />,
+      );
+      const payoffLabel = screen.getByText(
+        ANNUITY_CARD_COPY.balanceTrendPayoffLabel,
+      );
+      expect(payoffLabel.nextElementSibling?.textContent).toBe(
+        ANNUITY_CARD_COPY.balanceTrendPaymentsRemainingCount(7),
+      );
+    });
+
+    it("shows the placeholder when durationMonths is undefined", () => {
+      render(
+        <AnnuityBalanceTrend
+          annuity={makeAnnuity({ durationMonths: undefined })}
+          payments={[]}
+        />,
+      );
+      const payoffLabel = screen.getByText(
+        ANNUITY_CARD_COPY.balanceTrendPayoffLabel,
+      );
+      expect(payoffLabel.nextElementSibling?.textContent).toBe(
+        ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      );
+    });
+  });
 });

--- a/src/components/annuities/AnnuityBalanceTrend.spec.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.spec.tsx
@@ -25,7 +25,10 @@ describe("AnnuityBalanceTrend", () => {
   describe("renders the section title with the annuity name", () => {
     it("shows the annuity name uppercased in the title", () => {
       render(
-        <AnnuityBalanceTrend annuity={makeAnnuity({ name: "Auto Loan" })} />,
+        <AnnuityBalanceTrend
+          annuity={makeAnnuity({ name: "Auto Loan" })}
+          payments={[]}
+        />,
       );
       expect(
         screen.getByText(ANNUITY_CARD_COPY.balanceTrendTitle("AUTO LOAN")),
@@ -35,7 +38,7 @@ describe("AnnuityBalanceTrend", () => {
 
   describe("renders the chart placeholder", () => {
     it("renders an element with the chart placeholder label", () => {
-      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} payments={[]} />);
       expect(
         screen.getByRole("img", {
           name: ANNUITY_CARD_COPY.balanceTrendChartPlaceholder,
@@ -46,24 +49,88 @@ describe("AnnuityBalanceTrend", () => {
 
   describe("renders the Started / Now / Payoff summary row", () => {
     it("renders the Started label", () => {
-      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} payments={[]} />);
       expect(
         screen.getByText(ANNUITY_CARD_COPY.balanceTrendStartedLabel),
       ).toBeDefined();
     });
 
     it("renders the Now label", () => {
-      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} payments={[]} />);
       expect(
         screen.getByText(ANNUITY_CARD_COPY.balanceTrendNowLabel),
       ).toBeDefined();
     });
 
     it("renders the Payoff label", () => {
-      render(<AnnuityBalanceTrend annuity={makeAnnuity()} />);
+      render(<AnnuityBalanceTrend annuity={makeAnnuity()} payments={[]} />);
       expect(
         screen.getByText(ANNUITY_CARD_COPY.balanceTrendPayoffLabel),
       ).toBeDefined();
+    });
+  });
+
+  describe("shows presentValue as Started for a PV-derived annuity", () => {
+    it("displays the formatted presentValue under the Started label", () => {
+      const pvAnnuity = makeAnnuity({
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
+        presentValue: 10000,
+        annualRatePercent: 5,
+        durationMonths: 12,
+      });
+      render(<AnnuityBalanceTrend annuity={pvAnnuity} payments={[]} />);
+      expect(screen.getAllByText("$10,000.00").length).toBeGreaterThanOrEqual(
+        1,
+      );
+    });
+
+    it("displays placeholder when annuity has no presentValue", () => {
+      render(
+        <AnnuityBalanceTrend
+          annuity={makeAnnuity({ presentValue: undefined })}
+          payments={[]}
+        />,
+      );
+      const placeholders = screen.getAllByText(
+        ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      );
+      expect(placeholders.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("shows computed Now balance for a PV-derived annuity", () => {
+    it("shows the presentValue as Now balance when 0 payments have been made", () => {
+      const pvAnnuity = makeAnnuity({
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
+        presentValue: 10000,
+        annualRatePercent: 5,
+        durationMonths: 12,
+      });
+      render(<AnnuityBalanceTrend annuity={pvAnnuity} payments={[]} />);
+      // Both Started and Now show $10,000.00 when no payments have been made
+      const values = screen.getAllByText("$10,000.00");
+      expect(values.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("shows a reduced Now balance after some payments", () => {
+      const pvAnnuity = makeAnnuity({
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
+        presentValue: 10000,
+        annualRatePercent: 5,
+        durationMonths: 12,
+      });
+      const payments = Array.from({ length: 6 }, (_, i) => ({
+        id: `p${String(i + 1)}`,
+        amount: 856.07,
+        date: new Date(`2024-0${String(i + 1)}-01T00:00:00.000Z`),
+      }));
+      render(<AnnuityBalanceTrend annuity={pvAnnuity} payments={payments} />);
+      const nowLabel = screen.getByText(ANNUITY_CARD_COPY.balanceTrendNowLabel);
+      const nowValue = nowLabel.nextElementSibling;
+      expect(nowValue?.textContent).not.toBe(
+        ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      );
+      expect(nowValue?.textContent).not.toBe("$10,000.00");
     });
   });
 });

--- a/src/components/annuities/AnnuityBalanceTrend.stories.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.stories.tsx
@@ -22,5 +22,6 @@ export const Default: Story = {
       durationMonths: 360,
       monthlyMode: AnnuityMonthlyMode.PVDerived,
     },
+    payments: [],
   },
 };

--- a/src/components/annuities/AnnuityBalanceTrend.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.tsx
@@ -54,7 +54,7 @@ export function AnnuityBalanceTrend({
 
   const payoffValue =
     annuity.durationMonths !== undefined
-      ? ANNUITY_CARD_COPY.termRemainingMonths(
+      ? ANNUITY_CARD_COPY.balanceTrendPaymentsRemainingCount(
           Math.max(0, annuity.durationMonths - payments.length),
         )
       : placeholder;

--- a/src/components/annuities/AnnuityBalanceTrend.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.tsx
@@ -5,8 +5,8 @@ import { calculateRemainingPrincipal } from "@/lib/annuity-math";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
 import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
-import type { AnnuityPaymentRecord } from "./AnnuityPaymentHistoryTable";
 import { ANNUITY_CARD_COPY } from "./copy";
+import type { AnnuityPaymentRecord } from "./types";
 
 export interface AnnuityBalanceTrendProps {
   annuity: Annuity;

--- a/src/components/annuities/AnnuityBalanceTrend.tsx
+++ b/src/components/annuities/AnnuityBalanceTrend.tsx
@@ -1,15 +1,64 @@
 "use client";
 
 import { Card } from "@/components/ui/card";
+import { calculateRemainingPrincipal } from "@/lib/annuity-math";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
+import type { AnnuityPaymentRecord } from "./AnnuityPaymentHistoryTable";
 import { ANNUITY_CARD_COPY } from "./copy";
 
 export interface AnnuityBalanceTrendProps {
   annuity: Annuity;
+  payments: AnnuityPaymentRecord[];
 }
 
-export function AnnuityBalanceTrend({ annuity }: AnnuityBalanceTrendProps) {
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const placeholder = ANNUITY_CARD_COPY.balanceTrendPlaceholderValue;
+
+export function AnnuityBalanceTrend({
+  annuity,
+  payments,
+}: AnnuityBalanceTrendProps) {
+  const startedValue =
+    annuity.presentValue !== undefined
+      ? currencyFormatter.format(annuity.presentValue)
+      : placeholder;
+
+  const nowValue =
+    annuity.presentValue !== undefined &&
+    annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
+    annuity.annualRatePercent !== undefined &&
+    annuity.durationMonths !== undefined
+      ? currencyFormatter.format(
+          calculateRemainingPrincipal({
+            annualRatePercent: annuity.annualRatePercent,
+            durationMonths: annuity.durationMonths,
+            monthsElapsed: payments.length,
+            presentValue: annuity.presentValue,
+          }),
+        )
+      : annuity.presentValue !== undefined
+        ? currencyFormatter.format(
+            Math.max(
+              0,
+              annuity.presentValue -
+                payments.reduce((sum, p) => sum + p.amount, 0),
+            ),
+          )
+        : placeholder;
+
+  const payoffValue =
+    annuity.durationMonths !== undefined
+      ? ANNUITY_CARD_COPY.termRemainingMonths(
+          Math.max(0, annuity.durationMonths - payments.length),
+        )
+      : placeholder;
+
   return (
     <Card className="flex flex-col gap-4 p-4">
       <h3 className="text-sm font-semibold">
@@ -28,25 +77,19 @@ export function AnnuityBalanceTrend({ annuity }: AnnuityBalanceTrendProps) {
           <p className="text-xs text-muted-foreground">
             {ANNUITY_CARD_COPY.balanceTrendStartedLabel}
           </p>
-          <p className="font-medium">
-            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
-          </p>
+          <p className="font-medium">{startedValue}</p>
         </div>
         <div className="px-2">
           <p className="text-xs text-muted-foreground">
             {ANNUITY_CARD_COPY.balanceTrendNowLabel}
           </p>
-          <p className="font-medium">
-            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
-          </p>
+          <p className="font-medium">{nowValue}</p>
         </div>
         <div className="px-2">
           <p className="text-xs text-muted-foreground">
             {ANNUITY_CARD_COPY.balanceTrendPayoffLabel}
           </p>
-          <p className="font-medium">
-            {ANNUITY_CARD_COPY.balanceTrendPlaceholderValue}
-          </p>
+          <p className="font-medium">{payoffValue}</p>
         </div>
       </div>
     </Card>

--- a/src/components/annuities/AnnuityPaymentHistoryTable.spec.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.spec.tsx
@@ -27,6 +27,7 @@ describe("AnnuityPaymentHistoryTable", () => {
       render(
         <AnnuityPaymentHistoryTable
           annuity={makeAnnuity({ name: "Car Loan" })}
+          payments={[]}
         />,
       );
       expect(
@@ -37,22 +38,108 @@ describe("AnnuityPaymentHistoryTable", () => {
 
   describe("renders table column headers", () => {
     it("shows the Month column header", () => {
-      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      render(
+        <AnnuityPaymentHistoryTable annuity={makeAnnuity()} payments={[]} />,
+      );
       expect(screen.getByText(ANNUITY_CARD_COPY.columnMonth)).toBeDefined();
     });
 
     it("shows the Balance column header", () => {
-      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      render(
+        <AnnuityPaymentHistoryTable annuity={makeAnnuity()} payments={[]} />,
+      );
       expect(screen.getByText(ANNUITY_CARD_COPY.columnBalance)).toBeDefined();
     });
   });
 
-  describe("renders empty state", () => {
+  describe("renders empty state when no payments exist", () => {
     it("shows the empty-state message when no payments exist", () => {
-      render(<AnnuityPaymentHistoryTable annuity={makeAnnuity()} />);
+      render(
+        <AnnuityPaymentHistoryTable annuity={makeAnnuity()} payments={[]} />,
+      );
       expect(
         screen.getByText(ANNUITY_CARD_COPY.paymentHistoryEmpty),
       ).toBeDefined();
+    });
+  });
+
+  describe("renders one row per payment when payments exist", () => {
+    it("does not show the empty-state message when payments exist", () => {
+      render(
+        <AnnuityPaymentHistoryTable
+          annuity={makeAnnuity()}
+          payments={[
+            {
+              id: "p1",
+              amount: 100,
+              date: new Date("2024-01-15T00:00:00.000Z"),
+            },
+          ]}
+        />,
+      );
+      expect(
+        screen.queryByText(ANNUITY_CARD_COPY.paymentHistoryEmpty),
+      ).toBeNull();
+    });
+
+    it("shows the payment amount formatted as currency", () => {
+      render(
+        <AnnuityPaymentHistoryTable
+          annuity={makeAnnuity()}
+          payments={[
+            {
+              id: "p1",
+              amount: 856.07,
+              date: new Date("2024-03-10T00:00:00.000Z"),
+            },
+          ]}
+        />,
+      );
+      expect(screen.getByText("$856.07")).toBeDefined();
+    });
+
+    it("shows the payment date formatted as month and year", () => {
+      render(
+        <AnnuityPaymentHistoryTable
+          annuity={makeAnnuity()}
+          payments={[
+            {
+              id: "p1",
+              amount: 100,
+              date: new Date("2024-01-15T00:00:00.000Z"),
+            },
+          ]}
+        />,
+      );
+      expect(screen.getByText("Jan 2024")).toBeDefined();
+    });
+  });
+
+  describe("shows principal and interest breakdown for PV-derived annuities", () => {
+    it("shows non-placeholder principal and interest values for a PV-derived annuity", () => {
+      const pvAnnuity = makeAnnuity({
+        monthlyMode: AnnuityMonthlyMode.PVDerived,
+        presentValue: 10000,
+        annualRatePercent: 5,
+        durationMonths: 12,
+      });
+      render(
+        <AnnuityPaymentHistoryTable
+          annuity={pvAnnuity}
+          payments={[
+            {
+              id: "p1",
+              amount: 856.07,
+              date: new Date("2024-01-15T00:00:00.000Z"),
+            },
+          ]}
+        />,
+      );
+      // Principal and Interest columns should show computed currency values, not "—"
+      const placeholders = screen.queryAllByText(
+        ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      );
+      expect(placeholders.length).toBe(0);
     });
   });
 });

--- a/src/components/annuities/AnnuityPaymentHistoryTable.stories.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.stories.tsx
@@ -22,5 +22,6 @@ export const Default: Story = {
       durationMonths: 360,
       monthlyMode: AnnuityMonthlyMode.PVDerived,
     },
+    payments: [],
   },
 };

--- a/src/components/annuities/AnnuityPaymentHistoryTable.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.tsx
@@ -6,13 +6,9 @@ import type { Annuity } from "@/lib/firebase/schema/annuities";
 import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
 import { ANNUITY_CARD_COPY } from "./copy";
+import type { AnnuityPaymentRecord } from "./types";
 
-export interface AnnuityPaymentRecord {
-  id: string;
-  amount: number;
-  date: Date;
-  notes?: string;
-}
+export type { AnnuityPaymentRecord } from "./types";
 
 export interface AnnuityPaymentHistoryTableProps {
   annuity: Annuity;
@@ -42,13 +38,16 @@ function buildRows(
   annuity: Annuity,
   payments: AnnuityPaymentRecord[],
 ): PaymentRowData[] {
+  const sorted = [...payments].sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
   const isPVDerived =
     annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
     annuity.presentValue !== undefined &&
     annuity.annualRatePercent !== undefined &&
     annuity.durationMonths !== undefined;
 
-  return payments.map((payment, index) => {
+  return sorted.map((payment, index) => {
     const month = monthFormatter.format(payment.date);
     const paymentFormatted = currencyFormatter.format(payment.amount);
 
@@ -88,9 +87,7 @@ function buildRows(
         ? Math.max(
             0,
             annuity.presentValue -
-              payments
-                .slice(0, index + 1)
-                .reduce((sum, p) => sum + p.amount, 0),
+              sorted.slice(0, index + 1).reduce((sum, p) => sum + p.amount, 0),
           )
         : undefined;
 

--- a/src/components/annuities/AnnuityPaymentHistoryTable.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.tsx
@@ -1,17 +1,119 @@
 "use client";
 
 import { Card } from "@/components/ui/card";
+import { calculateRemainingPrincipal } from "@/lib/annuity-math";
 import type { Annuity } from "@/lib/firebase/schema/annuities";
+import { AnnuityMonthlyMode } from "@/lib/firebase/schema/annuities";
 
 import { ANNUITY_CARD_COPY } from "./copy";
 
+export interface AnnuityPaymentRecord {
+  id: string;
+  amount: number;
+  date: Date;
+  notes?: string;
+}
+
 export interface AnnuityPaymentHistoryTableProps {
   annuity: Annuity;
+  payments: AnnuityPaymentRecord[];
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});
+
+interface PaymentRowData {
+  id: string;
+  month: string;
+  payment: string;
+  principal: string;
+  interest: string;
+  balance: string;
+}
+
+function buildRows(
+  annuity: Annuity,
+  payments: AnnuityPaymentRecord[],
+): PaymentRowData[] {
+  const isPVDerived =
+    annuity.monthlyMode === AnnuityMonthlyMode.PVDerived &&
+    annuity.presentValue !== undefined &&
+    annuity.annualRatePercent !== undefined &&
+    annuity.durationMonths !== undefined;
+
+  return payments.map((payment, index) => {
+    const month = monthFormatter.format(payment.date);
+    const paymentFormatted = currencyFormatter.format(payment.amount);
+
+    if (
+      isPVDerived &&
+      annuity.presentValue !== undefined &&
+      annuity.annualRatePercent !== undefined &&
+      annuity.durationMonths !== undefined
+    ) {
+      const commonArgs = {
+        annualRatePercent: annuity.annualRatePercent,
+        durationMonths: annuity.durationMonths,
+        presentValue: annuity.presentValue,
+      };
+      const balanceBefore = calculateRemainingPrincipal({
+        ...commonArgs,
+        monthsElapsed: index,
+      });
+      const balanceAfter = calculateRemainingPrincipal({
+        ...commonArgs,
+        monthsElapsed: index + 1,
+      });
+      const principal = balanceBefore - balanceAfter;
+      const interest = payment.amount - principal;
+      return {
+        id: payment.id,
+        month,
+        payment: paymentFormatted,
+        principal: currencyFormatter.format(principal),
+        interest: currencyFormatter.format(interest),
+        balance: currencyFormatter.format(balanceAfter),
+      };
+    }
+
+    const balanceAfter =
+      annuity.presentValue !== undefined
+        ? Math.max(
+            0,
+            annuity.presentValue -
+              payments
+                .slice(0, index + 1)
+                .reduce((sum, p) => sum + p.amount, 0),
+          )
+        : undefined;
+
+    return {
+      id: payment.id,
+      month,
+      payment: paymentFormatted,
+      principal: ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      interest: ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+      balance:
+        balanceAfter !== undefined
+          ? currencyFormatter.format(balanceAfter)
+          : ANNUITY_CARD_COPY.balanceTrendPlaceholderValue,
+    };
+  });
 }
 
 export function AnnuityPaymentHistoryTable({
   annuity,
+  payments,
 }: AnnuityPaymentHistoryTableProps) {
+  const rows = buildRows(annuity, payments);
+
   return (
     <Card>
       <div className="px-4 py-3">
@@ -41,14 +143,34 @@ export function AnnuityPaymentHistoryTable({
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td
-                colSpan={5}
-                className="px-4 py-8 text-center text-muted-foreground"
-              >
-                {ANNUITY_CARD_COPY.paymentHistoryEmpty}
-              </td>
-            </tr>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  {ANNUITY_CARD_COPY.paymentHistoryEmpty}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr key={row.id} className="border-b last:border-0">
+                  <td className="px-4 py-2">{row.month}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {row.payment}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {row.principal}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {row.interest}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {row.balance}
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/components/annuities/AnnuityPaymentHistoryTable.tsx
+++ b/src/components/annuities/AnnuityPaymentHistoryTable.tsx
@@ -70,8 +70,9 @@ function buildRows(
         ...commonArgs,
         monthsElapsed: index + 1,
       });
+      const monthlyRate = annuity.annualRatePercent / 100 / 12;
+      const interest = balanceBefore * monthlyRate;
       const principal = balanceBefore - balanceAfter;
-      const interest = payment.amount - principal;
       return {
         id: payment.id,
         month,

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -1,6 +1,8 @@
 export const ANNUITY_CARD_COPY = {
   balanceTrendChartPlaceholder: "Balance trend chart",
   balanceTrendNowLabel: "Now",
+  balanceTrendPaymentsRemainingCount: (count: number) =>
+    count === 1 ? "1 payment left" : `${String(count)} payments left`,
   balanceTrendPayoffLabel: "Payments remaining",
   balanceTrendPlaceholderValue: "—",
   balanceTrendStartedLabel: "Started",

--- a/src/components/annuities/copy.ts
+++ b/src/components/annuities/copy.ts
@@ -1,7 +1,7 @@
 export const ANNUITY_CARD_COPY = {
   balanceTrendChartPlaceholder: "Balance trend chart",
   balanceTrendNowLabel: "Now",
-  balanceTrendPayoffLabel: "Payoff",
+  balanceTrendPayoffLabel: "Payments remaining",
   balanceTrendPlaceholderValue: "—",
   balanceTrendStartedLabel: "Started",
   balanceTrendTitle: (annuityName: string) =>

--- a/src/components/annuities/index.ts
+++ b/src/components/annuities/index.ts
@@ -20,3 +20,4 @@ export { EditAnnuityDialog } from "./EditAnnuityDialog";
 export type { EditAnnuityDialogViewProps } from "./EditAnnuityDialogView";
 export { EditAnnuityDialogView } from "./EditAnnuityDialogView";
 export { NewAnnuityDialog } from "./NewAnnuityDialog";
+export type { AnnuityPaymentRecord } from "./types";

--- a/src/components/annuities/types.ts
+++ b/src/components/annuities/types.ts
@@ -1,6 +1,3 @@
-export interface AnnuityPaymentRecord {
-  id: string;
-  amount: number;
-  date: Date;
-  notes?: string;
-}
+import type { AnnuityPayment } from "@/lib/firebase/schema/annuity-payments";
+
+export type AnnuityPaymentRecord = Omit<AnnuityPayment, "annuityId">;

--- a/src/components/annuities/types.ts
+++ b/src/components/annuities/types.ts
@@ -1,0 +1,6 @@
+export interface AnnuityPaymentRecord {
+  id: string;
+  amount: number;
+  date: Date;
+  notes?: string;
+}


### PR DESCRIPTION
Wires `AnnuityPaymentHistoryTable` and `AnnuityBalanceTrend` to accept a `payments` prop and render real data. Previously both components were shells with no data binding.

`AnnuityPaymentHistoryTable` now renders one row per payment with month, payment amount, principal, interest, and remaining balance. For PV-derived annuities the principal/interest split is computed via amortization math (`calculateRemainingPrincipal`); for flat annuities those columns show a placeholder and balance is tracked as `presentValue − sum(payments)`. An empty-state message is shown when no payments exist.

`AnnuityBalanceTrend` now populates its Started / Now / Payoff summary from the annuity's `presentValue`, remaining balance (same amortization vs flat logic as the table), and remaining term. The page subscribes to `useAnnuityPayments(uid, selectedAnnuityId)` and passes `selectedPayments` to both components.

17 new/updated tests covering: title rendering, column headers, empty state, payment row formatting (currency + month/year), and PV-derived principal/interest breakdown.

Closes #198

---
*Created by Claude Sonnet 4.5*