### PR TITLE
fix(goal-funding): exclude future-dated deposits from computeMonthlyDepositRate

### DIFF
--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -137,6 +137,39 @@ describe("computeMonthlyDepositRate", () => {
       expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(900);
     });
 
+    it("includes a UTC-midnight deposit on the same local calendar day as referenceDate", () => {
+      // Deposit dates travel through the system as UTC midnight (new Date("YYYY-MM-DD")).
+      // A same-day deposit must be included even when referenceDate has a time component,
+      // which requires normalising the comparison to local-date UTC midnight.
+      const refDateWithTime = new Date(2025, 5, 15, 12, 0, 0); // June 15 at noon local
+      const sameDayDeposit = new Date("2025-06-15"); // UTC midnight June 15
+      const transactions = [
+        makeTransaction({ amount: 300, date: sameDayDeposit }),
+      ];
+      // $300 over min 1 month = $300/month
+      expect(computeMonthlyDepositRate(transactions, refDateWithTime)).toBe(
+        300,
+      );
+    });
+
+    it("excludes a UTC-midnight deposit dated the next local calendar day", () => {
+      // A deposit dated June 16 (UTC midnight) must be excluded when referenceDate is
+      // June 15 (any local time), because June 16 is a future date relative to June 15.
+      const refDateWithTime = new Date(2025, 5, 15, 12, 0, 0); // June 15 at noon local
+      const transactions = [
+        makeTransaction({ amount: 300, date: new Date("2025-06-15") }),
+        makeTransaction({
+          id: "tx-next",
+          amount: 600,
+          date: new Date("2025-06-16"),
+        }),
+      ];
+      // Only June 15 deposit ($300) counts — June 16 is excluded
+      expect(computeMonthlyDepositRate(transactions, refDateWithTime)).toBe(
+        300,
+      );
+    });
+
     it("excludes a future-dated deposit from the sum and earliest-deposit anchor", () => {
       // Jan 2026 deposit is after REF_DATE (Jun 2025) — it must not contribute
       // to the sum or serve as the earliest-deposit anchor.

--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -104,6 +104,57 @@ describe("computeMonthlyDepositRate", () => {
       expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(240);
     });
   });
+
+  describe("excludes future-dated deposits", () => {
+    it("returns 0 when all deposits are after the reference date", () => {
+      // Only future deposits (Jul 2025) — nothing to base a rate on
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 6, 1) }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(0);
+    });
+
+    it("excludes future deposits from the total but includes past deposits", () => {
+      // Past: Jan $600; future: Jul $1200 (should be excluded).
+      // Window: Jan to Jun = 5 months → $120/month
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-future",
+          amount: 1200,
+          date: new Date(2025, 6, 1),
+        }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(120);
+    });
+
+    it("uses the reference-date month itself as in-window (not future)", () => {
+      // Deposit on Jun 1 (same as REF_DATE) is not future — it counts.
+      // Window is clamped to min 1; $900 / 1 = $900
+      const transactions = [
+        makeTransaction({ amount: 900, date: new Date(2025, 5, 1) }),
+      ];
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(900);
+    });
+
+    it("does not use a future deposit as the earliest-deposit anchor", () => {
+      // If the future deposit were included as the earliest, its earlier calendar
+      // month (Jul) would expand the window. With filtering, only the past deposit
+      // (Jan) sets the anchor: Jan to Jun = 5 months → $600/5 = $120/month.
+      // Without filtering: a future deposit after REF would not be "earlier" than
+      // Jan anyway — but we want to confirm future deposits don't slip through.
+      const transactions = [
+        makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
+        makeTransaction({
+          id: "tx-future",
+          amount: 600,
+          date: new Date(2026, 0, 1), // Jan 2026 — clearly future
+        }),
+      ];
+      // Only Jan 2025 deposit counts: $600 over 5 months = $120/month
+      expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(120);
+    });
+  });
 });
 
 describe("computeGoalEta", () => {

--- a/src/lib/goal-funding.spec.ts
+++ b/src/lib/goal-funding.spec.ts
@@ -137,12 +137,10 @@ describe("computeMonthlyDepositRate", () => {
       expect(computeMonthlyDepositRate(transactions, REF_DATE)).toBe(900);
     });
 
-    it("does not use a future deposit as the earliest-deposit anchor", () => {
-      // If the future deposit were included as the earliest, its earlier calendar
-      // month (Jul) would expand the window. With filtering, only the past deposit
-      // (Jan) sets the anchor: Jan to Jun = 5 months → $600/5 = $120/month.
-      // Without filtering: a future deposit after REF would not be "earlier" than
-      // Jan anyway — but we want to confirm future deposits don't slip through.
+    it("excludes a future-dated deposit from the sum and earliest-deposit anchor", () => {
+      // Jan 2026 deposit is after REF_DATE (Jun 2025) — it must not contribute
+      // to the sum or serve as the earliest-deposit anchor.
+      // Only Jan 2025 ($600) counts: window = 5 months → $120/month.
       const transactions = [
         makeTransaction({ amount: 600, date: new Date(2025, 0, 1) }),
         makeTransaction({

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -15,15 +15,29 @@ import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goal
  * Only deposits on or before `referenceDate` are included — future-dated
  * entries (possible via the deposit dialog) are excluded from both the sum
  * and the earliest-deposit anchor, so they cannot inflate the projected rate.
+ *
+ * Deposit dates are stored as UTC midnight (from ISO date strings), while
+ * `referenceDate` carries a local time component. The comparison is
+ * normalised to UTC midnight of the local calendar day so that a deposit
+ * dated "today" is always included regardless of the caller's UTC offset.
  */
 export function computeMonthlyDepositRate(
   transactions: BudgetLedgerTransaction[],
   referenceDate: Date = new Date(),
 ): number {
+  const refDayUTC = Date.UTC(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate(),
+  );
   const deposits = transactions.filter(
     (tx) =>
       tx.type === BudgetLedgerTransactionType.Deposit &&
-      tx.date <= referenceDate,
+      Date.UTC(
+        tx.date.getUTCFullYear(),
+        tx.date.getUTCMonth(),
+        tx.date.getUTCDate(),
+      ) <= refDayUTC,
   );
 
   if (deposits.length === 0) return 0;

--- a/src/lib/goal-funding.ts
+++ b/src/lib/goal-funding.ts
@@ -11,13 +11,19 @@ import type { BudgetLedgerSavingsGoal } from "@/lib/firebase/schema/savings-goal
  * calendar month of the reference date (exclusive of the start month — e.g.
  * January to June yields 5 months). The window is clamped to a minimum of 1
  * month so a single-month history still yields a meaningful rate.
+ *
+ * Only deposits on or before `referenceDate` are included — future-dated
+ * entries (possible via the deposit dialog) are excluded from both the sum
+ * and the earliest-deposit anchor, so they cannot inflate the projected rate.
  */
 export function computeMonthlyDepositRate(
   transactions: BudgetLedgerTransaction[],
   referenceDate: Date = new Date(),
 ): number {
   const deposits = transactions.filter(
-    (tx) => tx.type === BudgetLedgerTransactionType.Deposit,
+    (tx) =>
+      tx.type === BudgetLedgerTransactionType.Deposit &&
+      tx.date <= referenceDate,
   );
 
   if (deposits.length === 0) return 0;


### PR DESCRIPTION
The deposit dialog accepts any date, so users can create deposits dated in the future. Previously, `computeMonthlyDepositRate` included all deposits regardless of date, which inflated the monthly average and produced unrealistically optimistic goal ETAs.

The fix adds a `tx.date <= referenceDate` guard to the deposit filter, excluding future-dated entries from both the deposit total and the earliest-deposit anchor used to compute the time window. This ensures only realized, historical deposits inform the projected rate.

Closes #257

---
*Created by Claude Sonnet 4.5*