### PR TITLE
fix: add missing integrity hash for vercel-deploy-scripts tarball in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6025,7 +6025,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f:
-    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f}
+    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f, integrity: sha512-1ZYXLjyeIN0hd1FOuQrKx0incfrZe9uJ8RpYixlFam2r3HHvzPzramXEeuTBDK9Uz4vjyumEvG9QVHZhovEKTw==}
     version: 0.0.0
     engines: {node: '>=18', pnpm: '>=9'}
     hasBin: true


### PR DESCRIPTION
pnpm 10.34.x introduced strict enforcement of the `integrity` field for tarball URL dependencies. The `vercel-deploy-scripts@v3.1.0` entry was generated by an older pnpm that didn't write this field, which causes `ERR_PNPM_MISSING_TARBALL_INTEGRITY` on any pnpm >= 10.34.

We're currently pinned to pnpm 10.30.3 via the `packageManager` field (and the CI setup action reads from that field rather than floating on a major), so this isn't breaking today. But the moment pnpm is bumped past 10.34 the lockfile would fail integrity checks across all branches simultaneously.

SHA-512 integrity computed from the published tarball and written directly into the lockfile entry.

The setup action equivalent of [rmartz/hidden-role-game#704](https://github.com/rmartz/hidden-role-game/pull/704) was already in place here (no `version: 10` floating) — this is the lockfile half of that fix, analogous to [rmartz/hidden-role-game#702](https://github.com/rmartz/hidden-role-game/pull/702).

---
*Created by Claude Sonnet 4.6*