### PR TITLE
chore: exclude pnpm-lock.yaml from lint-staged prettier pass

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,11 @@
+export default {
+  "*.{js,mjs,cjs,ts,tsx,jsx}": [
+    "eslint --fix --max-warnings 0 --no-warn-ignored",
+  ],
+  "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml}": (files) => {
+    const filtered = files.filter((f) => !f.endsWith("pnpm-lock.yaml"));
+    return filtered.length > 0
+      ? [`prettier --write ${filtered.join(" ")}`]
+      : [];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -21,14 +21,6 @@
     "env:validate": "node scripts/validate-config.mjs",
     "secrets-check": "node scripts/validate-config.mjs && secrets-check --config .gitleaks.toml"
   },
-  "lint-staged": {
-    "*.{js,mjs,cjs,ts,tsx,jsx}": [
-      "eslint --fix --max-warnings 0 --no-warn-ignored"
-    ],
-    "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml}": [
-      "prettier --write"
-    ]
-  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "@firebase/util",


### PR DESCRIPTION
The `*.yaml` glob in the inline `package.json` lint-staged config matched `pnpm-lock.yaml` and passed it to `prettier --write` as an explicit positional argument. Explicit positional args bypass `.prettierignore`, so the lockfile was being formatted on every staged install.

Moves the lint-staged config to `lint-staged.config.mjs` so the yaml entry can use a filter function to strip `pnpm-lock.yaml` before prettier is invoked. All other yaml/yml files (`pnpm-workspace.yaml`, `deployment/*.yml`, `.github/workflows/*.yml`) continue to be formatted normally.

---
*Created by Claude Sonnet 4.6*