### PR TITLE
refactor(investments): replace inline allocation card in InvestmentsView with AllocationDashboardView

### DIFF
--- a/src/components/investments/InvestmentsView.tsx
+++ b/src/components/investments/InvestmentsView.tsx
@@ -8,13 +8,13 @@ import type {
 } from "@/lib/firebase/schema/investments";
 import { Posture } from "@/lib/firebase/schema/investments";
 
+import { AllocationDashboardView } from "./AllocationDashboardView";
 import {
   AGGREGATE_BUY_SELL_COPY,
   INVESTMENTS_VIEW_COPY,
   LEDGER_INVESTMENT_TABLE_COPY,
   MONTHLY_DISTRIBUTION_COPY,
   RECOMMENDED_CARD_COPY,
-  TARGET_ALLOCATION_COPY,
 } from "./copy";
 import { INVESTMENTS_PLACEHOLDER_FIXTURE } from "./fixtures";
 import { PostureCard } from "./PostureCard";
@@ -136,36 +136,7 @@ export function InvestmentsView({
       {/* Middle two-column section */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {/* Target allocation */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold">
-              {TARGET_ALLOCATION_COPY.title}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-3">
-            {accounts.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                {TARGET_ALLOCATION_COPY.noAccountsConfigured}
-              </p>
-            ) : (
-              accounts.map((account) => (
-                <div
-                  key={account.id}
-                  className="flex items-center justify-between text-sm"
-                >
-                  <span>{account.name}</span>
-                  <span className="font-mono text-muted-foreground">
-                    {String(account.currentPercent)}% /{" "}
-                    {String(account.targetPercent)}%
-                  </span>
-                </div>
-              ))
-            )}
-            <p className="text-xs text-muted-foreground">
-              {TARGET_ALLOCATION_COPY.footerNote}
-            </p>
-          </CardContent>
-        </Card>
+        <AllocationDashboardView accounts={accounts} />
 
         {/* Monthly distribution */}
         <Card>


### PR DESCRIPTION
Removes the inline "Target allocation" card from `InvestmentsView` and replaces it with `<AllocationDashboardView accounts={accounts} />`. This eliminates a duplicate implementation that rendered the same per-account allocation data with a simpler UI, while `AllocationDashboardView` provides the richer bar/marker/deviation display.

The only file changed is `InvestmentsView.tsx`: the 30-line inline card block and the now-unused `TARGET_ALLOCATION_COPY` import are deleted, replaced by a single component call.

## Acceptance Criteria
- [x] `InvestmentsView` renders `<AllocationDashboardView>` where the inline card previously lived.
- [x] The inline implementation (the `accounts.map(...)` block and surrounding card JSX inside `InvestmentsView`) is removed.
- [x] All existing `InvestmentsView` tests continue to pass.
- [x] `AllocationDashboardView` stories and spec are unchanged (no new tests needed — the component is already covered).

## Tests
11 existing `InvestmentsView` tests passing. Full suite: 1317 tests across 170 files, all passing.

Closes #240

---
*Created by Claude Sonnet 4.6*