### PR TITLE
feat(goals): mark goal as purchased with automatic expense recording

### DIFF
--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -5,6 +5,7 @@ import { use, useMemo } from "react";
 
 import { GoalPurchaseView } from "@/components/goal-purchase";
 import { GOAL_PURCHASE_PAGE_COPY } from "@/components/goal-purchase/copy";
+import type { PurchaseFormData } from "@/components/goal-purchase/GoalPurchaseForm";
 import { useAuth } from "@/hooks/use-auth";
 import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
 import { useSavingsGoal } from "@/hooks/use-savings-goal";
@@ -12,6 +13,7 @@ import { useSavingsGoals } from "@/hooks/use-savings-goals";
 import { useTransactions } from "@/hooks/use-transactions";
 import { computeMonthlyDepositRate } from "@/lib/goal-funding";
 import { calculateLedgerBalance } from "@/lib/reconciliation/ledger-balance";
+import { purchaseGoal } from "@/services/goal-purchase";
 
 interface GoalPurchasePageProps {
   params: Promise<{ goalId: string }>;
@@ -63,8 +65,9 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   );
   const siblings = siblingGoals.filter((g) => g.id !== goal.id);
 
-  function handleSubmit() {
-    // TODO: Implement purchase recording in epic #14 (Goal Purchase Flow)
+  async function handleSubmit(data: PurchaseFormData) {
+    if (!goal) return;
+    await purchaseGoal(uid, goal, data);
     router.push("/goals");
   }
 

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -150,6 +150,28 @@ describe("GoalPurchaseForm — actions", () => {
       });
     });
 
+    it("shows an amount error when amount is cleared and submit is clicked", async () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(GOAL_PURCHASE_FORM_COPY.amountLabel),
+        { target: { value: "" } },
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(screen.getByText(GOAL_PURCHASE_FORM_COPY.amountError)).toBeDefined();
+      });
+    });
+
     it("passes the entered description to onSubmit", async () => {
       const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { currencyFormatter } from "@/lib/formatters";
+
 import { GOAL_PURCHASE_FORM_COPY } from "./copy";
 import { GoalPurchaseForm } from "./GoalPurchaseForm";
 
@@ -60,6 +62,32 @@ describe("GoalPurchaseForm — fields", () => {
       expect(
         screen.getByText(GOAL_PURCHASE_FORM_COPY.expenseNote("Travel Fund")),
       ).toBeDefined();
+    });
+
+    it("shows the formatted targetAmount in the expense note by default", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Travel Fund"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(currencyFormatter.format(5000))).toBeDefined();
+    });
+
+    it("updates the expense note preview when the user edits the amount", () => {
+      render(
+        <GoalPurchaseForm
+          ledgerName="Travel Fund"
+          targetAmount={5000}
+          onSubmit={vi.fn()}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(GOAL_PURCHASE_FORM_COPY.amountLabel),
+        { target: { value: "1250.50" } },
+      );
+      expect(screen.getByText(currencyFormatter.format(1250.5))).toBeDefined();
     });
   });
 });

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -274,7 +274,11 @@ describe("GoalPurchaseForm — actions", () => {
     });
 
     it("re-enables the submit button after onSubmit resolves", async () => {
-      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      let resolve: () => void = () => undefined;
+      const deferred = new Promise<void>((res) => {
+        resolve = res;
+      });
+      const onSubmit = vi.fn().mockReturnValue(deferred);
       render(
         <GoalPurchaseForm
           ledgerName="Primary"
@@ -286,6 +290,10 @@ describe("GoalPurchaseForm — actions", () => {
         name: GOAL_PURCHASE_FORM_COPY.submitButton,
       });
       fireEvent.click(button);
+      await vi.waitFor(() => {
+        expect((button as HTMLButtonElement).disabled).toBe(true);
+      });
+      resolve();
       await vi.waitFor(() => {
         expect((button as HTMLButtonElement).disabled).toBe(false);
       });

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -244,6 +244,35 @@ describe("GoalPurchaseForm — actions", () => {
       });
     });
 
+    it("clears a stale submit error when a new submission attempt begins", async () => {
+      const onSubmit = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockResolvedValue(undefined);
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      const button = screen.getByRole("button", {
+        name: GOAL_PURCHASE_FORM_COPY.submitButton,
+      });
+      fireEvent.click(button);
+      await vi.waitFor(() => {
+        expect(
+          screen.getByText(GOAL_PURCHASE_FORM_COPY.submitError),
+        ).toBeDefined();
+      });
+      fireEvent.click(button);
+      await vi.waitFor(() => {
+        expect(
+          screen.queryByText(GOAL_PURCHASE_FORM_COPY.submitError),
+        ).toBeNull();
+      });
+    });
+
     it("re-enables the submit button after onSubmit resolves", async () => {
       const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -98,5 +98,71 @@ describe("GoalPurchaseForm — actions", () => {
       );
       expect(onSubmit).toHaveBeenCalledOnce();
     });
+
+    it("passes the entered amount to onSubmit", () => {
+      const onSubmit = vi.fn();
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(GOAL_PURCHASE_FORM_COPY.amountLabel),
+        { target: { value: "1250.50" } },
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 1250.5 }),
+      );
+    });
+
+    it("passes the entered description to onSubmit", () => {
+      const onSubmit = vi.fn();
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(GOAL_PURCHASE_FORM_COPY.noteLabel),
+        { target: { value: "Studio Display refurb" } },
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Studio Display refurb" }),
+      );
+    });
+
+    it("passes a Date object for the purchase date to onSubmit", () => {
+      const onSubmit = vi.fn();
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      const callArg = (vi.mocked(onSubmit).mock.calls[0] ?? [])[0] as {
+        date: unknown;
+      };
+      expect(callArg.date).toBeInstanceOf(Date);
+    });
   });
 });

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -82,8 +82,8 @@ describe("GoalPurchaseForm — actions", () => {
   });
 
   describe("Mark purchased button calls onSubmit", () => {
-    it("calls onSubmit when the submit button is clicked", () => {
-      const onSubmit = vi.fn();
+    it("calls onSubmit when the submit button is clicked", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(
         <GoalPurchaseForm
           ledgerName="Primary"
@@ -96,11 +96,13 @@ describe("GoalPurchaseForm — actions", () => {
           name: GOAL_PURCHASE_FORM_COPY.submitButton,
         }),
       );
-      expect(onSubmit).toHaveBeenCalledOnce();
+      await vi.waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
     });
 
-    it("passes the entered amount to onSubmit", () => {
-      const onSubmit = vi.fn();
+    it("passes the entered amount to onSubmit", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(
         <GoalPurchaseForm
           ledgerName="Primary"
@@ -117,13 +119,39 @@ describe("GoalPurchaseForm — actions", () => {
           name: GOAL_PURCHASE_FORM_COPY.submitButton,
         }),
       );
+      await vi.waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({ amount: 1250.5 }),
       );
     });
 
-    it("passes the entered description to onSubmit", () => {
-      const onSubmit = vi.fn();
+    it("does not call onSubmit when amount is cleared", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(GOAL_PURCHASE_FORM_COPY.amountLabel),
+        { target: { value: "" } },
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    it("passes the entered description to onSubmit", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(
         <GoalPurchaseForm
           ledgerName="Primary"
@@ -140,13 +168,16 @@ describe("GoalPurchaseForm — actions", () => {
           name: GOAL_PURCHASE_FORM_COPY.submitButton,
         }),
       );
+      await vi.waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({ description: "Studio Display refurb" }),
       );
     });
 
-    it("passes a Date object for the purchase date to onSubmit", () => {
-      const onSubmit = vi.fn();
+    it("passes a Date object for the purchase date to onSubmit", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
       render(
         <GoalPurchaseForm
           ledgerName="Primary"
@@ -159,10 +190,52 @@ describe("GoalPurchaseForm — actions", () => {
           name: GOAL_PURCHASE_FORM_COPY.submitButton,
         }),
       );
+      await vi.waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
       const callArg = (vi.mocked(onSubmit).mock.calls[0] ?? [])[0] as {
         date: unknown;
       };
       expect(callArg.date).toBeInstanceOf(Date);
+    });
+
+    it("shows an error message when onSubmit rejects", async () => {
+      const onSubmit = vi.fn().mockRejectedValue(new Error("network error"));
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: GOAL_PURCHASE_FORM_COPY.submitButton,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(
+          screen.getByText(GOAL_PURCHASE_FORM_COPY.submitError),
+        ).toBeDefined();
+      });
+    });
+
+    it("re-enables the submit button after onSubmit resolves", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      render(
+        <GoalPurchaseForm
+          ledgerName="Primary"
+          targetAmount={5000}
+          onSubmit={onSubmit}
+        />,
+      );
+      const button = screen.getByRole("button", {
+        name: GOAL_PURCHASE_FORM_COPY.submitButton,
+      });
+      fireEvent.click(button);
+      await vi.waitFor(() => {
+        expect((button as HTMLButtonElement).disabled).toBe(false);
+      });
     });
   });
 });

--- a/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.spec.tsx
@@ -168,7 +168,9 @@ describe("GoalPurchaseForm — actions", () => {
         }),
       );
       await vi.waitFor(() => {
-        expect(screen.getByText(GOAL_PURCHASE_FORM_COPY.amountError)).toBeDefined();
+        expect(
+          screen.getByText(GOAL_PURCHASE_FORM_COPY.amountError),
+        ).toBeDefined();
       });
     });
 

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -22,21 +22,42 @@ export interface GoalPurchaseFormProps {
   onSubmit: (data: PurchaseFormData) => Promise<void> | void;
 }
 
+function localDateString(d: Date): string {
+  const year = String(d.getFullYear());
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 export function GoalPurchaseForm({
   ledgerName,
   targetAmount,
   onSubmit,
 }: GoalPurchaseFormProps) {
-  const [amount, setAmount] = useState(targetAmount);
-  const [dateStr, setDateStr] = useState(new Date().toISOString().slice(0, 10));
+  const [amountStr, setAmountStr] = useState(String(targetAmount));
+  const [dateStr, setDateStr] = useState(localDateString(new Date()));
   const [description, setDescription] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | undefined>();
 
-  function handleSubmit() {
-    void onSubmit({
-      amount,
-      date: new Date(dateStr),
-      description,
-    });
+  async function handleSubmit() {
+    const amount = parseFloat(amountStr);
+    if (isNaN(amount) || amount <= 0) {
+      return;
+    }
+    setIsSubmitting(true);
+    setSubmitError(undefined);
+    try {
+      await onSubmit({
+        amount,
+        date: new Date(`${dateStr}T00:00:00`),
+        description,
+      });
+    } catch {
+      setSubmitError(GOAL_PURCHASE_FORM_COPY.submitError);
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -54,9 +75,9 @@ export function GoalPurchaseForm({
             type="number"
             min={0}
             step={0.01}
-            value={amount}
+            value={amountStr}
             onChange={(e) => {
-              setAmount(parseFloat(e.target.value));
+              setAmountStr(e.target.value);
             }}
             className="pl-6"
           />
@@ -100,6 +121,10 @@ export function GoalPurchaseForm({
         </span>
       </div>
 
+      {submitError !== undefined && (
+        <p className="text-sm text-destructive">{submitError}</p>
+      )}
+
       <div className="flex items-center justify-between">
         <Link
           href="/goals"
@@ -107,7 +132,12 @@ export function GoalPurchaseForm({
         >
           {GOAL_PURCHASE_FORM_COPY.cancelButton}
         </Link>
-        <Button onClick={handleSubmit}>
+        <Button
+          onClick={() => {
+            void handleSubmit();
+          }}
+          disabled={isSubmitting}
+        >
           {GOAL_PURCHASE_FORM_COPY.submitButton}
         </Button>
       </div>

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -44,6 +44,7 @@ export function GoalPurchaseForm({
 
   async function handleSubmit() {
     if (isSubmitting) return;
+    setSubmitError(undefined);
     let valid = true;
 
     const amount = parseFloat(amountStr);
@@ -65,7 +66,6 @@ export function GoalPurchaseForm({
     if (!valid) return;
 
     setIsSubmitting(true);
-    setSubmitError(undefined);
     try {
       await onSubmit({
         amount,
@@ -80,7 +80,14 @@ export function GoalPurchaseForm({
   }
 
   return (
-    <div className="flex flex-col gap-5">
+    <form
+      noValidate
+      className="flex flex-col gap-5"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void handleSubmit();
+      }}
+    >
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="purchase-amount">
           {GOAL_PURCHASE_FORM_COPY.amountLabel}
@@ -92,7 +99,7 @@ export function GoalPurchaseForm({
           <Input
             id="purchase-amount"
             type="number"
-            min={0}
+            min="0.01"
             step={0.01}
             value={amountStr}
             onChange={(e) => {
@@ -179,15 +186,10 @@ export function GoalPurchaseForm({
         >
           {GOAL_PURCHASE_FORM_COPY.cancelButton}
         </Link>
-        <Button
-          onClick={() => {
-            void handleSubmit();
-          }}
-          disabled={isSubmitting}
-        >
+        <Button type="submit" disabled={isSubmitting}>
           {GOAL_PURCHASE_FORM_COPY.submitButton}
         </Button>
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -104,6 +104,7 @@ export function GoalPurchaseForm({
             value={amountStr}
             onChange={(e) => {
               setAmountStr(e.target.value);
+              setAmountError(undefined);
             }}
             className="pl-6"
             aria-invalid={amountError !== undefined}
@@ -133,6 +134,7 @@ export function GoalPurchaseForm({
           value={dateStr}
           onChange={(e) => {
             setDateStr(e.target.value);
+            setDateError(undefined);
           }}
           aria-invalid={dateError !== undefined}
           aria-describedby={

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -171,7 +171,7 @@ export function GoalPurchaseForm({
       <div className="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
         <span>{GOAL_PURCHASE_FORM_COPY.expenseNote(ledgerName)}</span>
         <span className="font-mono font-medium text-foreground">
-          {currencyFormatter.format(targetAmount)}
+          {currencyFormatter.format(parseFloat(amountStr) || targetAmount)}
         </span>
       </div>
 

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -37,20 +37,39 @@ export function GoalPurchaseForm({
   const [amountStr, setAmountStr] = useState(String(targetAmount));
   const [dateStr, setDateStr] = useState(localDateString(new Date()));
   const [description, setDescription] = useState("");
+  const [amountError, setAmountError] = useState<string | undefined>();
+  const [dateError, setDateError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | undefined>();
 
   async function handleSubmit() {
+    if (isSubmitting) return;
+    let valid = true;
+
     const amount = parseFloat(amountStr);
     if (isNaN(amount) || amount <= 0) {
-      return;
+      setAmountError(GOAL_PURCHASE_FORM_COPY.amountError);
+      valid = false;
+    } else {
+      setAmountError(undefined);
     }
+
+    const date = new Date(`${dateStr}T00:00:00`);
+    if (!dateStr || isNaN(date.getTime())) {
+      setDateError(GOAL_PURCHASE_FORM_COPY.dateError);
+      valid = false;
+    } else {
+      setDateError(undefined);
+    }
+
+    if (!valid) return;
+
     setIsSubmitting(true);
     setSubmitError(undefined);
     try {
       await onSubmit({
         amount,
-        date: new Date(`${dateStr}T00:00:00`),
+        date,
         description,
       });
     } catch {
@@ -80,8 +99,21 @@ export function GoalPurchaseForm({
               setAmountStr(e.target.value);
             }}
             className="pl-6"
+            aria-invalid={amountError !== undefined}
+            aria-describedby={
+              amountError !== undefined ? "purchase-amount-error" : undefined
+            }
           />
         </div>
+        {amountError !== undefined && (
+          <p
+            id="purchase-amount-error"
+            role="alert"
+            className="text-xs text-destructive"
+          >
+            {amountError}
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -95,7 +127,20 @@ export function GoalPurchaseForm({
           onChange={(e) => {
             setDateStr(e.target.value);
           }}
+          aria-invalid={dateError !== undefined}
+          aria-describedby={
+            dateError !== undefined ? "purchase-date-error" : undefined
+          }
         />
+        {dateError !== undefined && (
+          <p
+            id="purchase-date-error"
+            role="alert"
+            className="text-xs text-destructive"
+          >
+            {dateError}
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -122,7 +167,9 @@ export function GoalPurchaseForm({
       </div>
 
       {submitError !== undefined && (
-        <p className="text-sm text-destructive">{submitError}</p>
+        <p role="alert" className="text-sm text-destructive">
+          {submitError}
+        </p>
       )}
 
       <div className="flex items-center justify-between">

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -171,7 +171,11 @@ export function GoalPurchaseForm({
       <div className="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
         <span>{GOAL_PURCHASE_FORM_COPY.expenseNote(ledgerName)}</span>
         <span className="font-mono font-medium text-foreground">
-          {currencyFormatter.format(parseFloat(amountStr) || targetAmount)}
+          {currencyFormatter.format(
+            Number.isFinite(parseFloat(amountStr))
+              ? parseFloat(amountStr)
+              : targetAmount,
+          )}
         </span>
       </div>
 

--- a/src/components/goal-purchase/GoalPurchaseForm.tsx
+++ b/src/components/goal-purchase/GoalPurchaseForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,10 +10,16 @@ import { currencyFormatter } from "@/lib/formatters";
 
 import { GOAL_PURCHASE_FORM_COPY } from "./copy";
 
+export interface PurchaseFormData {
+  amount: number;
+  date: Date;
+  description: string;
+}
+
 export interface GoalPurchaseFormProps {
   ledgerName: string;
   targetAmount: number;
-  onSubmit: () => void;
+  onSubmit: (data: PurchaseFormData) => Promise<void> | void;
 }
 
 export function GoalPurchaseForm({
@@ -20,6 +27,18 @@ export function GoalPurchaseForm({
   targetAmount,
   onSubmit,
 }: GoalPurchaseFormProps) {
+  const [amount, setAmount] = useState(targetAmount);
+  const [dateStr, setDateStr] = useState(new Date().toISOString().slice(0, 10));
+  const [description, setDescription] = useState("");
+
+  function handleSubmit() {
+    void onSubmit({
+      amount,
+      date: new Date(dateStr),
+      description,
+    });
+  }
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1.5">
@@ -35,7 +54,10 @@ export function GoalPurchaseForm({
             type="number"
             min={0}
             step={0.01}
-            defaultValue={targetAmount}
+            value={amount}
+            onChange={(e) => {
+              setAmount(parseFloat(e.target.value));
+            }}
             className="pl-6"
           />
         </div>
@@ -48,7 +70,10 @@ export function GoalPurchaseForm({
         <Input
           id="purchase-date"
           type="date"
-          defaultValue={new Date().toISOString().slice(0, 10)}
+          value={dateStr}
+          onChange={(e) => {
+            setDateStr(e.target.value);
+          }}
         />
       </div>
 
@@ -60,6 +85,10 @@ export function GoalPurchaseForm({
           id="purchase-note"
           rows={3}
           placeholder={GOAL_PURCHASE_FORM_COPY.notePlaceholder}
+          value={description}
+          onChange={(e) => {
+            setDescription(e.target.value);
+          }}
           className="flex w-full rounded-lg border border-input bg-background px-2.5 py-1.5 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
         />
       </div>
@@ -78,7 +107,7 @@ export function GoalPurchaseForm({
         >
           {GOAL_PURCHASE_FORM_COPY.cancelButton}
         </Link>
-        <Button onClick={onSubmit}>
+        <Button onClick={handleSubmit}>
           {GOAL_PURCHASE_FORM_COPY.submitButton}
         </Button>
       </div>

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -6,6 +6,7 @@ import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goal
 import { currencyFormatter } from "@/lib/formatters";
 
 import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import type { PurchaseFormData } from "./GoalPurchaseForm";
 import { GoalPurchaseForm } from "./GoalPurchaseForm";
 import { GoalPurchaseWarning } from "./GoalPurchaseWarning";
 import { GoalSiblingProjections } from "./GoalSiblingProjections";
@@ -17,7 +18,7 @@ export interface GoalPurchaseViewProps {
   monthlyAllocation: number;
   referenceDate: Date;
   siblingGoals: BudgetLedgerSavingsGoal[];
-  onSubmit: () => void;
+  onSubmit: (data: PurchaseFormData) => Promise<void> | void;
 }
 
 export function GoalPurchaseView({

--- a/src/components/goal-purchase/copy.ts
+++ b/src/components/goal-purchase/copy.ts
@@ -19,6 +19,7 @@ export const GOAL_PURCHASE_FORM_COPY = {
   noteLabel: "Note",
   notePlaceholder: "e.g. Studio Display refurb…",
   submitButton: "Mark purchased",
+  submitError: "Something went wrong. Please try again.",
 } as const;
 
 export const GOAL_PURCHASE_WARNING_COPY = {

--- a/src/components/goal-purchase/copy.ts
+++ b/src/components/goal-purchase/copy.ts
@@ -10,9 +10,11 @@ export const GOAL_PURCHASE_VIEW_COPY = {
 } as const;
 
 export const GOAL_PURCHASE_FORM_COPY = {
+  amountError: "Please enter a valid amount greater than zero.",
   amountLabel: "Amount actually spent",
   amountPrefix: "$",
   cancelButton: "Cancel",
+  dateError: "Please enter a valid date.",
   dateLabel: "Date",
   expenseNote: (ledgerName: string) =>
     `Will record an expense in ${ledgerName}`,

--- a/src/services/goal-purchase.spec.ts
+++ b/src/services/goal-purchase.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("firebase/database", () => ({
+  getDatabase: vi.fn(),
+  push: vi.fn(),
+  ref: vi.fn(),
+  remove: vi.fn(),
+  runTransaction: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client", () => ({
+  getClientApp: vi.fn(() => ({ name: "mock-app" })),
+}));
+
+import { getDatabase, push, ref, set } from "firebase/database";
+
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { purchaseGoal } from "./goal-purchase";
+
+const mockDb = { type: "mock-db" };
+const mockRef = { type: "mock-ref" };
+
+function makeGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "New Laptop",
+    targetAmount: 1500,
+    fundedAmount: 1500,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getDatabase).mockReturnValue(mockDb as never);
+  vi.mocked(ref).mockReturnValue(mockRef as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("purchaseGoal", () => {
+  describe("creates an expense transaction on the goal's ledger", () => {
+    it("pushes a transaction with type Expense to firebase", async () => {
+      const newRef = { key: "txn-new" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+
+      const goal = makeGoal({ ledgerId: "ledger-abc" });
+      const purchaseDate = new Date("2024-06-15T00:00:00.000Z");
+
+      await purchaseGoal("uid-1", goal, {
+        amount: 1499.99,
+        date: purchaseDate,
+        description: "Studio Display",
+      });
+
+      const setCall = vi.mocked(set).mock.calls[0] ?? [];
+      const payload = setCall[1] as {
+        type: string;
+        amount: number;
+        date: string;
+        description: string;
+      };
+      expect(payload.type).toBe(BudgetLedgerTransactionType.Expense);
+      expect(payload.amount).toBe(1499.99);
+      expect(payload.date).toBe(purchaseDate.toISOString());
+      expect(payload.description).toBe("Studio Display");
+    });
+
+    it("writes the transaction to the goal's ledger path", async () => {
+      const newRef = { key: "txn-new" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+
+      const goal = makeGoal({ ledgerId: "ledger-xyz" });
+
+      await purchaseGoal("uid-1", goal, {
+        amount: 500,
+        date: new Date("2024-01-01T00:00:00.000Z"),
+        description: "Vacation",
+      });
+
+      expect(ref).toHaveBeenCalledWith(
+        mockDb,
+        "users/uid-1/budgetLedgerTransactions/ledger-xyz",
+      );
+    });
+  });
+
+  describe("removes the savings goal after recording the expense", () => {
+    it("calls runTransaction to delete and reorder the goal", async () => {
+      const { runTransaction } = await import("firebase/database");
+
+      const newRef = { key: "txn-new" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+      vi.mocked(runTransaction).mockResolvedValue(undefined as never);
+
+      const goal = makeGoal({ id: "goal-1", ledgerId: "ledger-1" });
+
+      await purchaseGoal("uid-1", goal, {
+        amount: 1500,
+        date: new Date("2024-06-01T00:00:00.000Z"),
+        description: "New laptop",
+      });
+
+      expect(runTransaction).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/goal-purchase.spec.ts
+++ b/src/services/goal-purchase.spec.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/firebase/client", () => ({
   getClientApp: vi.fn(() => ({ name: "mock-app" })),
 }));
 
-import { getDatabase, push, ref, set } from "firebase/database";
+import { getDatabase, push, ref, remove, set } from "firebase/database";
 
 import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
@@ -113,6 +113,30 @@ describe("purchaseGoal", () => {
       });
 
       expect(runTransaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("compensates on partial failure", () => {
+    it("deletes the transaction and rethrows if deleteSavingsGoalAndReorder fails", async () => {
+      const { runTransaction } = await import("firebase/database");
+
+      const newRef = { key: "txn-comp" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+      vi.mocked(runTransaction).mockRejectedValue(new Error("delete failed"));
+      vi.mocked(remove).mockResolvedValue(undefined);
+
+      const goal = makeGoal({ id: "goal-1", ledgerId: "ledger-1" });
+
+      await expect(
+        purchaseGoal("uid-1", goal, {
+          amount: 1500,
+          date: new Date("2024-06-01T00:00:00.000Z"),
+          description: "New laptop",
+        }),
+      ).rejects.toThrow("delete failed");
+
+      expect(remove).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/goal-purchase.spec.ts
+++ b/src/services/goal-purchase.spec.ts
@@ -75,6 +75,42 @@ describe("purchaseGoal", () => {
       expect(payload.description).toBe("Studio Display");
     });
 
+    it("falls back to the goal name when description is empty", async () => {
+      const newRef = { key: "txn-new" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+
+      const goal = makeGoal({ name: "New Laptop", ledgerId: "ledger-abc" });
+
+      await purchaseGoal("uid-1", goal, {
+        amount: 1500,
+        date: new Date("2024-06-15T00:00:00.000Z"),
+        description: "",
+      });
+
+      const setCall = vi.mocked(set).mock.calls[0] ?? [];
+      const payload = setCall[1] as { description: string };
+      expect(payload.description).toBe("New Laptop");
+    });
+
+    it("falls back to the goal name when description is whitespace", async () => {
+      const newRef = { key: "txn-new" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+
+      const goal = makeGoal({ name: "New Laptop", ledgerId: "ledger-abc" });
+
+      await purchaseGoal("uid-1", goal, {
+        amount: 1500,
+        date: new Date("2024-06-15T00:00:00.000Z"),
+        description: "   ",
+      });
+
+      const setCall = vi.mocked(set).mock.calls[0] ?? [];
+      const payload = setCall[1] as { description: string };
+      expect(payload.description).toBe("New Laptop");
+    });
+
     it("writes the transaction to the goal's ledger path", async () => {
       const newRef = { key: "txn-new" };
       vi.mocked(push).mockReturnValue(newRef as never);
@@ -139,26 +175,32 @@ describe("purchaseGoal", () => {
       expect(remove).toHaveBeenCalled();
     });
 
-    it("throws a combined error if rollback also fails", async () => {
+    it("throws an AggregateError preserving both errors if rollback also fails", async () => {
       const { runTransaction } = await import("firebase/database");
 
       const newRef = { key: "txn-comp" };
       vi.mocked(push).mockReturnValue(newRef as never);
       vi.mocked(set).mockResolvedValue(undefined);
-      vi.mocked(runTransaction).mockRejectedValue(new Error("delete failed"));
-      vi.mocked(remove).mockRejectedValue(new Error("rollback failed"));
+      const deletionErr = new Error("delete failed");
+      const rollbackErr = new Error("rollback failed");
+      vi.mocked(runTransaction).mockRejectedValue(deletionErr);
+      vi.mocked(remove).mockRejectedValue(rollbackErr);
 
       const goal = makeGoal({ id: "goal-1", ledgerId: "ledger-1" });
 
-      await expect(
-        purchaseGoal("uid-1", goal, {
-          amount: 1500,
-          date: new Date("2024-06-01T00:00:00.000Z"),
-          description: "New laptop",
-        }),
-      ).rejects.toThrow(
+      const thrown = await purchaseGoal("uid-1", goal, {
+        amount: 1500,
+        date: new Date("2024-06-01T00:00:00.000Z"),
+        description: "New laptop",
+      }).catch((e: unknown) => e);
+
+      expect(thrown).toBeInstanceOf(AggregateError);
+      const aggregate = thrown as AggregateError;
+      expect(aggregate.message).toBe(
         "Goal deletion failed and transaction rollback also failed",
       );
+      expect(aggregate.errors).toContain(deletionErr);
+      expect(aggregate.errors).toContain(rollbackErr);
     });
   });
 });

--- a/src/services/goal-purchase.spec.ts
+++ b/src/services/goal-purchase.spec.ts
@@ -138,5 +138,27 @@ describe("purchaseGoal", () => {
 
       expect(remove).toHaveBeenCalled();
     });
+
+    it("throws a combined error if rollback also fails", async () => {
+      const { runTransaction } = await import("firebase/database");
+
+      const newRef = { key: "txn-comp" };
+      vi.mocked(push).mockReturnValue(newRef as never);
+      vi.mocked(set).mockResolvedValue(undefined);
+      vi.mocked(runTransaction).mockRejectedValue(new Error("delete failed"));
+      vi.mocked(remove).mockRejectedValue(new Error("rollback failed"));
+
+      const goal = makeGoal({ id: "goal-1", ledgerId: "ledger-1" });
+
+      await expect(
+        purchaseGoal("uid-1", goal, {
+          amount: 1500,
+          date: new Date("2024-06-01T00:00:00.000Z"),
+          description: "New laptop",
+        }),
+      ).rejects.toThrow(
+        "Goal deletion failed and transaction rollback also failed",
+      );
+    });
   });
 });

--- a/src/services/goal-purchase.ts
+++ b/src/services/goal-purchase.ts
@@ -2,7 +2,7 @@ import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
 import { deleteSavingsGoalAndReorder } from "./savings-goals";
-import { createTransaction } from "./transactions";
+import { createTransaction, deleteTransaction } from "./transactions";
 
 export interface PurchaseGoalInput {
   amount: number;
@@ -15,11 +15,16 @@ export async function purchaseGoal(
   goal: BudgetLedgerSavingsGoal,
   data: PurchaseGoalInput,
 ): Promise<void> {
-  await createTransaction(uid, goal.ledgerId, {
+  const transaction = await createTransaction(uid, goal.ledgerId, {
     type: BudgetLedgerTransactionType.Expense,
     date: data.date,
     amount: data.amount,
     description: data.description,
   });
-  await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
+  try {
+    await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
+  } catch (err) {
+    await deleteTransaction(uid, goal.ledgerId, transaction.id);
+    throw err;
+  }
 }

--- a/src/services/goal-purchase.ts
+++ b/src/services/goal-purchase.ts
@@ -24,7 +24,14 @@ export async function purchaseGoal(
   try {
     await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
   } catch (err) {
-    await deleteTransaction(uid, goal.ledgerId, transaction.id);
+    try {
+      await deleteTransaction(uid, goal.ledgerId, transaction.id);
+    } catch (rollbackErr) {
+      throw new Error(
+        "Goal deletion failed and transaction rollback also failed",
+        { cause: rollbackErr },
+      );
+    }
     throw err;
   }
 }

--- a/src/services/goal-purchase.ts
+++ b/src/services/goal-purchase.ts
@@ -15,11 +15,13 @@ export async function purchaseGoal(
   goal: BudgetLedgerSavingsGoal,
   data: PurchaseGoalInput,
 ): Promise<void> {
+  const description =
+    data.description.trim() !== "" ? data.description.trim() : goal.name;
   const transaction = await createTransaction(uid, goal.ledgerId, {
     type: BudgetLedgerTransactionType.Expense,
     date: data.date,
     amount: data.amount,
-    description: data.description,
+    description,
   });
   try {
     await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
@@ -27,7 +29,8 @@ export async function purchaseGoal(
     try {
       await deleteTransaction(uid, goal.ledgerId, transaction.id);
     } catch (rollbackErr) {
-      throw new Error(
+      throw new AggregateError(
+        [err, rollbackErr],
         "Goal deletion failed and transaction rollback also failed",
         { cause: rollbackErr },
       );

--- a/src/services/goal-purchase.ts
+++ b/src/services/goal-purchase.ts
@@ -26,13 +26,17 @@ export async function purchaseGoal(
   try {
     await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
   } catch (err) {
+    let rollbackErr: unknown;
     try {
       await deleteTransaction(uid, goal.ledgerId, transaction.id);
-    } catch (rollbackErr) {
+    } catch (e) {
+      rollbackErr = e;
+    }
+    if (rollbackErr !== undefined) {
       throw new AggregateError(
         [err, rollbackErr],
         "Goal deletion failed and transaction rollback also failed",
-        { cause: rollbackErr },
+        { cause: err },
       );
     }
     throw err;

--- a/src/services/goal-purchase.ts
+++ b/src/services/goal-purchase.ts
@@ -1,0 +1,25 @@
+import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { deleteSavingsGoalAndReorder } from "./savings-goals";
+import { createTransaction } from "./transactions";
+
+export interface PurchaseGoalInput {
+  amount: number;
+  date: Date;
+  description: string;
+}
+
+export async function purchaseGoal(
+  uid: string,
+  goal: BudgetLedgerSavingsGoal,
+  data: PurchaseGoalInput,
+): Promise<void> {
+  await createTransaction(uid, goal.ledgerId, {
+    type: BudgetLedgerTransactionType.Expense,
+    date: data.date,
+    amount: data.amount,
+    description: data.description,
+  });
+  await deleteSavingsGoalAndReorder(uid, goal.ledgerId, goal.id);
+}


### PR DESCRIPTION
Implements the "Mark as purchased" flow for savings goals. When a user submits the goal purchase form, a `Expense` transaction is written to the goal's ledger and the goal itself is deleted (with priority reordering of siblings).

The `purchaseGoal` service orchestrates both operations: `createTransaction` for the ledger expense and `deleteSavingsGoalAndReorder` for goal cleanup. `GoalPurchaseForm` was converted from uncontrolled to controlled inputs so amount, date, and description values are collected and passed to `onSubmit`. The `GoalPurchasePage` wires everything up, calling `purchaseGoal` on submit and navigating to `/goals` on success.

Manual testing: navigate to a goal's `/purchase` page, adjust the amount and note, click "Mark purchased" — the goal should disappear from the goals list and the ledger's transaction history should show a new expense.

Closes #199

---
*Created by Claude Sonnet 4.5*