### PR TITLE
chore: mark pnpm-lock.yaml as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pnpm-lock.yaml linguist-generated=true


### PR DESCRIPTION
Adds `.gitattributes` marking `pnpm-lock.yaml` as `linguist-generated=true`. This collapses the lockfile in GitHub PR diffs by default (so reviewers don't have to scroll past thousands of lines of lockfile changes) and excludes it from the repo's language statistics.

Companion to [#283](https://github.com/rmartz/personal-budget/pull/283), which excluded `pnpm-lock.yaml` from the lint-staged prettier pass. Together these two changes give the lockfile the full autogenerated treatment.

---
*Created by Claude Sonnet 4.6*