### PR TITLE
ci!: add type-check job to CI workflow

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,6 +34,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm tsc
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `type-check` job to the CI workflow that runs `pnpm tsc` on every push and pull request. TypeScript strict mode is already configured project-wide; this job ensures type errors are caught in CI rather than surfacing only at build time or locally.

The job is placed between `format` and `build` — it's fast (no compilation output, just type inference) and logically grouped with the other static analysis checks.

---
*Created by Claude Sonnet 4.6*