### PR TITLE
perf(goal-funding): reduce O(n²) harmonic sum recomputation

### DIFF
--- a/src/components/goal-purchase/GoalSiblingProjections.tsx
+++ b/src/components/goal-purchase/GoalSiblingProjections.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 import { monthYearFormatter } from "@/lib/formatters";
-import { computeGoalEta } from "@/lib/goal-funding";
+import { computeGoalEtaFromShare, computeZipfShares } from "@/lib/goal-funding";
 
 import { GOAL_SIBLING_PROJECTIONS_COPY } from "./copy";
 
@@ -27,6 +27,8 @@ export function GoalSiblingProjections({
   const unfundedSiblingGoals = siblingGoals.filter(
     (g) => g.fundedAmount < g.targetAmount,
   );
+  const priorShares = computeZipfShares(allGoalsBeforePurchase);
+  const newShares = computeZipfShares(unfundedSiblingGoals);
 
   return (
     <Card>
@@ -53,15 +55,15 @@ export function GoalSiblingProjections({
             </thead>
             <tbody>
               {siblingGoals.map((goal) => {
-                const priorEta = computeGoalEta(
+                const priorEta = computeGoalEtaFromShare(
                   goal,
-                  allGoalsBeforePurchase,
+                  priorShares.get(goal.id) ?? 0,
                   monthlyAllocation,
                   referenceDate,
                 );
-                const newEta = computeGoalEta(
+                const newEta = computeGoalEtaFromShare(
                   goal,
-                  unfundedSiblingGoals,
+                  newShares.get(goal.id) ?? 0,
                   monthlyAllocation,
                   referenceDate,
                 );

--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -6,7 +6,12 @@ import {
 } from "@/lib/firebase/schema/budget-ledger-transactions";
 import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goals";
 
-import { computeGoalEta, computeMonthlyDepositRate } from "./goal-funding";
+import {
+  computeGoalEta,
+  computeGoalEtaFromShare,
+  computeMonthlyDepositRate,
+  computeZipfShares,
+} from "./goal-funding";
 
 function makeTransaction(
   overrides: Partial<BudgetLedgerTransaction> = {},
@@ -207,6 +212,92 @@ describe("computeGoalEta", () => {
       expect(eta1!.getMonth()).toBe(6); // July
       // goal2: 2 months from Jun → Aug 2025
       expect(eta2!.getMonth()).toBe(7); // August
+    });
+  });
+});
+
+describe("computeZipfShares", () => {
+  describe("returns an empty Map when the goals list is empty", () => {
+    it("returns an empty Map for an empty goals array", () => {
+      expect(computeZipfShares([])).toEqual(new Map());
+    });
+  });
+
+  describe("returns a share of 1.0 for a single goal", () => {
+    it("single goal gets the full allocation", () => {
+      const goal = makeGoal({ id: "g1", priority: 1 });
+      const shares = computeZipfShares([goal]);
+      expect(shares.get("g1")).toBe(1);
+    });
+  });
+
+  describe("distributes shares proportionally to 1/priority", () => {
+    it("priority-1 gets twice the share of priority-2", () => {
+      // harmonic = 1/1 + 1/2 = 1.5; g1 share = 2/3, g2 share = 1/3
+      const g1 = makeGoal({ id: "g1", priority: 1 });
+      const g2 = makeGoal({ id: "g2", priority: 2 });
+      const shares = computeZipfShares([g1, g2]);
+      expect(shares.get("g1")).toBeCloseTo(2 / 3);
+      expect(shares.get("g2")).toBeCloseTo(1 / 3);
+    });
+
+    it("all shares sum to 1 across multiple goals", () => {
+      const goals = [
+        makeGoal({ id: "g1", priority: 1 }),
+        makeGoal({ id: "g2", priority: 2 }),
+        makeGoal({ id: "g3", priority: 3 }),
+      ];
+      const shares = computeZipfShares(goals);
+      const total = [...shares.values()].reduce((sum, s) => sum + s, 0);
+      expect(total).toBeCloseTo(1);
+    });
+  });
+});
+
+describe("computeGoalEtaFromShare", () => {
+  describe("returns undefined when there is no allocation or goal is funded", () => {
+    it("returns undefined when monthlyAllocation is 0", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 0 });
+      expect(computeGoalEtaFromShare(goal, 1, 0, REF_DATE)).toBeUndefined();
+    });
+
+    it("returns undefined when the goal is already fully funded", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 1000 });
+      expect(computeGoalEtaFromShare(goal, 1, 500, REF_DATE)).toBeUndefined();
+    });
+
+    it("returns undefined when the Zipf share is 0", () => {
+      const goal = makeGoal({ targetAmount: 1000, fundedAmount: 0 });
+      expect(computeGoalEtaFromShare(goal, 0, 500, REF_DATE)).toBeUndefined();
+    });
+  });
+
+  describe("computes the same ETA as computeGoalEta given the matching share", () => {
+    it("produces the same date for a single goal with share 1.0", () => {
+      const goal = makeGoal({
+        targetAmount: 1000,
+        fundedAmount: 0,
+        priority: 1,
+      });
+      const etaFromShare = computeGoalEtaFromShare(goal, 1.0, 500, REF_DATE);
+      const etaDirect = computeGoalEta(goal, [goal], 500, REF_DATE);
+      expect(etaFromShare?.getTime()).toBe(etaDirect?.getTime());
+    });
+
+    it("produces the same date for a priority-1 goal in a two-goal set", () => {
+      const goal1 = makeGoal({ id: "g1", priority: 1, targetAmount: 600 });
+      const goal2 = makeGoal({ id: "g2", priority: 2, targetAmount: 600 });
+      const allGoals = [goal1, goal2];
+      const shares = computeZipfShares(allGoals);
+
+      const etaFromShare = computeGoalEtaFromShare(
+        goal1,
+        shares.get("g1") ?? 0,
+        900,
+        REF_DATE,
+      );
+      const etaDirect = computeGoalEta(goal1, allGoals, 900, REF_DATE);
+      expect(etaFromShare?.getTime()).toBe(etaDirect?.getTime());
     });
   });
 });

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -108,8 +108,8 @@ export function computeGoalEta(
 ): Date | undefined {
   if (monthlyAllocation === 0) return undefined;
 
-  const shares = computeZipfShares(allGoals);
-  const share = shares.get(goal.id) ?? 0;
+  const harmonic = allGoals.reduce((sum, g) => sum + 1 / g.priority, 0);
+  const share = harmonic === 0 ? 0 : 1 / goal.priority / harmonic;
 
   return computeGoalEtaFromShare(goal, share, monthlyAllocation, referenceDate);
 }

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -42,7 +42,8 @@ export function computeMonthlyDepositRate(
  * sum to 1. The harmonic sum is computed once for the entire set, making this
  * O(n) regardless of how many per-goal projections are subsequently derived.
  *
- * Returns an empty Map when `goals` is empty (harmonic sum would be 0).
+ * Returns an empty Map when the harmonic sum is 0, which occurs when `goals`
+ * is empty or when all goals have non-finite priorities.
  */
 export function computeZipfShares(
   goals: BudgetLedgerSavingsGoal[],
@@ -74,7 +75,7 @@ export function computeGoalEtaFromShare(
   if (remaining <= 0) return undefined;
 
   const monthlyForGoal = monthlyAllocation * share;
-  if (monthlyForGoal === 0) return undefined;
+  if (!(monthlyForGoal > 0)) return undefined;
 
   const monthsNeeded = Math.ceil(remaining / monthlyForGoal);
 

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -38,14 +38,51 @@ export function computeMonthlyDepositRate(
 }
 
 /**
- * Computes the Zipf weight for a goal with the given priority within an ordered
- * list of goals. Goals are allocated a share of the monthly budget proportional
- * to 1/priority, normalised so all shares sum to 1.
+ * Computes the Zipf weight for each goal in the set, normalised so all shares
+ * sum to 1. The harmonic sum is computed once for the entire set, making this
+ * O(n) regardless of how many per-goal projections are subsequently derived.
+ *
+ * Returns an empty Map when `goals` is empty (harmonic sum would be 0).
  */
-function zipfShare(priority: number, goals: BudgetLedgerSavingsGoal[]): number {
+export function computeZipfShares(
+  goals: BudgetLedgerSavingsGoal[],
+): Map<string, number> {
   const harmonic = goals.reduce((sum, g) => sum + 1 / g.priority, 0);
-  if (harmonic === 0) return 0;
-  return 1 / priority / harmonic;
+  if (harmonic === 0) return new Map();
+  return new Map(goals.map((g) => [g.id, 1 / g.priority / harmonic]));
+}
+
+/**
+ * Projects the date by which the given goal will be fully funded, given a
+ * precomputed Zipf share for that goal and the ledger's monthly allocation.
+ *
+ * Returns `undefined` when:
+ * - `monthlyAllocation` is 0 or `share` is 0 (cannot project without income)
+ * - The goal is already fully funded (`fundedAmount >= targetAmount`)
+ *
+ * Prefer this function in loops where multiple goals share the same denominator
+ * set — precompute shares with `computeZipfShares` and pass each goal's share
+ * here to keep the total work O(n) instead of O(n²).
+ */
+export function computeGoalEtaFromShare(
+  goal: BudgetLedgerSavingsGoal,
+  share: number,
+  monthlyAllocation: number,
+  referenceDate: Date = new Date(),
+): Date | undefined {
+  const remaining = goal.targetAmount - goal.fundedAmount;
+  if (remaining <= 0) return undefined;
+
+  const monthlyForGoal = monthlyAllocation * share;
+  if (monthlyForGoal === 0) return undefined;
+
+  const monthsNeeded = Math.ceil(remaining / monthlyForGoal);
+
+  return new Date(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth() + monthsNeeded,
+    1,
+  );
 }
 
 /**
@@ -58,6 +95,10 @@ function zipfShare(priority: number, goals: BudgetLedgerSavingsGoal[]): number {
  *
  * `allGoals` must include `goal` itself so that the Zipf denominator is
  * computed correctly across all competing goals.
+ *
+ * When projecting ETAs for multiple goals that share the same denominator set,
+ * prefer `computeZipfShares` + `computeGoalEtaFromShare` to avoid recomputing
+ * the harmonic sum for each goal.
  */
 export function computeGoalEta(
   goal: BudgetLedgerSavingsGoal,
@@ -67,19 +108,8 @@ export function computeGoalEta(
 ): Date | undefined {
   if (monthlyAllocation === 0) return undefined;
 
-  const remaining = goal.targetAmount - goal.fundedAmount;
-  if (remaining <= 0) return undefined;
+  const shares = computeZipfShares(allGoals);
+  const share = shares.get(goal.id) ?? 0;
 
-  const share = zipfShare(goal.priority, allGoals);
-  const monthlyForGoal = monthlyAllocation * share;
-
-  if (monthlyForGoal === 0) return undefined;
-
-  const monthsNeeded = Math.ceil(remaining / monthlyForGoal);
-
-  return new Date(
-    referenceDate.getFullYear(),
-    referenceDate.getMonth() + monthsNeeded,
-    1,
-  );
+  return computeGoalEtaFromShare(goal, share, monthlyAllocation, referenceDate);
 }


### PR DESCRIPTION
`zipfShare` previously recomputed the harmonic sum (an O(n) reduce) on every invocation. `GoalSiblingProjections` called `computeGoalEta` twice per sibling row, making the total work O(n²) over the goal list.

This PR decouples normalization from projection: a new `computeZipfShares(goals)` function computes the harmonic sum once per denominator set and returns a `Map<goalId, share>`. A companion `computeGoalEtaFromShare(goal, share, monthlyAllocation, referenceDate)` accepts a precomputed share and projects the ETA directly. `GoalSiblingProjections` now calls `computeZipfShares` once for the before-purchase set and once for the after-purchase set — two O(n) passes instead of 2n O(n) passes. The existing `computeGoalEta` signature is preserved as a convenience wrapper for single-goal call sites.

## Acceptance Criteria
- [x] Harmonic sum is computed once per denominator set, not once per `zipfShare` call
- [x] All existing `computeGoalEta` callers produce identical numerical results
- [x] `computeZipfShares` is exported and usable independently for batch callers

## Tests
9 tests added, all passing. Full suite: 1374/1374.

Closes #253

---
*Created by Claude Sonnet 4.5*