### PR TITLE
chore(infra): add pnpm install step to AGENTS.md worktree setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ pnpm run env:validate # Validate deployment config files against schema
 pnpm run secrets-check # Config validation + gitleaks scan (also runs pre-commit)
 ```
 
+## Worktree Setup
+
+After creating a git worktree (`git worktree add .git-worktrees/<name>`), run `pnpm install --frozen-lockfile` inside it before invoking any build or test commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
+
 ## Deployment Config
 
 Public (non-secret) environment config lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; patterns matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ pnpm run secrets-check # Config validation + gitleaks scan (also runs pre-commit
 
 ## Worktree Setup
 
-After creating a git worktree (`git worktree add .git-worktrees/<name>`), run `pnpm install --frozen-lockfile` inside it before invoking any build or test commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
+After creating a git worktree (`git worktree add .git-worktrees/<name>`), run `pnpm install --frozen-lockfile` inside it before invoking any build, lint, format, type-check, or test commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. This step typically requires no network access when the global store is already populated, since only hardlinks are created — it takes a few seconds.
 
 ## Deployment Config
 


### PR DESCRIPTION
Adds a "Worktree Setup" section to `AGENTS.md` (the canonical file — `CLAUDE.md` is a symlink to it) immediately after the "Common Commands" block, instructing agents and humans to run `pnpm install --frozen-lockfile` in a fresh worktree before invoking any build, lint, format, type-check, or test command. The note clarifies that when the global pnpm store is already populated, the step only creates hardlinks — no download needed, a few seconds at most.

This addresses the recurring sub-agent failure mode where a worktree is created and then `pnpm test` / `pnpm lint` fail immediately because `node_modules` is absent.

Closes #239

---
*Created by Claude Sonnet 4.5*