### PR TITLE
feat(goals): display projected funding dates for sibling goals

### DIFF
--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { use } from "react";
+import { use, useMemo } from "react";
 
 import { GoalPurchaseView } from "@/components/goal-purchase";
 import { GOAL_PURCHASE_PAGE_COPY } from "@/components/goal-purchase/copy";
@@ -31,6 +31,7 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   const ledgerId = goal?.ledgerId ?? "";
   const { savingsGoals: siblingGoals } = useSavingsGoals(uid, ledgerId);
   const { transactions } = useTransactions(uid, ledgerId);
+  const referenceDate = useMemo(() => new Date(), []);
 
   if (authLoading || goalLoading || !user) {
     return null;
@@ -56,7 +57,10 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
     cashCap: budgetLedger?.cashCap,
     transactions,
   });
-  const monthlyAllocation = computeMonthlyDepositRate(transactions);
+  const monthlyAllocation = computeMonthlyDepositRate(
+    transactions,
+    referenceDate,
+  );
   const siblings = siblingGoals.filter((g) => g.id !== goal.id);
 
   function handleSubmit() {

--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -75,6 +75,7 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
         ledgerCashBalance={ledgerCashBalance}
         ledgerName={ledgerName}
         monthlyAllocation={monthlyAllocation}
+        referenceDate={referenceDate}
         siblingGoals={siblings}
         onSubmit={handleSubmit}
       />

--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -9,6 +9,9 @@ import { useAuth } from "@/hooks/use-auth";
 import { useLedgersSubscription } from "@/hooks/use-ledgers-subscription";
 import { useSavingsGoal } from "@/hooks/use-savings-goal";
 import { useSavingsGoals } from "@/hooks/use-savings-goals";
+import { useTransactions } from "@/hooks/use-transactions";
+import { computeMonthlyDepositRate } from "@/lib/goal-funding";
+import { calculateLedgerBalance } from "@/lib/reconciliation/ledger-balance";
 
 interface GoalPurchasePageProps {
   params: Promise<{ goalId: string }>;
@@ -27,6 +30,7 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   const { ledgers } = useLedgersSubscription(uid);
   const ledgerId = goal?.ledgerId ?? "";
   const { savingsGoals: siblingGoals } = useSavingsGoals(uid, ledgerId);
+  const { transactions } = useTransactions(uid, ledgerId);
 
   if (authLoading || goalLoading || !user) {
     return null;
@@ -46,8 +50,13 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
     return null;
   }
 
-  const ledger = ledgers.find((l) => l.id === goal.ledgerId);
-  const ledgerName = ledger?.name ?? goal.ledgerId;
+  const budgetLedger = ledgers.find((l) => l.id === goal.ledgerId);
+  const ledgerName = budgetLedger?.name ?? goal.ledgerId;
+  const { cashBalance: ledgerCashBalance } = calculateLedgerBalance({
+    cashCap: budgetLedger?.cashCap,
+    transactions,
+  });
+  const monthlyAllocation = computeMonthlyDepositRate(transactions);
   const siblings = siblingGoals.filter((g) => g.id !== goal.id);
 
   function handleSubmit() {
@@ -59,7 +68,9 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
     <div className="mx-auto w-full max-w-4xl px-4 py-8">
       <GoalPurchaseView
         goal={goal}
+        ledgerCashBalance={ledgerCashBalance}
         ledgerName={ledgerName}
+        monthlyAllocation={monthlyAllocation}
         siblingGoals={siblings}
         onSubmit={handleSubmit}
       />

--- a/src/components/goal-purchase/GoalPurchaseView.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.spec.tsx
@@ -8,6 +8,8 @@ import { GoalPurchaseView } from "./GoalPurchaseView";
 
 afterEach(cleanup);
 
+const referenceDate = new Date(2025, 5, 1);
+
 function makeGoal(
   overrides: Partial<BudgetLedgerSavingsGoal> = {},
 ): BudgetLedgerSavingsGoal {
@@ -31,6 +33,7 @@ describe("GoalPurchaseView — header", () => {
           ledgerCashBalance={10000}
           ledgerName="Tech Fund"
           monthlyAllocation={500}
+          referenceDate={referenceDate}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -50,6 +53,7 @@ describe("GoalPurchaseView — header", () => {
           ledgerCashBalance={20000}
           ledgerName="Primary"
           monthlyAllocation={500}
+          referenceDate={referenceDate}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -72,6 +76,7 @@ describe("GoalPurchaseView — panels", () => {
           ledgerCashBalance={0}
           ledgerName="Primary"
           monthlyAllocation={500}
+          referenceDate={referenceDate}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -86,6 +91,7 @@ describe("GoalPurchaseView — panels", () => {
           ledgerCashBalance={5000}
           ledgerName="Primary"
           monthlyAllocation={500}
+          referenceDate={referenceDate}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -102,6 +108,7 @@ describe("GoalPurchaseView — panels", () => {
           ledgerCashBalance={10000}
           ledgerName="Primary"
           monthlyAllocation={500}
+          referenceDate={referenceDate}
           siblingGoals={[makeGoal({ id: "g2", name: "Vacation" })]}
           onSubmit={vi.fn()}
         />,

--- a/src/components/goal-purchase/GoalPurchaseView.spec.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.spec.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
-import { GOAL_PURCHASE_VIEW_COPY } from "./copy";
+import { GOAL_PURCHASE_VIEW_COPY, GOAL_PURCHASE_WARNING_COPY } from "./copy";
 import { GoalPurchaseView } from "./GoalPurchaseView";
 
 afterEach(cleanup);
@@ -28,7 +28,9 @@ describe("GoalPurchaseView — header", () => {
       render(
         <GoalPurchaseView
           goal={makeGoal({ name: "New Laptop" })}
+          ledgerCashBalance={10000}
           ledgerName="Tech Fund"
+          monthlyAllocation={500}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -45,7 +47,9 @@ describe("GoalPurchaseView — header", () => {
       render(
         <GoalPurchaseView
           goal={makeGoal({ targetAmount: 10000 })}
+          ledgerCashBalance={20000}
           ledgerName="Primary"
+          monthlyAllocation={500}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
@@ -61,16 +65,32 @@ describe("GoalPurchaseView — header", () => {
 
 describe("GoalPurchaseView — panels", () => {
   describe("renders the warning panel", () => {
-    it("shows the insufficient cash warning headline", () => {
+    it("shows the insufficient cash warning when ledger balance is below target", () => {
       render(
         <GoalPurchaseView
-          goal={makeGoal()}
+          goal={makeGoal({ targetAmount: 5000 })}
+          ledgerCashBalance={0}
           ledgerName="Primary"
+          monthlyAllocation={500}
           siblingGoals={[]}
           onSubmit={vi.fn()}
         />,
       );
-      expect(screen.getByText(/Insufficient cash/i)).toBeDefined();
+      expect(screen.getByText(GOAL_PURCHASE_WARNING_COPY.title)).toBeDefined();
+    });
+
+    it("hides the insufficient cash warning when ledger balance meets the target", () => {
+      render(
+        <GoalPurchaseView
+          goal={makeGoal({ targetAmount: 5000 })}
+          ledgerCashBalance={5000}
+          ledgerName="Primary"
+          monthlyAllocation={500}
+          siblingGoals={[]}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.queryByText(GOAL_PURCHASE_WARNING_COPY.title)).toBeNull();
     });
   });
 
@@ -79,7 +99,9 @@ describe("GoalPurchaseView — panels", () => {
       render(
         <GoalPurchaseView
           goal={makeGoal()}
+          ledgerCashBalance={10000}
           ledgerName="Primary"
+          monthlyAllocation={500}
           siblingGoals={[makeGoal({ id: "g2", name: "Vacation" })]}
           onSubmit={vi.fn()}
         />,

--- a/src/components/goal-purchase/GoalPurchaseView.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.stories.tsx
@@ -41,7 +41,9 @@ const siblingGoals = [
 export const NoSiblings: Story = {
   args: {
     goal: baseGoal,
+    ledgerCashBalance: 2000,
     ledgerName: "Tech Fund",
+    monthlyAllocation: 400,
     siblingGoals: [],
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},
@@ -51,7 +53,21 @@ export const NoSiblings: Story = {
 export const WithSiblings: Story = {
   args: {
     goal: baseGoal,
+    ledgerCashBalance: 2000,
     ledgerName: "Tech Fund",
+    monthlyAllocation: 400,
+    siblingGoals,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onSubmit: () => {},
+  },
+};
+
+export const InsufficientCash: Story = {
+  args: {
+    goal: baseGoal,
+    ledgerCashBalance: 0,
+    ledgerName: "Tech Fund",
+    monthlyAllocation: 400,
     siblingGoals,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},

--- a/src/components/goal-purchase/GoalPurchaseView.stories.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.stories.tsx
@@ -38,12 +38,15 @@ const siblingGoals = [
   },
 ];
 
+const referenceDate = new Date(2025, 5, 1);
+
 export const NoSiblings: Story = {
   args: {
     goal: baseGoal,
     ledgerCashBalance: 2000,
     ledgerName: "Tech Fund",
     monthlyAllocation: 400,
+    referenceDate,
     siblingGoals: [],
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},
@@ -56,6 +59,7 @@ export const WithSiblings: Story = {
     ledgerCashBalance: 2000,
     ledgerName: "Tech Fund",
     monthlyAllocation: 400,
+    referenceDate,
     siblingGoals,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},
@@ -68,6 +72,7 @@ export const InsufficientCash: Story = {
     ledgerCashBalance: 0,
     ledgerName: "Tech Fund",
     monthlyAllocation: 400,
+    referenceDate,
     siblingGoals,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -15,6 +15,7 @@ export interface GoalPurchaseViewProps {
   ledgerCashBalance: number;
   ledgerName: string;
   monthlyAllocation: number;
+  referenceDate: Date;
   siblingGoals: BudgetLedgerSavingsGoal[];
   onSubmit: () => void;
 }
@@ -24,6 +25,7 @@ export function GoalPurchaseView({
   ledgerCashBalance,
   ledgerName,
   monthlyAllocation,
+  referenceDate,
   siblingGoals,
   onSubmit,
 }: GoalPurchaseViewProps) {
@@ -60,6 +62,7 @@ export function GoalPurchaseView({
           <GoalSiblingProjections
             monthlyAllocation={monthlyAllocation}
             purchasedGoal={goal}
+            referenceDate={referenceDate}
             siblingGoals={siblingGoals}
           />
         </div>

--- a/src/components/goal-purchase/GoalPurchaseView.tsx
+++ b/src/components/goal-purchase/GoalPurchaseView.tsx
@@ -12,17 +12,22 @@ import { GoalSiblingProjections } from "./GoalSiblingProjections";
 
 export interface GoalPurchaseViewProps {
   goal: BudgetLedgerSavingsGoal;
+  ledgerCashBalance: number;
   ledgerName: string;
+  monthlyAllocation: number;
   siblingGoals: BudgetLedgerSavingsGoal[];
   onSubmit: () => void;
 }
 
 export function GoalPurchaseView({
   goal,
+  ledgerCashBalance,
   ledgerName,
+  monthlyAllocation,
   siblingGoals,
   onSubmit,
 }: GoalPurchaseViewProps) {
+  const hasInsufficientCash = goal.targetAmount > ledgerCashBalance;
   return (
     <div className="flex flex-col gap-6">
       <div>
@@ -51,8 +56,12 @@ export function GoalPurchaseView({
         />
 
         <div className="flex flex-col gap-4">
-          <GoalPurchaseWarning />
-          <GoalSiblingProjections siblingGoals={siblingGoals} />
+          {hasInsufficientCash && <GoalPurchaseWarning />}
+          <GoalSiblingProjections
+            monthlyAllocation={monthlyAllocation}
+            purchasedGoal={goal}
+            siblingGoals={siblingGoals}
+          />
         </div>
       </div>
     </div>

--- a/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
@@ -97,8 +97,8 @@ describe("GoalSiblingProjections — table", () => {
       const placeholders = screen.queryAllByText(
         GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder,
       );
-      // There should be fewer than 2 placeholders (at least one ETA is shown)
-      expect(placeholders.length).toBeLessThan(2);
+      // Both ETAs should resolve to concrete dates — no placeholders expected
+      expect(placeholders.length).toBe(0);
     });
   });
 
@@ -133,6 +133,3 @@ describe("GoalSiblingProjections — table", () => {
     });
   });
 });
-
-// Suppress React warnings from vi.fn() usage in other suites leaking into this file
-vi.fn();

--- a/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
@@ -102,6 +102,43 @@ describe("GoalSiblingProjections — table", () => {
     });
   });
 
+  describe("excludes fully-funded siblings from the New ETA denominator", () => {
+    it("shows concrete ETAs for unfunded siblings when a fully-funded sibling is present", () => {
+      // "Vacation" is unfunded; "Already Funded" is fully funded.
+      // The unfunded sibling's ETA columns should show concrete dates.
+      // The fully-funded sibling correctly returns undefined for both ETAs
+      // (it needs no more funding), so exactly 2 placeholders total should appear —
+      // one per ETA column for "Already Funded" only.
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={1200}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[
+            makeGoal({
+              id: "g2",
+              name: "Vacation",
+              priority: 2,
+              targetAmount: 600,
+              fundedAmount: 0,
+            }),
+            makeGoal({
+              id: "g3",
+              name: "Already Funded",
+              priority: 3,
+              targetAmount: 500,
+              fundedAmount: 500,
+            }),
+          ]}
+        />,
+      );
+      // Exactly 2 placeholders: one per ETA column for the fully-funded sibling only
+      const placeholders = screen.queryAllByText(
+        GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder,
+      );
+      expect(placeholders.length).toBe(2);
+    });
+  });
+
   describe("shows placeholder when monthly allocation is zero", () => {
     it("renders the placeholder in both ETA columns when allocation is 0", () => {
       render(

--- a/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
@@ -1,0 +1,138 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
+import { GoalSiblingProjections } from "./GoalSiblingProjections";
+
+afterEach(cleanup);
+
+function makeGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "Emergency Fund",
+    targetAmount: 1000,
+    fundedAmount: 0,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+const purchasedGoal = makeGoal({
+  id: "purchased",
+  name: "Studio Display",
+  priority: 1,
+});
+
+describe("GoalSiblingProjections — structure", () => {
+  describe("renders the section title", () => {
+    it("shows the sibling projections title", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={500}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[]}
+        />,
+      );
+      expect(
+        screen.getByText(GOAL_SIBLING_PROJECTIONS_COPY.title),
+      ).toBeDefined();
+    });
+  });
+
+  describe("renders the footer note", () => {
+    it("shows the footer text", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={500}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[]}
+        />,
+      );
+      expect(
+        screen.getByText(GOAL_SIBLING_PROJECTIONS_COPY.footer),
+      ).toBeDefined();
+    });
+  });
+});
+
+describe("GoalSiblingProjections — table", () => {
+  describe("renders sibling goal rows", () => {
+    it("shows each sibling goal name", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={500}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[
+            makeGoal({ id: "g2", name: "MacBook Pro", priority: 2 }),
+            makeGoal({ id: "g3", name: "Keyboard", priority: 3 }),
+          ]}
+        />,
+      );
+      expect(screen.getByText("MacBook Pro")).toBeDefined();
+      expect(screen.getByText("Keyboard")).toBeDefined();
+    });
+
+    it("shows projected ETA dates when monthly allocation is non-zero", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={1200}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[
+            makeGoal({
+              id: "g2",
+              name: "Vacation",
+              priority: 2,
+              targetAmount: 600,
+              fundedAmount: 0,
+            }),
+          ]}
+        />,
+      );
+      // With allocation, we should NOT see placeholder for both columns
+      const placeholders = screen.queryAllByText(
+        GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder,
+      );
+      // There should be fewer than 2 placeholders (at least one ETA is shown)
+      expect(placeholders.length).toBeLessThan(2);
+    });
+  });
+
+  describe("shows placeholder when monthly allocation is zero", () => {
+    it("renders the placeholder in both ETA columns when allocation is 0", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={0}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[makeGoal({ id: "g2", name: "Vacation", priority: 2 })]}
+        />,
+      );
+      const placeholders = screen.queryAllByText(
+        GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder,
+      );
+      expect(placeholders.length).toBe(2);
+    });
+  });
+
+  describe("hides the table when there are no sibling goals", () => {
+    it("does not render column headers when siblingGoals is empty", () => {
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={500}
+          purchasedGoal={purchasedGoal}
+          siblingGoals={[]}
+        />,
+      );
+      expect(
+        screen.queryByText(GOAL_SIBLING_PROJECTIONS_COPY.columnGoal),
+      ).toBeNull();
+    });
+  });
+});
+
+// Suppress React warnings from vi.fn() usage in other suites leaking into this file
+vi.fn();

--- a/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.spec.tsx
@@ -28,6 +28,8 @@ const purchasedGoal = makeGoal({
   priority: 1,
 });
 
+const referenceDate = new Date(2025, 5, 1);
+
 describe("GoalSiblingProjections — structure", () => {
   describe("renders the section title", () => {
     it("shows the sibling projections title", () => {
@@ -35,6 +37,7 @@ describe("GoalSiblingProjections — structure", () => {
         <GoalSiblingProjections
           monthlyAllocation={500}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[]}
         />,
       );
@@ -50,6 +53,7 @@ describe("GoalSiblingProjections — structure", () => {
         <GoalSiblingProjections
           monthlyAllocation={500}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[]}
         />,
       );
@@ -67,6 +71,7 @@ describe("GoalSiblingProjections — table", () => {
         <GoalSiblingProjections
           monthlyAllocation={500}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[
             makeGoal({ id: "g2", name: "MacBook Pro", priority: 2 }),
             makeGoal({ id: "g3", name: "Keyboard", priority: 3 }),
@@ -82,6 +87,7 @@ describe("GoalSiblingProjections — table", () => {
         <GoalSiblingProjections
           monthlyAllocation={1200}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[
             makeGoal({
               id: "g2",
@@ -113,6 +119,7 @@ describe("GoalSiblingProjections — table", () => {
         <GoalSiblingProjections
           monthlyAllocation={1200}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[
             makeGoal({
               id: "g2",
@@ -139,12 +146,67 @@ describe("GoalSiblingProjections — table", () => {
     });
   });
 
+  describe("includes fully-funded purchased goal in the Was ETA denominator", () => {
+    it("shows different Was and New ETAs when the purchased goal is fully funded", () => {
+      // When the purchased goal is fully funded (the typical purchase-flow case),
+      // it must still appear in the Was denominator so the Zipf share for siblings
+      // is smaller pre-purchase than post-purchase. This produces a Was ETA that
+      // is further out than the New ETA, demonstrating the benefit of the purchase.
+      //
+      // Setup: purchasedGoal (priority 1, fully funded), sibling (priority 2, needs $600).
+      // Was denominator: [sibling(p=2), purchasedGoal(p=1)] → sibling gets 1/3 of allocation
+      // New denominator: [sibling(p=2)] → sibling gets 100% of allocation
+      // With $1200/month: Was monthly = $400 → ceil(600/400) = 2 months (Aug 2025)
+      //                    New monthly = $1200 → ceil(600/1200) = 1 month (Jul 2025)
+      const fullyFundedPurchasedGoal = makeGoal({
+        id: "purchased",
+        name: "Studio Display",
+        priority: 1,
+        targetAmount: 1000,
+        fundedAmount: 1000,
+      });
+      render(
+        <GoalSiblingProjections
+          monthlyAllocation={1200}
+          purchasedGoal={fullyFundedPurchasedGoal}
+          referenceDate={referenceDate}
+          siblingGoals={[
+            makeGoal({
+              id: "g2",
+              name: "Vacation",
+              priority: 2,
+              targetAmount: 600,
+              fundedAmount: 0,
+            }),
+          ]}
+        />,
+      );
+      // Both ETA columns should show concrete dates (not placeholders)
+      const placeholders = screen.queryAllByText(
+        GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder,
+      );
+      expect(placeholders.length).toBe(0);
+
+      // Was ETA = Aug 2025 (2 months out); New ETA = Jul 2025 (1 month out)
+      // The month/year formatter uses { month: "short", year: "numeric" } locale "en-US".
+      const wasEta = new Date(2025, 7, 1); // Aug 2025
+      const newEta = new Date(2025, 6, 1); // Jul 2025
+      const formatter = new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        year: "numeric",
+      });
+      expect(screen.getByText(formatter.format(wasEta))).toBeDefined();
+      expect(screen.getByText(formatter.format(newEta))).toBeDefined();
+    });
+  });
+
   describe("shows placeholder when monthly allocation is zero", () => {
     it("renders the placeholder in both ETA columns when allocation is 0", () => {
       render(
         <GoalSiblingProjections
           monthlyAllocation={0}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[makeGoal({ id: "g2", name: "Vacation", priority: 2 })]}
         />,
       );
@@ -161,6 +223,7 @@ describe("GoalSiblingProjections — table", () => {
         <GoalSiblingProjections
           monthlyAllocation={500}
           purchasedGoal={purchasedGoal}
+          referenceDate={referenceDate}
           siblingGoals={[]}
         />,
       );

--- a/src/components/goal-purchase/GoalSiblingProjections.stories.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.stories.tsx
@@ -10,6 +10,8 @@ const meta: Meta<typeof GoalSiblingProjections> = {
 export default meta;
 type Story = StoryObj<typeof GoalSiblingProjections>;
 
+const referenceDate = new Date(2025, 5, 1);
+
 const purchasedGoal = {
   id: "goal-1",
   ledgerId: "ledger-1",
@@ -42,6 +44,7 @@ export const WithSiblings: Story = {
   args: {
     monthlyAllocation: 400,
     purchasedGoal,
+    referenceDate,
     siblingGoals,
   },
 };
@@ -50,6 +53,7 @@ export const NoAllocation: Story = {
   args: {
     monthlyAllocation: 0,
     purchasedGoal,
+    referenceDate,
     siblingGoals,
   },
 };
@@ -58,6 +62,7 @@ export const NoSiblings: Story = {
   args: {
     monthlyAllocation: 400,
     purchasedGoal,
+    referenceDate,
     siblingGoals: [],
   },
 };

--- a/src/components/goal-purchase/GoalSiblingProjections.stories.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { GoalSiblingProjections } from "./GoalSiblingProjections";
+
+const meta: Meta<typeof GoalSiblingProjections> = {
+  component: GoalSiblingProjections,
+  title: "GoalPurchase/GoalSiblingProjections",
+};
+
+export default meta;
+type Story = StoryObj<typeof GoalSiblingProjections>;
+
+const purchasedGoal = {
+  id: "goal-1",
+  ledgerId: "ledger-1",
+  name: "Studio Display",
+  targetAmount: 1599,
+  fundedAmount: 1599,
+  priority: 1,
+};
+
+const siblingGoals = [
+  {
+    id: "goal-2",
+    ledgerId: "ledger-1",
+    name: "MacBook Pro",
+    targetAmount: 2499,
+    fundedAmount: 1200,
+    priority: 2,
+  },
+  {
+    id: "goal-3",
+    ledgerId: "ledger-1",
+    name: "Mechanical Keyboard",
+    targetAmount: 350,
+    fundedAmount: 100,
+    priority: 3,
+  },
+];
+
+export const WithSiblings: Story = {
+  args: {
+    monthlyAllocation: 400,
+    purchasedGoal,
+    siblingGoals,
+  },
+};
+
+export const NoAllocation: Story = {
+  args: {
+    monthlyAllocation: 0,
+    purchasedGoal,
+    siblingGoals,
+  },
+};
+
+export const NoSiblings: Story = {
+  args: {
+    monthlyAllocation: 400,
+    purchasedGoal,
+    siblingGoals: [],
+  },
+};

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -21,6 +21,9 @@ export function GoalSiblingProjections({
   const allGoalsBeforePurchase = [...siblingGoals, purchasedGoal].filter(
     (g) => g.fundedAmount < g.targetAmount,
   );
+  const unfundedSiblingGoals = siblingGoals.filter(
+    (g) => g.fundedAmount < g.targetAmount,
+  );
 
   return (
     <Card>
@@ -54,7 +57,7 @@ export function GoalSiblingProjections({
                 );
                 const newEta = computeGoalEta(
                   goal,
-                  siblingGoals,
+                  unfundedSiblingGoals,
                   monthlyAllocation,
                 );
                 return (

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -2,17 +2,24 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+import { monthYearFormatter } from "@/lib/formatters";
+import { computeGoalEta } from "@/lib/goal-funding";
 
 import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
 
 export interface GoalSiblingProjectionsProps {
+  monthlyAllocation: number;
+  purchasedGoal: BudgetLedgerSavingsGoal;
   siblingGoals: BudgetLedgerSavingsGoal[];
 }
 
 export function GoalSiblingProjections({
+  monthlyAllocation,
+  purchasedGoal,
   siblingGoals,
 }: GoalSiblingProjectionsProps) {
-  // TODO: Implement real ETA recalculation in epic #14 (Goal Purchase Flow)
+  const allGoalsBeforePurchase = [...siblingGoals, purchasedGoal];
+
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -37,17 +44,33 @@ export function GoalSiblingProjections({
               </tr>
             </thead>
             <tbody>
-              {siblingGoals.map((goal) => (
-                <tr key={goal.id} className="border-b last:border-b-0">
-                  <td className="px-4 py-2 font-medium">{goal.name}</td>
-                  <td className="px-4 py-2 text-muted-foreground">
-                    {GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
-                  </td>
-                  <td className="px-4 py-2 text-muted-foreground">
-                    {GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
-                  </td>
-                </tr>
-              ))}
+              {siblingGoals.map((goal) => {
+                const priorEta = computeGoalEta(
+                  goal,
+                  allGoalsBeforePurchase,
+                  monthlyAllocation,
+                );
+                const newEta = computeGoalEta(
+                  goal,
+                  siblingGoals,
+                  monthlyAllocation,
+                );
+                return (
+                  <tr key={goal.id} className="border-b last:border-b-0">
+                    <td className="px-4 py-2 font-medium">{goal.name}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {priorEta !== undefined
+                        ? monthYearFormatter.format(priorEta)
+                        : GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {newEta !== undefined
+                        ? monthYearFormatter.format(newEta)
+                        : GOAL_SIBLING_PROJECTIONS_COPY.etaPlaceholder}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         )}

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -18,7 +18,9 @@ export function GoalSiblingProjections({
   purchasedGoal,
   siblingGoals,
 }: GoalSiblingProjectionsProps) {
-  const allGoalsBeforePurchase = [...siblingGoals, purchasedGoal];
+  const allGoalsBeforePurchase = [...siblingGoals, purchasedGoal].filter(
+    (g) => g.fundedAmount < g.targetAmount,
+  );
 
   return (
     <Card>

--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -10,17 +10,20 @@ import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
 export interface GoalSiblingProjectionsProps {
   monthlyAllocation: number;
   purchasedGoal: BudgetLedgerSavingsGoal;
+  referenceDate: Date;
   siblingGoals: BudgetLedgerSavingsGoal[];
 }
 
 export function GoalSiblingProjections({
   monthlyAllocation,
   purchasedGoal,
+  referenceDate,
   siblingGoals,
 }: GoalSiblingProjectionsProps) {
-  const allGoalsBeforePurchase = [...siblingGoals, purchasedGoal].filter(
-    (g) => g.fundedAmount < g.targetAmount,
-  );
+  const allGoalsBeforePurchase = [
+    ...siblingGoals.filter((g) => g.fundedAmount < g.targetAmount),
+    purchasedGoal,
+  ];
   const unfundedSiblingGoals = siblingGoals.filter(
     (g) => g.fundedAmount < g.targetAmount,
   );
@@ -54,11 +57,13 @@ export function GoalSiblingProjections({
                   goal,
                   allGoalsBeforePurchase,
                   monthlyAllocation,
+                  referenceDate,
                 );
                 const newEta = computeGoalEta(
                   goal,
                   unfundedSiblingGoals,
                   monthlyAllocation,
+                  referenceDate,
                 );
                 return (
                   <tr key={goal.id} className="border-b last:border-b-0">

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -2,3 +2,8 @@ export const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
 });
+
+export const monthYearFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});

--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BudgetLedgerTransaction,
+  BudgetLedgerTransactionType,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { computeGoalEta, computeMonthlyDepositRate } from "./goal-funding";
+
+function makeTransaction(
+  overrides: Partial<BudgetLedgerTransaction> = {},
+): BudgetLedgerTransaction {
+  return {
+    id: "tx-1",
+    ledgerId: "ledger-1",
+    type: BudgetLedgerTransactionType.Deposit,
+    date: new Date(2025, 0, 1), // Jan 1, 2025 local
+    amount: 500,
+    description: "Test deposit",
+    ...overrides,
+  };
+}
+
+function makeGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "Test Goal",
+    targetAmount: 1000,
+    fundedAmount: 0,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+// Reference date used across tests for determinism (local Jun 1, 2025)
+const REF_DATE = new Date(2025, 5, 1);
+
+describe("computeMonthlyDepositRate", () => {
+  describe("returns 0 for empty or deposit-free transaction sets", () => {
+    it("returns 0 when there are no transactions", () => {
+      expect(computeMonthlyDepositRate([], REF_DATE)).toBe(0);
+    });
+
+    it("returns 0 when there are only expense transactions", () => {
+      const transactions = [
+        makeTransaction({
+          type: BudgetLedgerTransactionType.Expense,
+          amount: 200,
+          date: new Date("2025-01-01"),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(0);
+    });
+  });
+
+  describe("computes deposit rate over the correct time window", () => {
+    it("divides total deposits by calendar months from first deposit to reference", () => {
+      // Jan to Jun = 5 calendar months; total = $1500 → $300/month
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-2",
+          amount: 600,
+          date: new Date(2025, 2, 1),
+        }),
+        makeTransaction({
+          id: "tx-3",
+          amount: 300,
+          date: new Date(2025, 4, 1),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(300);
+    });
+
+    it("uses a minimum window of 1 month when all deposits are in the reference month", () => {
+      // All deposits in Jun 2025 → 0 elapsed months → clamped to 1
+      const transactions = [
+        makeTransaction({ amount: 900, date: new Date(2025, 5, 1) }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(900);
+    });
+
+    it("ignores expense amounts but uses all deposit dates for the window", () => {
+      // Deposits: Jan $600 + Apr $600 = $1200; expenses excluded from total.
+      // Window: Jan to Jun = 5 months → $240/month
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-expense",
+          type: BudgetLedgerTransactionType.Expense,
+          amount: 999,
+          date: new Date(2025, 1, 1),
+        }),
+        makeTransaction({
+          id: "tx-2",
+          amount: 600,
+          date: new Date(2025, 3, 1),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(240);
+    });
+  });
+});
+
+describe("computeGoalEta", () => {
+  describe("returns undefined when there is no monthly allocation", () => {
+    it("returns undefined when monthlyAllocation is 0", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 0 });
+      expect(computeGoalEta(goal, [goal], 0, REF_DATE)).toBeUndefined();
+    });
+  });
+
+  describe("returns undefined when the goal is already fully funded", () => {
+    it("returns undefined when fundedAmount equals targetAmount", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 1000 });
+      expect(computeGoalEta(goal, [goal], 500, REF_DATE)).toBeUndefined();
+    });
+
+    it("returns undefined when fundedAmount exceeds targetAmount", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 1200 });
+      expect(computeGoalEta(goal, [goal], 500, REF_DATE)).toBeUndefined();
+    });
+  });
+
+  describe("computes ETA for a single goal", () => {
+    it("returns a date 2 months out when a $1000 goal gets $500/month with Zipf share 1.0", () => {
+      // 1 goal → Zipf share = 1.0; $500/month; $1000 remaining → 2 months
+      const goal = makeGoal({
+        targetAmount: 1000,
+        fundedAmount: 0,
+        priority: 1,
+      });
+      const eta = computeGoalEta(goal, [goal], 500, REF_DATE);
+      // REF_DATE = Jun 1, 2025 + 2 months = Aug 1, 2025
+      expect(eta).toBeDefined();
+      expect(eta!.getFullYear()).toBe(2025);
+      expect(eta!.getMonth()).toBe(7); // August (0-indexed)
+    });
+
+    it("returns a date 1 month out when the goal needs $250 at $500/month", () => {
+      const goal = makeGoal({
+        targetAmount: 500,
+        fundedAmount: 250,
+        priority: 1,
+      });
+      const eta = computeGoalEta(goal, [goal], 500, REF_DATE);
+      // $250 remaining / $500 per month = 0.5 months → round up to 1 month
+      expect(eta).toBeDefined();
+      expect(eta!.getFullYear()).toBe(2025);
+      expect(eta!.getMonth()).toBe(6); // July
+    });
+  });
+
+  describe("applies Zipf weights across multiple goals", () => {
+    it("priority-1 goal gets funded before priority-2 goal with equal remaining amounts", () => {
+      const goal1 = makeGoal({
+        id: "g1",
+        priority: 1,
+        targetAmount: 1000,
+        fundedAmount: 0,
+      });
+      const goal2 = makeGoal({
+        id: "g2",
+        priority: 2,
+        targetAmount: 1000,
+        fundedAmount: 0,
+      });
+      const allGoals = [goal1, goal2];
+
+      const eta1 = computeGoalEta(goal1, allGoals, 600, REF_DATE);
+      const eta2 = computeGoalEta(goal2, allGoals, 600, REF_DATE);
+
+      expect(eta1).toBeDefined();
+      expect(eta2).toBeDefined();
+      expect(eta1!.getTime()).toBeLessThan(eta2!.getTime());
+    });
+
+    it("distributes monthly allocation by Zipf weights between two goals", () => {
+      // 2 goals: Zipf share for priority-1 = (1) / (1 + 0.5) = 2/3
+      // Zipf share for priority-2 = (0.5) / (1 + 0.5) = 1/3
+      // Monthly allocation: $900; goal1 gets $600/month, goal2 gets $300/month
+      // goal1 needs $600 → 1 month; goal2 needs $600 → 2 months
+      const goal1 = makeGoal({
+        id: "g1",
+        priority: 1,
+        targetAmount: 600,
+        fundedAmount: 0,
+      });
+      const goal2 = makeGoal({
+        id: "g2",
+        priority: 2,
+        targetAmount: 600,
+        fundedAmount: 0,
+      });
+      const allGoals = [goal1, goal2];
+
+      const eta1 = computeGoalEta(goal1, allGoals, 900, REF_DATE);
+      const eta2 = computeGoalEta(goal2, allGoals, 900, REF_DATE);
+
+      expect(eta1).toBeDefined();
+      expect(eta2).toBeDefined();
+      // goal1: 1 month from Jun → Jul 2025
+      expect(eta1!.getMonth()).toBe(6); // July
+      // goal2: 2 months from Jun → Aug 2025
+      expect(eta2!.getMonth()).toBe(7); // August
+    });
+  });
+});

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -76,7 +76,9 @@ export function computeGoalEta(
 
   const monthsNeeded = Math.ceil(remaining / monthlyForGoal);
 
-  const eta = new Date(referenceDate);
-  eta.setMonth(eta.getMonth() + monthsNeeded);
-  return eta;
+  return new Date(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth() + monthsNeeded,
+    1,
+  );
 }

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -8,8 +8,9 @@ import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goal
  * Computes the average monthly deposit amount from a transaction history.
  *
  * The time window runs from the calendar month of the earliest deposit to the
- * calendar month of the reference date (inclusive). The window is clamped to a
- * minimum of 1 month so a single-month history still yields a meaningful rate.
+ * calendar month of the reference date (exclusive of the start month — e.g.
+ * January to June yields 5 months). The window is clamped to a minimum of 1
+ * month so a single-month history still yields a meaningful rate.
  */
 export function computeMonthlyDepositRate(
   transactions: BudgetLedgerTransaction[],

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -1,0 +1,82 @@
+import {
+  type BudgetLedgerTransaction,
+  BudgetLedgerTransactionType,
+} from "@/lib/firebase/schema/budget-ledger-transactions";
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+/**
+ * Computes the average monthly deposit amount from a transaction history.
+ *
+ * The time window runs from the calendar month of the earliest deposit to the
+ * calendar month of the reference date (inclusive). The window is clamped to a
+ * minimum of 1 month so a single-month history still yields a meaningful rate.
+ */
+export function computeMonthlyDepositRate(
+  transactions: BudgetLedgerTransaction[],
+  referenceDate: Date = new Date(),
+): number {
+  const deposits = transactions.filter(
+    (tx) => tx.type === BudgetLedgerTransactionType.Deposit,
+  );
+
+  if (deposits.length === 0) return 0;
+
+  const totalDeposits = deposits.reduce((sum, tx) => sum + tx.amount, 0);
+
+  const earliestDeposit = deposits.reduce((earliest, tx) =>
+    tx.date < earliest.date ? tx : earliest,
+  );
+
+  const refMonths = referenceDate.getFullYear() * 12 + referenceDate.getMonth();
+  const startMonths =
+    earliestDeposit.date.getFullYear() * 12 + earliestDeposit.date.getMonth();
+
+  const monthsElapsed = Math.max(1, refMonths - startMonths);
+
+  return totalDeposits / monthsElapsed;
+}
+
+/**
+ * Computes the Zipf weight for a goal with the given priority within an ordered
+ * list of goals. Goals are allocated a share of the monthly budget proportional
+ * to 1/priority, normalised so all shares sum to 1.
+ */
+function zipfShare(priority: number, goals: BudgetLedgerSavingsGoal[]): number {
+  const harmonic = goals.reduce((sum, g) => sum + 1 / g.priority, 0);
+  if (harmonic === 0) return 0;
+  return 1 / priority / harmonic;
+}
+
+/**
+ * Projects the date by which the given goal will be fully funded, based on a
+ * Zipf-weighted share of the ledger's monthly deposit allocation.
+ *
+ * Returns `undefined` when:
+ * - `monthlyAllocation` is 0 (cannot project without income data)
+ * - The goal is already fully funded (`fundedAmount >= targetAmount`)
+ *
+ * `allGoals` must include `goal` itself so that the Zipf denominator is
+ * computed correctly across all competing goals.
+ */
+export function computeGoalEta(
+  goal: BudgetLedgerSavingsGoal,
+  allGoals: BudgetLedgerSavingsGoal[],
+  monthlyAllocation: number,
+  referenceDate: Date = new Date(),
+): Date | undefined {
+  if (monthlyAllocation === 0) return undefined;
+
+  const remaining = goal.targetAmount - goal.fundedAmount;
+  if (remaining <= 0) return undefined;
+
+  const share = zipfShare(goal.priority, allGoals);
+  const monthlyForGoal = monthlyAllocation * share;
+
+  if (monthlyForGoal === 0) return undefined;
+
+  const monthsNeeded = Math.ceil(remaining / monthlyForGoal);
+
+  const eta = new Date(referenceDate);
+  eta.setMonth(eta.getMonth() + monthsNeeded);
+  return eta;
+}


### PR DESCRIPTION
Implements real projected funding ETAs for the sibling goals panel on the purchase confirmation screen. Previously both the "Was" and "New ETA" columns showed placeholder dashes.

A new `goal-funding` utility module provides `computeMonthlyDepositRate` (averages deposits over history) and `computeGoalEta` (projects a Date using Zipf-weighted allocation). The purchase page derives the ledger's monthly deposit rate from `useTransactions` and passes it through `GoalPurchaseView` to `GoalSiblingProjections`. The component now renders two live dates per sibling: "Was" (ETA before the purchase, when the purchased goal still competed for the allocation) and "New ETA" (after the purchase, with one fewer goal in the Zipf denominator).

Also threads `ledgerCashBalance` through `GoalPurchaseView` and conditionally renders `GoalPurchaseWarning` when the ledger balance falls below the goal's target amount.

Closes #201

---
*Created by Claude Sonnet 4.6*