### PR TITLE
fix(ci): prevent Storybook Screenshots race on concurrent PR runs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -54,6 +54,9 @@ jobs:
   storybook-screenshots:
     name: Storybook Screenshots
     if: github.event_name == 'pull_request'
+    concurrency:
+      group: storybook-screenshots-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The `storybook-screenshots` CI job pushes captured screenshots to the `gh-screenshots` branch. When two runs fire concurrently for the same PR (e.g. an initial commit run still in progress when a fix commit lands), both try to push to the same `pr-<N>/` prefix simultaneously — the second push fails with "Update is not a fast forward", marking the CI check as failed even though no screenshot content is wrong.

Adding a `concurrency` group scoped to the PR number causes the older in-progress run to be cancelled when a new one starts for the same PR. Since only the latest commit's screenshots matter, this is the correct resolution: the newer run always wins, and no concurrent push race can occur.

## Acceptance Criteria
- [x] `storybook-screenshots` job has a `concurrency` group scoped to `github.event.pull_request.number`
- [x] `cancel-in-progress: true` ensures the newer commit's run takes precedence
- [x] Normal (single-run) case is unaffected

## Tests
No Vitest tests — this is a CI workflow configuration change. Verified by reading the updated YAML.

Closes #252

---
*Created by Claude Sonnet 4.5*