### PR TITLE
feat(goal-purchase): conditionally show insufficient cash warning

### DIFF
--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -27,13 +27,22 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
     isLoading: goalLoading,
     error: goalError,
   } = useSavingsGoal(uid, goalId);
-  const { ledgers } = useLedgersSubscription(uid);
+  const { ledgers, isLoading: ledgersLoading } = useLedgersSubscription(uid);
   const ledgerId = goal?.ledgerId ?? "";
   const { savingsGoals: siblingGoals } = useSavingsGoals(uid, ledgerId);
-  const { transactions } = useTransactions(uid, ledgerId);
+  const { transactions, isLoading: transactionsLoading } = useTransactions(
+    uid,
+    ledgerId,
+  );
   const referenceDate = useMemo(() => new Date(), []);
 
-  if (authLoading || goalLoading || !user) {
+  if (
+    authLoading ||
+    goalLoading ||
+    ledgersLoading ||
+    transactionsLoading ||
+    !user
+  ) {
     return null;
   }
 
@@ -52,9 +61,14 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   }
 
   const budgetLedger = ledgers.find((l) => l.id === goal.ledgerId);
-  const ledgerName = budgetLedger?.name ?? goal.ledgerId;
+
+  if (budgetLedger === undefined) {
+    return null;
+  }
+
+  const ledgerName = budgetLedger.name;
   const { cashBalance: ledgerCashBalance } = calculateLedgerBalance({
-    cashCap: budgetLedger?.cashCap,
+    cashCap: budgetLedger.cashCap,
     transactions,
   });
   const monthlyAllocation = computeMonthlyDepositRate(

--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -63,7 +63,13 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   const budgetLedger = ledgers.find((l) => l.id === goal.ledgerId);
 
   if (budgetLedger === undefined) {
-    return null;
+    return (
+      <div className="mx-auto w-full max-w-4xl px-4 py-8">
+        <p className="text-center text-destructive">
+          {GOAL_PURCHASE_PAGE_COPY.ledgerNotFoundMessage}
+        </p>
+      </div>
+    );
   }
 
   const ledgerName = budgetLedger.name;

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -30,6 +30,7 @@ export function GoalPurchaseView({
   onSubmit,
 }: GoalPurchaseViewProps) {
   const hasInsufficientCash = goal.targetAmount > ledgerCashBalance;
+
   return (
     <div className="flex flex-col gap-6">
       <div>

--- a/src/components/goal-purchase/copy.ts
+++ b/src/components/goal-purchase/copy.ts
@@ -1,5 +1,6 @@
 export const GOAL_PURCHASE_PAGE_COPY = {
   errorMessage: "Failed to load goal. Please try again later.",
+  ledgerNotFoundMessage: "The associated ledger could not be found.",
 } as const;
 
 export const GOAL_PURCHASE_VIEW_COPY = {

--- a/src/hooks/use-transactions.spec.ts
+++ b/src/hooks/use-transactions.spec.ts
@@ -41,6 +41,30 @@ describe("useTransactions", () => {
       const { result } = renderHook(() => useTransactions("", "ledger-1"));
       expect(result.current.transactions).toEqual([]);
     });
+
+    it("sets isLoading to false when ledgerId is empty", () => {
+      const { result } = renderHook(() => useTransactions("uid-1", ""));
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("sets isLoading to true when ledgerId transitions from empty to a real value", () => {
+      // Simulate the subscription never resolving (pending Firebase call)
+      mockOnValue.mockReturnValue(mockUnsubscribe);
+
+      let ledgerId = "";
+      const { result, rerender } = renderHook(() =>
+        useTransactions("uid-1", ledgerId),
+      );
+
+      // Initially empty ledgerId — isLoading should be false
+      expect(result.current.isLoading).toBe(false);
+
+      ledgerId = "ledger-1";
+      rerender();
+
+      // After ledgerId becomes real, isLoading must be true before the subscription resolves
+      expect(result.current.isLoading).toBe(true);
+    });
   });
 
   describe("subscription", () => {

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -14,21 +14,24 @@ export function useTransactions(uid: string, ledgerId: string) {
   const [transactions, setTransactions] = useState<BudgetLedgerTransaction[]>(
     [],
   );
-  const [isLoading, setIsLoading] = useState(true);
+  const [loadedForKey, setLoadedForKey] = useState("");
   const [error, setError] = useState<Error | undefined>(undefined);
+
+  const key = uid && ledgerId ? `${uid}:${ledgerId}` : "";
+  const isLoading = !!uid && !!ledgerId && loadedForKey !== key;
 
   useEffect(() => {
     if (!uid || !ledgerId) {
       setError(undefined);
       setTransactions([]);
-      setIsLoading(false);
+      setLoadedForKey("");
       return;
     }
 
     setError(undefined);
-    setIsLoading(true);
     const db = getDatabase(getClientApp());
     const txRef = ref(db, `users/${uid}/budgetLedgerTransactions/${ledgerId}`);
+    const currentKey = `${uid}:${ledgerId}`;
 
     const unsubscribe = onValue(
       txRef,
@@ -46,11 +49,11 @@ export function useTransactions(uid: string, ledgerId: string) {
             ),
           );
         }
-        setIsLoading(false);
+        setLoadedForKey(currentKey);
       },
       (err) => {
         setError(err);
-        setIsLoading(false);
+        setLoadedForKey(currentKey);
       },
     );
 

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -24,6 +24,7 @@ export function useTransactions(uid: string, ledgerId: string) {
       return;
     }
 
+    setIsLoading(true);
     const db = getDatabase(getClientApp());
     const txRef = ref(db, `users/${uid}/budgetLedgerTransactions/${ledgerId}`);
 

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -19,11 +19,13 @@ export function useTransactions(uid: string, ledgerId: string) {
 
   useEffect(() => {
     if (!uid || !ledgerId) {
+      setError(undefined);
       setTransactions([]);
       setIsLoading(false);
       return;
     }
 
+    setError(undefined);
     setIsLoading(true);
     const db = getDatabase(getClientApp());
     const txRef = ref(db, `users/${uid}/budgetLedgerTransactions/${ledgerId}`);


### PR DESCRIPTION
The insufficient cash warning on the goal purchase page was always visible regardless of the ledger's actual cash balance. This PR makes it conditional: the warning only appears when `goal.targetAmount > ledgerCashBalance`.

`GoalPurchaseView` now accepts a `ledgerCashBalance: number` prop and computes `hasInsufficientCash` to gate the `GoalPurchaseWarning` render. The page continues to use `useLedgersSubscription` for ledger metadata (including the `cashCap` needed for balance computation). A new `useTransactions` call replays the ledger's transaction history through `calculateLedgerBalance` to derive the real cash balance.

The early-return guard was extended to include both `ledgersLoading` (from `useLedgersSubscription`) and `transactionsLoading` (from `useTransactions`) so the page withholds rendering until both data sources are ready. Without these guards, `calculateLedgerBalance` would run with `cashCap: undefined` (overstating cash) or with an empty transaction list (understating cash), causing the warning to flash incorrectly during the load window. The `useTransactions` hook was also updated to set `isLoading` back to `true` at the top of its effect when both `uid` and `ledgerId` are non-empty, closing a stale-false race where `ledgerId` transitions from `""` to a real value between React render cycles.

To test: visit the purchase page for a goal whose target exceeds the ledger's cash balance — the warning card should appear. For a goal where the ledger has sufficient cash, no warning should show. On page load, neither state should flash before data arrives.

Closes #200

---
*Created by Claude Sonnet 4.5*