### PR TITLE
feat(ci): enable CI for PRs targeting non-default branches

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `ci-actions.yml` workflow had `branches: ["main"]` on its `pull_request` trigger, which meant CI only ran on PRs targeting `main`. Stacked PRs — where PR B targets PR A's feature branch rather than `main` — received no CI coverage.

This removes the `branches` filter from the `pull_request` trigger so CI runs on all PRs regardless of base branch. The `push` trigger's `branches: ["main"]` filter is unchanged: CI on direct pushes remains scoped to main only.

`secret-scan.yml` and `sentry-release.yml` were already correct: secret scan already had an unfiltered `pull_request` trigger, and the Sentry release workflow is push-only and intentionally main-scoped.

Closes #268

---
*Created by Claude Sonnet 4.5*