### PR TITLE
fix(goal-funding): clamp deposits to cashCap in computeMonthlyDepositRate

### DIFF
--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -60,6 +60,7 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   const monthlyAllocation = computeMonthlyDepositRate(
     transactions,
     referenceDate,
+    budgetLedger?.cashCap,
   );
   const siblings = siblingGoals.filter((g) => g.id !== goal.id);
 

--- a/src/app/(app)/goals/[goalId]/purchase/page.tsx
+++ b/src/app/(app)/goals/[goalId]/purchase/page.tsx
@@ -80,7 +80,7 @@ export default function GoalPurchasePage({ params }: GoalPurchasePageProps) {
   const monthlyAllocation = computeMonthlyDepositRate(
     transactions,
     referenceDate,
-    budgetLedger?.cashCap,
+    budgetLedger.cashCap,
   );
   const siblings = siblingGoals.filter((g) => g.id !== goal.id);
 

--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -104,6 +104,46 @@ describe("computeMonthlyDepositRate", () => {
       expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(240);
     });
   });
+
+  describe("clamps each deposit to cashCap when provided", () => {
+    it("limits each deposit to the cashCap before summing", () => {
+      // cashCap = 500; deposits of $800 and $600 → clamped to $500 each
+      // Total cash: $1000 over 5 months → $200/month
+      const transactions = [
+        makeTransaction({ amount: 800, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-2",
+          amount: 600,
+          date: new Date(2025, 3, 1),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE, 500)).toBe(200);
+    });
+
+    it("does not clamp deposits that are below cashCap", () => {
+      // cashCap = 1000; deposits of $600 and $400 are both under cap
+      // Total: $1000 over 5 months → $200/month (same as uncapped)
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-2",
+          amount: 400,
+          date: new Date(2025, 3, 1),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE, 1000)).toBe(200);
+    });
+
+    it("behaves identically to no cashCap when cashCap is undefined", () => {
+      // $600 deposit, Jan to Jun = 5 months → $120/month with or without cap
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE, undefined)).toBe(
+        computeMonthlyDepositRate(transactions, REF_DATE),
+      );
+    });
+  });
 });
 
 describe("computeGoalEta", () => {

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -11,10 +11,16 @@ import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goal
  * calendar month of the reference date (exclusive of the start month — e.g.
  * January to June yields 5 months). The window is clamped to a minimum of 1
  * month so a single-month history still yields a meaningful rate.
+ *
+ * When `cashCap` is provided, each deposit's contribution is clamped to
+ * `Math.min(deposit.amount, cashCap)`, reflecting only the portion that flows
+ * into the cash split. Omit `cashCap` (or pass `undefined`) for ledgers with
+ * no cash cap.
  */
 export function computeMonthlyDepositRate(
   transactions: BudgetLedgerTransaction[],
   referenceDate: Date = new Date(),
+  cashCap?: number,
 ): number {
   const deposits = transactions.filter(
     (tx) => tx.type === BudgetLedgerTransactionType.Deposit,
@@ -22,7 +28,11 @@ export function computeMonthlyDepositRate(
 
   if (deposits.length === 0) return 0;
 
-  const totalDeposits = deposits.reduce((sum, tx) => sum + tx.amount, 0);
+  const totalDeposits = deposits.reduce(
+    (sum, tx) =>
+      sum + (cashCap !== undefined ? Math.min(tx.amount, cashCap) : tx.amount),
+    0,
+  );
 
   const earliestDeposit = deposits.reduce((earliest, tx) =>
     tx.date < earliest.date ? tx : earliest,


### PR DESCRIPTION
For ledgers with a `cashCap`, only the cash-split portion of each deposit flows into savings goals. Previously `computeMonthlyDepositRate` summed the full deposit amount regardless, inflating the monthly rate and producing optimistic goal ETAs on capped ledgers. This PR adds an optional `cashCap` parameter that clamps each deposit's contribution to `Math.min(amount, cashCap)` before accumulating.

The goal purchase page is updated to forward `budgetLedger?.cashCap` to the function so the ETA projections on the purchase confirmation screen now reflect the correct allocation rate.

Closes #256

---
*Created by Claude Sonnet 4.5*