### PR TITLE
refactor(reconcile): consolidate chronological-replay logic shared by calculateLedgerBalance and calculateMonthlyInvestmentTarget

### DIFF
--- a/src/lib/reconciliation/ledger-balance.spec.ts
+++ b/src/lib/reconciliation/ledger-balance.spec.ts
@@ -84,6 +84,53 @@ describe("calculateLedgerBalance — expenses only", () => {
   });
 });
 
+describe("calculateLedgerBalance — optional starting balances", () => {
+  it("starts from the provided startingCashBalance instead of zero", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      startingCashBalance: 400,
+      transactions: [],
+    });
+    expect(result.cashBalance).toBe(400);
+    expect(result.investmentBalance).toBe(0);
+  });
+
+  it("starts from the provided startingInvestmentBalance instead of zero", () => {
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      startingInvestmentBalance: 250,
+      transactions: [],
+    });
+    expect(result.cashBalance).toBe(0);
+    expect(result.investmentBalance).toBe(250);
+  });
+
+  it("applies transactions on top of both starting balances", () => {
+    // Cash already 800 of 1000 cap; deposit 400 fills 200 to cash and 200 to investment.
+    // Starting investment 100 + 200 overflow = 300.
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      startingCashBalance: 800,
+      startingInvestmentBalance: 100,
+      transactions: [makeDeposit(400)],
+    });
+    expect(result.cashBalance).toBe(1000);
+    expect(result.investmentBalance).toBe(300);
+  });
+
+  it("deducts an expense from the starting cash balance", () => {
+    // Starting cash 500; expense 200; no investment draw needed.
+    const result = calculateLedgerBalance({
+      cashCap: 1000,
+      startingCashBalance: 500,
+      startingInvestmentBalance: 300,
+      transactions: [makeExpense(200)],
+    });
+    expect(result.cashBalance).toBe(300);
+    expect(result.investmentBalance).toBe(300);
+  });
+});
+
 describe("calculateLedgerBalance — mixed transactions", () => {
   it("deducts expenses from cash before investment", () => {
     const result = calculateLedgerBalance({

--- a/src/lib/reconciliation/ledger-balance.ts
+++ b/src/lib/reconciliation/ledger-balance.ts
@@ -23,6 +23,13 @@ export interface LedgerBalanceResult {
  * Deposits fill the cash portion up to the cash cap; any amount above the cap
  * overflows into the investment portion. Expenses deduct from cash first; when
  * cash is exhausted, the remainder deducts from investment.
+ *
+ * @param startingCashBalance - Initial cash balance before replaying
+ *   transactions. Defaults to 0. Pass a non-zero value to continue from an
+ *   arbitrary balance, e.g. when chaining multi-period calculations.
+ * @param startingInvestmentBalance - Initial investment balance before
+ *   replaying transactions. Defaults to 0. Pass a non-zero value to continue
+ *   from an arbitrary balance, e.g. when chaining multi-period calculations.
  */
 export function calculateLedgerBalance({
   cashCap,

--- a/src/lib/reconciliation/ledger-balance.ts
+++ b/src/lib/reconciliation/ledger-balance.ts
@@ -6,6 +6,8 @@ import { applyExpenseDeduction } from "./expense-deduction";
 
 export interface LedgerBalanceInput {
   cashCap: number | undefined;
+  startingCashBalance?: number;
+  startingInvestmentBalance?: number;
   transactions: BudgetLedgerTransaction[];
 }
 
@@ -24,6 +26,8 @@ export interface LedgerBalanceResult {
  */
 export function calculateLedgerBalance({
   cashCap,
+  startingCashBalance = 0,
+  startingInvestmentBalance = 0,
   transactions,
 }: LedgerBalanceInput): LedgerBalanceResult {
   const sorted = [...transactions].sort((a, b) => {
@@ -64,6 +68,9 @@ export function calculateLedgerBalance({
         investmentBalance: Math.max(0, next.investmentBalance),
       };
     },
-    { cashBalance: 0, investmentBalance: 0 },
+    {
+      cashBalance: startingCashBalance,
+      investmentBalance: startingInvestmentBalance,
+    },
   );
 }

--- a/src/lib/reconciliation/monthly-investment-target.ts
+++ b/src/lib/reconciliation/monthly-investment-target.ts
@@ -1,8 +1,6 @@
 import type { BudgetLedgerTransaction } from "@/lib/firebase/schema/budget-ledger-transactions";
-import { BudgetLedgerTransactionType } from "@/lib/firebase/schema/budget-ledger-transactions";
 
-import { applyDepositSplit } from "./deposit-split";
-import { applyExpenseDeduction } from "./expense-deduction";
+import { calculateLedgerBalance } from "./ledger-balance";
 
 export interface MonthlyInvestmentTargetInput {
   cashCap: number | undefined;
@@ -34,49 +32,11 @@ export function calculateMonthlyInvestmentTarget({
   startingInvestmentBalance,
   transactions,
 }: MonthlyInvestmentTargetInput): MonthlyInvestmentTargetResult {
-  const sorted = [...transactions].sort((a, b) => {
-    const dateDiff = a.date.getTime() - b.date.getTime();
-    if (dateDiff !== 0) return dateDiff;
-    if (
-      a.type === BudgetLedgerTransactionType.Deposit &&
-      b.type === BudgetLedgerTransactionType.Expense
-    )
-      return -1;
-    if (
-      a.type === BudgetLedgerTransactionType.Expense &&
-      b.type === BudgetLedgerTransactionType.Deposit
-    )
-      return 1;
-    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  const { investmentBalance } = calculateLedgerBalance({
+    cashCap,
+    startingCashBalance,
+    startingInvestmentBalance,
+    transactions,
   });
-
-  const ending = sorted.reduce(
-    (balance, tx) => {
-      if (tx.type === BudgetLedgerTransactionType.Deposit) {
-        return applyDepositSplit({
-          cashBalance: balance.cashBalance,
-          cashCap,
-          depositAmount: tx.amount,
-          investmentBalance: balance.investmentBalance,
-        });
-      }
-      const next = applyExpenseDeduction({
-        cashBalance: balance.cashBalance,
-        expenseAmount: tx.amount,
-        investmentBalance: balance.investmentBalance,
-      });
-      return {
-        cashBalance: Math.max(0, next.cashBalance),
-        investmentBalance: Math.max(0, next.investmentBalance),
-      };
-    },
-    {
-      cashBalance: startingCashBalance,
-      investmentBalance: startingInvestmentBalance,
-    },
-  );
-
-  return {
-    netInvestmentTarget: ending.investmentBalance - startingInvestmentBalance,
-  };
+  return { netInvestmentTarget: investmentBalance - startingInvestmentBalance };
 }


### PR DESCRIPTION
The sort comparator and reduce body for chronological transaction replay were duplicated between `calculateLedgerBalance` and `calculateMonthlyInvestmentTarget`. This PR eliminates the duplication by extending `calculateLedgerBalance` to accept optional `startingCashBalance` and `startingInvestmentBalance` parameters (defaulting to 0), then reducing `calculateMonthlyInvestmentTarget` to a thin wrapper that calls it and returns `endingInvestmentBalance - startingInvestmentBalance`.

The two copies of the comparator and reduce body can no longer drift independently, and the `MonthlyInvestmentTargetInput` interface is preserved unchanged so all callers continue to compile without modification.

## Acceptance Criteria
- [x] `calculateLedgerBalance` accepts optional `startingCashBalance` and `startingInvestmentBalance` parameters (defaulting to 0)
- [x] `calculateMonthlyInvestmentTarget` is a thin wrapper that delegates to `calculateLedgerBalance`
- [x] No behavioral regression — all existing tests for both functions continue to pass
- [x] The duplicated sort comparator and reduce body exist in only one place

## Tests
4 tests added (optional starting balances on `calculateLedgerBalance`), all passing. 332 total tests passing.

Closes #233

---
*Created by Claude Sonnet 4.6*