### PR TITLE
feat(goals): extract GoalProgressBar component

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -2,16 +2,11 @@
 
 import Link from "next/link";
 
-import { Bar } from "@/components/ui/bar";
 import { Card } from "@/components/ui/card";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
 import { GOAL_CARD_COPY, GOALS_LIST_COPY } from "./copy";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-});
+import { GoalProgressBar } from "./GoalProgressBar";
 
 export interface GoalCardProps {
   goal: BudgetLedgerSavingsGoal;
@@ -19,13 +14,8 @@ export interface GoalCardProps {
 }
 
 export function GoalCard({ goal, ledgerName }: GoalCardProps) {
-  const isFullyFunded = goal.fundedAmount >= goal.targetAmount;
-  const progressPercent = isFullyFunded
-    ? 100
-    : goal.targetAmount > 0
-      ? Math.min(99, Math.floor((goal.fundedAmount / goal.targetAmount) * 100))
-      : 0;
-  const amountToGo = Math.max(0, goal.targetAmount - goal.fundedAmount);
+  const isFullyFunded =
+    goal.targetAmount > 0 && goal.fundedAmount >= goal.targetAmount;
 
   return (
     <Link href={`/goals/${goal.id}/purchase`} className="block">
@@ -44,35 +34,10 @@ export function GoalCard({ goal, ledgerName }: GoalCardProps) {
 
         <p className="text-base font-semibold leading-snug">{goal.name}</p>
 
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-2xl font-bold tabular-nums">
-            {currencyFormatter.format(goal.fundedAmount)}
-          </span>
-          <span className="text-sm text-muted-foreground">
-            {GOAL_CARD_COPY.ofTarget(
-              currencyFormatter.format(goal.targetAmount),
-            )}
-          </span>
-        </div>
-
-        <Bar value={progressPercent} className="w-full" />
-
-        <div className="flex items-center justify-between text-sm">
-          <span className="text-muted-foreground">
-            {GOAL_CARD_COPY.fundedLabel(progressPercent)}
-          </span>
-          <span
-            className={
-              isFullyFunded
-                ? "font-medium text-green-600 dark:text-green-400"
-                : "text-muted-foreground"
-            }
-          >
-            {isFullyFunded
-              ? GOALS_LIST_COPY.readyToPurchase
-              : GOAL_CARD_COPY.toGoLabel(currencyFormatter.format(amountToGo))}
-          </span>
-        </div>
+        <GoalProgressBar
+          fundedAmount={goal.fundedAmount}
+          targetAmount={goal.targetAmount}
+        />
       </Card>
     </Link>
   );

--- a/src/components/goals/GoalProgressBar.spec.tsx
+++ b/src/components/goals/GoalProgressBar.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GOAL_CARD_COPY, GOALS_LIST_COPY } from "./copy";
+import { GoalProgressBar } from "./GoalProgressBar";
+
+afterEach(cleanup);
+
+describe("GoalProgressBar — funded amount", () => {
+  it("shows the funded amount formatted as currency", () => {
+    render(<GoalProgressBar fundedAmount={2500} targetAmount={10000} />);
+    expect(screen.getByText("$2,500.00")).toBeDefined();
+  });
+
+  it("shows the target amount via the ofTarget copy", () => {
+    render(<GoalProgressBar fundedAmount={1000} targetAmount={8000} />);
+    expect(
+      screen.getByText(GOAL_CARD_COPY.ofTarget("$8,000.00")),
+    ).toBeDefined();
+  });
+});
+
+describe("GoalProgressBar — percent funded", () => {
+  it("shows the funded percentage via the fundedLabel copy", () => {
+    render(<GoalProgressBar fundedAmount={1000} targetAmount={4000} />);
+    expect(screen.getByText(GOAL_CARD_COPY.fundedLabel(25))).toBeDefined();
+  });
+
+  it("shows 0% funded when targetAmount is 0", () => {
+    render(<GoalProgressBar fundedAmount={0} targetAmount={0} />);
+    expect(screen.getByText(GOAL_CARD_COPY.fundedLabel(0))).toBeDefined();
+  });
+
+  it("caps at 99% when not yet fully funded", () => {
+    render(<GoalProgressBar fundedAmount={9999} targetAmount={10000} />);
+    expect(screen.getByText(GOAL_CARD_COPY.fundedLabel(99))).toBeDefined();
+  });
+
+  it("shows 100% when fully funded", () => {
+    render(<GoalProgressBar fundedAmount={5000} targetAmount={5000} />);
+    expect(screen.getByText(GOAL_CARD_COPY.fundedLabel(100))).toBeDefined();
+  });
+});
+
+describe("GoalProgressBar — amount remaining", () => {
+  it("shows amount to go when not fully funded", () => {
+    render(<GoalProgressBar fundedAmount={1000} targetAmount={5000} />);
+    expect(
+      screen.getByText(GOAL_CARD_COPY.toGoLabel("$4,000.00")),
+    ).toBeDefined();
+  });
+
+  it("does not show the to-go label when fully funded", () => {
+    render(<GoalProgressBar fundedAmount={5000} targetAmount={5000} />);
+    expect(screen.queryByText(/to go/)).toBeNull();
+  });
+});
+
+describe("GoalProgressBar — fully funded indicator", () => {
+  it("shows the ready-to-purchase label when fundedAmount equals targetAmount", () => {
+    render(<GoalProgressBar fundedAmount={3000} targetAmount={3000} />);
+    expect(screen.getByText(GOALS_LIST_COPY.readyToPurchase)).toBeDefined();
+  });
+
+  it("shows the ready-to-purchase label when fundedAmount exceeds targetAmount", () => {
+    render(<GoalProgressBar fundedAmount={4000} targetAmount={3000} />);
+    expect(screen.getByText(GOALS_LIST_COPY.readyToPurchase)).toBeDefined();
+  });
+
+  it("does not show ready-to-purchase label when not fully funded", () => {
+    render(<GoalProgressBar fundedAmount={2999} targetAmount={3000} />);
+    expect(screen.queryByText(GOALS_LIST_COPY.readyToPurchase)).toBeNull();
+  });
+});

--- a/src/components/goals/GoalProgressBar.stories.tsx
+++ b/src/components/goals/GoalProgressBar.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { GoalProgressBar } from "./GoalProgressBar";
+
+const meta: Meta<typeof GoalProgressBar> = {
+  component: GoalProgressBar,
+  title: "Goals/GoalProgressBar",
+};
+
+export default meta;
+type Story = StoryObj<typeof GoalProgressBar>;
+
+export const Unfunded: Story = {
+  args: {
+    fundedAmount: 0,
+    targetAmount: 10000,
+  },
+};
+
+export const PartiallyFunded: Story = {
+  args: {
+    fundedAmount: 3500,
+    targetAmount: 10000,
+  },
+};
+
+export const MostlyFunded: Story = {
+  args: {
+    fundedAmount: 9200,
+    targetAmount: 10000,
+  },
+};
+
+export const FullyFunded: Story = {
+  args: {
+    fundedAmount: 10000,
+    targetAmount: 10000,
+  },
+};
+
+export const OverFunded: Story = {
+  args: {
+    fundedAmount: 10500,
+    targetAmount: 10000,
+  },
+};
+
+export const NoTarget: Story = {
+  args: {
+    fundedAmount: 0,
+    targetAmount: 0,
+  },
+};

--- a/src/components/goals/GoalProgressBar.tsx
+++ b/src/components/goals/GoalProgressBar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Bar } from "@/components/ui/bar";
+import { currencyFormatter } from "@/lib/formatters";
+
+import { GOAL_CARD_COPY, GOALS_LIST_COPY } from "./copy";
+
+export interface GoalProgressBarProps {
+  fundedAmount: number;
+  targetAmount: number;
+}
+
+export function GoalProgressBar({
+  fundedAmount,
+  targetAmount,
+}: GoalProgressBarProps) {
+  const isFullyFunded = targetAmount > 0 && fundedAmount >= targetAmount;
+  const progressPercent = isFullyFunded
+    ? 100
+    : targetAmount > 0
+      ? Math.min(99, Math.floor((fundedAmount / targetAmount) * 100))
+      : 0;
+  const amountToGo = Math.max(0, targetAmount - fundedAmount);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-2xl font-bold tabular-nums">
+          {currencyFormatter.format(fundedAmount)}
+        </span>
+        <span className="text-sm text-muted-foreground">
+          {GOAL_CARD_COPY.ofTarget(currencyFormatter.format(targetAmount))}
+        </span>
+      </div>
+
+      <Bar value={progressPercent} className="w-full" />
+
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">
+          {GOAL_CARD_COPY.fundedLabel(progressPercent)}
+        </span>
+        <span
+          className={
+            isFullyFunded
+              ? "font-medium text-green-600 dark:text-green-400"
+              : "text-muted-foreground"
+          }
+        >
+          {isFullyFunded
+            ? GOALS_LIST_COPY.readyToPurchase
+            : GOAL_CARD_COPY.toGoLabel(currencyFormatter.format(amountToGo))}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/goals/GoalsListView.spec.tsx
+++ b/src/components/goals/GoalsListView.spec.tsx
@@ -108,6 +108,53 @@ describe("GoalsListView — error state", () => {
   });
 });
 
+describe("GoalsListView — fullyFundedCount", () => {
+  describe("counts fully funded goals", () => {
+    it("counts goals where fundedAmount >= targetAmount and targetAmount > 0", () => {
+      const goals = [
+        makeGoal({ id: "g1", targetAmount: 5000, fundedAmount: 5000 }),
+        makeGoal({ id: "g2", targetAmount: 5000, fundedAmount: 3000 }),
+      ];
+      const { container } = render(
+        <GoalsListView
+          goals={goals}
+          ledgerNames={ledgerNames}
+          isLoading={false}
+        />,
+      );
+      const summaryParagraph = container.querySelector(
+        "p.text-muted-foreground",
+      );
+      expect(summaryParagraph?.textContent).toContain(
+        GOALS_LIST_COPY.fullyFundedCount(1),
+      );
+    });
+
+    it("does not count a goal with targetAmount === 0 as fully funded", () => {
+      const goals = [
+        makeGoal({ id: "g1", targetAmount: 0, fundedAmount: 0 }),
+        makeGoal({ id: "g2", targetAmount: 5000, fundedAmount: 5000 }),
+      ];
+      const { container } = render(
+        <GoalsListView
+          goals={goals}
+          ledgerNames={ledgerNames}
+          isLoading={false}
+        />,
+      );
+      const summaryParagraph = container.querySelector(
+        "p.text-muted-foreground",
+      );
+      expect(summaryParagraph?.textContent).toContain(
+        GOALS_LIST_COPY.fullyFundedCount(1),
+      );
+      expect(summaryParagraph?.textContent).not.toContain(
+        GOALS_LIST_COPY.fullyFundedCount(2),
+      );
+    });
+  });
+});
+
 describe("GoalsListView — populated state", () => {
   describe("renders a card for each goal", () => {
     it("renders goal names for all goals", () => {

--- a/src/components/goals/GoalsListView.tsx
+++ b/src/components/goals/GoalsListView.tsx
@@ -22,7 +22,7 @@ export function GoalsListView({
   error,
 }: GoalsListViewProps) {
   const fullyFunded = goals.filter(
-    (g) => g.fundedAmount >= g.targetAmount,
+    (g) => g.targetAmount > 0 && g.fundedAmount >= g.targetAmount,
   ).length;
 
   return (

--- a/src/components/goals/index.ts
+++ b/src/components/goals/index.ts
@@ -1,4 +1,6 @@
 export type { GoalCardProps } from "./GoalCard";
 export { GoalCard } from "./GoalCard";
+export type { GoalProgressBarProps } from "./GoalProgressBar";
+export { GoalProgressBar } from "./GoalProgressBar";
 export type { GoalsListViewProps } from "./GoalsListView";
 export { GoalsListView } from "./GoalsListView";


### PR DESCRIPTION
Extracts the funded amount / progress bar / percentage / remaining-amount display into a standalone `GoalProgressBar` component. `GoalCard` now delegates all progress rendering to it, removing the duplicated inline logic.

The component takes `fundedAmount` and `targetAmount` as props and handles all display states: partial funding (shows amount to go), full funding (shows "Ready to purchase"), and the edge case where `targetAmount === 0` (shows 0% rather than incorrectly treating 0/0 as fully funded). The shared `currencyFormatter` from `@/lib/formatters` is used instead of the previously local copy in `GoalCard`.

Closes #203

---
*Created by Claude Sonnet 4.5*