### PR TITLE
feat(goals): allocate deposits across goals using Zipf-weighted distribution

### DIFF
--- a/src/lib/goal-allocation.spec.ts
+++ b/src/lib/goal-allocation.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+import { allocateDeposit } from "./goal-allocation";
+
+function makeGoal(
+  overrides: Partial<BudgetLedgerSavingsGoal> = {},
+): BudgetLedgerSavingsGoal {
+  return {
+    id: "goal-1",
+    ledgerId: "ledger-1",
+    name: "Test Goal",
+    targetAmount: 1000,
+    fundedAmount: 0,
+    priority: 1,
+    ...overrides,
+  };
+}
+
+describe("allocateDeposit — empty goals", () => {
+  it("returns an empty object when there are no goals", () => {
+    const result = allocateDeposit([], 500);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+describe("allocateDeposit — zero deposit", () => {
+  it("allocates 0 to each goal when deposit is 0", () => {
+    const goals = [
+      makeGoal({ id: "g1", priority: 1 }),
+      makeGoal({ id: "g2", priority: 2 }),
+    ];
+    const result = allocateDeposit(goals, 0);
+    expect(result["g1"]).toBe(0);
+    expect(result["g2"]).toBe(0);
+  });
+});
+
+describe("allocateDeposit — single goal receives the full deposit", () => {
+  it("gives the single goal the entire deposit", () => {
+    const goal = makeGoal({ id: "g1", priority: 1 });
+    const result = allocateDeposit([goal], 500);
+    expect(result["g1"]).toBe(500);
+  });
+
+  it("gives the single goal the full amount regardless of priority value", () => {
+    const goal = makeGoal({ id: "g1", priority: 3 });
+    const result = allocateDeposit([goal], 300);
+    expect(result["g1"]).toBe(300);
+  });
+});
+
+describe("allocateDeposit — Zipf-weighted shares", () => {
+  it("gives priority-1 goal a larger share than priority-2 goal", () => {
+    const goal1 = makeGoal({ id: "g1", priority: 1 });
+    const goal2 = makeGoal({ id: "g2", priority: 2 });
+    const result = allocateDeposit([goal1, goal2], 300);
+    expect(result["g1"]!).toBeGreaterThan(result["g2"]!);
+  });
+
+  it("gives exactly correct integer allocations when the deposit divides evenly", () => {
+    // Zipf with priorities 1 and 2: harmonic = 1 + 0.5 = 1.5
+    // shares = 2/3 and 1/3
+    // 300 cents: g1 gets 200, g2 gets 100 exactly — no rounding needed
+    const goal1 = makeGoal({ id: "g1", priority: 1 });
+    const goal2 = makeGoal({ id: "g2", priority: 2 });
+    const result = allocateDeposit([goal1, goal2], 300);
+    expect(result["g1"]).toBe(200);
+    expect(result["g2"]).toBe(100);
+  });
+
+  it("scales share correctly across three Zipf-weighted goals with even division", () => {
+    // harmonic = 1 + 1/2 + 1/3 = 11/6
+    // shares ≈ 0.545, 0.273, 0.182
+    // 110 cents: g1 ≈ 60, g2 ≈ 30, g3 ≈ 20 — check g1 > g2 > g3
+    const goal1 = makeGoal({ id: "g1", priority: 1 });
+    const goal2 = makeGoal({ id: "g2", priority: 2 });
+    const goal3 = makeGoal({ id: "g3", priority: 3 });
+    const result = allocateDeposit([goal1, goal2, goal3], 110);
+    expect(result["g1"]!).toBeGreaterThan(result["g2"]!);
+    expect(result["g2"]!).toBeGreaterThan(result["g3"]!);
+  });
+});
+
+describe("allocateDeposit — total always equals the deposit amount", () => {
+  it("sums to the deposit amount for two goals with a fractional remainder", () => {
+    // 100 cents with priorities 1 and 2: exact = 66.67 and 33.33 — 1 extra penny
+    const goals = [
+      makeGoal({ id: "g1", priority: 1 }),
+      makeGoal({ id: "g2", priority: 2 }),
+    ];
+    const deposit = 100;
+    const result = allocateDeposit(goals, deposit, () => 0);
+    const total = Object.values(result).reduce((s, v) => s + v, 0);
+    expect(total).toBe(deposit);
+  });
+
+  it("sums to the deposit amount for three Zipf-weighted goals", () => {
+    const goals = [
+      makeGoal({ id: "g1", priority: 1 }),
+      makeGoal({ id: "g2", priority: 2 }),
+      makeGoal({ id: "g3", priority: 3 }),
+    ];
+    const deposit = 100;
+    const result = allocateDeposit(goals, deposit, () => 0);
+    const total = Object.values(result).reduce((s, v) => s + v, 0);
+    expect(total).toBe(deposit);
+  });
+
+  it("sums to the deposit for a large awkward amount", () => {
+    const goals = [
+      makeGoal({ id: "g1", priority: 1 }),
+      makeGoal({ id: "g2", priority: 2 }),
+      makeGoal({ id: "g3", priority: 3 }),
+    ];
+    const deposit = 999;
+    const result = allocateDeposit(goals, deposit, () => 0.5);
+    const total = Object.values(result).reduce((s, v) => s + v, 0);
+    expect(total).toBe(deposit);
+  });
+});
+
+describe("allocateDeposit — probabilistic penny rounding", () => {
+  it("rounds up the goal with the highest fractional remainder when random returns 0", () => {
+    // Priorities 1 and 2: exact = 66.666... and 33.333...
+    // floors: g1=66, g2=33 → extraPennies=1
+    // fracs: g1≈0.667 (larger), g2≈0.333
+    // random()=0 → threshold=0, iteration subtracts g1.frac first → g1 wins
+    const goal1 = makeGoal({ id: "g1", priority: 1 });
+    const goal2 = makeGoal({ id: "g2", priority: 2 });
+    const result = allocateDeposit([goal1, goal2], 100, () => 0);
+    expect(result["g1"]).toBe(67);
+    expect(result["g2"]).toBe(33);
+  });
+
+  it("each allocation is a non-negative integer", () => {
+    const goals = [
+      makeGoal({ id: "g1", priority: 1 }),
+      makeGoal({ id: "g2", priority: 2 }),
+      makeGoal({ id: "g3", priority: 3 }),
+    ];
+    const result = allocateDeposit(goals, 100, () => 0.5);
+    for (const cents of Object.values(result)) {
+      expect(cents).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(cents)).toBe(true);
+    }
+  });
+});

--- a/src/lib/goal-allocation.ts
+++ b/src/lib/goal-allocation.ts
@@ -1,0 +1,70 @@
+import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
+
+/**
+ * Allocates a deposit amount across savings goals using Zipf-weighted
+ * distribution. The goal with priority 1 receives the largest share (weight 1),
+ * priority 2 receives half (weight 1/2), priority 3 receives a third (weight
+ * 1/3), and so on. All weights are normalised so the shares sum to 1.
+ *
+ * The deposit amount is treated as an integer number of the smallest currency
+ * unit (e.g. cents). Fractional cents are distributed using probabilistic
+ * rounding: extra pennies are assigned to goals by weighted random draw
+ * proportional to each goal's fractional allocation, without replacement, so
+ * the total always exactly equals `depositAmountCents`.
+ *
+ * @param goals - The goals to allocate the deposit across. Order does not
+ *   matter — shares are determined by each goal's `priority` field.
+ * @param depositAmountCents - The total deposit in the smallest currency unit.
+ * @param random - Optional seeded random function (defaults to `Math.random`).
+ *   Injected for deterministic testing.
+ * @returns A map from goal ID to the integer cents allocated to that goal.
+ */
+export function allocateDeposit(
+  goals: BudgetLedgerSavingsGoal[],
+  depositAmountCents: number,
+  random: () => number = Math.random,
+): Record<string, number> {
+  if (goals.length === 0) return {};
+
+  const harmonic = goals.reduce((sum, g) => sum + 1 / g.priority, 0);
+
+  interface GoalAlloc {
+    frac: number;
+    floor: number;
+    id: string;
+  }
+
+  const allocs: GoalAlloc[] = goals.map((g) => {
+    const exact = (depositAmountCents * (1 / g.priority)) / harmonic;
+    const floor = Math.floor(exact);
+    return { id: g.id, floor, frac: exact - floor };
+  });
+
+  const totalFloor = allocs.reduce((s, a) => s + a.floor, 0);
+  const extraPennies = depositAmountCents - totalFloor;
+
+  // Distribute extra pennies using weighted random sampling without replacement.
+  // Each goal's probability of receiving a bonus cent is proportional to its
+  // fractional allocation remainder.
+  const bonuses = new Set<string>();
+  const remaining = allocs.filter((a) => a.frac > 0);
+
+  for (let i = 0; i < extraPennies; i++) {
+    const totalFrac = remaining.reduce((s, a) => s + a.frac, 0);
+    let threshold = random() * totalFrac;
+    for (let j = 0; j < remaining.length; j++) {
+      const candidate = remaining[j];
+      if (candidate === undefined) break;
+      threshold -= candidate.frac;
+      if (threshold <= 0) {
+        bonuses.add(candidate.id);
+        remaining.splice(j, 1);
+        break;
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    allocs.map((a) => [a.id, a.floor + (bonuses.has(a.id) ? 1 : 0)]),
+  );
+}


### PR DESCRIPTION
Adds `allocateDeposit` in `src/lib/goal-allocation.ts` — a pure utility that distributes a deposit amount (in integer cents) across savings goals using Zipf-weighted shares. The goal with priority 1 gets weight 1, priority 2 gets weight 1/2, priority 3 gets weight 1/3, and so on, with all weights normalised so the shares sum to 1.

Fractional cents are handled with probabilistic penny rounding: extra pennies are assigned to goals by weighted random draw proportional to each goal's fractional allocation remainder, without replacement, so the total always exactly equals the deposit.

## Acceptance Criteria
- [x] Distributes the full deposit proportional to Zipf weights (1/priority normalised)
- [x] Total of all allocations always exactly equals the deposit amount
- [x] Each allocation is a non-negative integer (whole cents)
- [x] Probabilistic rounding: fractional remainders determine bonus-cent probability via weighted random draw
- [x] Returns an empty map when there are no goals

## Tests
12 tests added, all passing.

Closes #202

---
*Created by Claude Sonnet 4.5*