### PR TITLE
fix(ci)!: correct file-length caps to 2× recommended max

### DIFF
--- a/.github/workflows/file-length.yml
+++ b/.github/workflows/file-length.yml
@@ -17,11 +17,11 @@ jobs:
 
       - name: Check changed file lengths
         run: |
-          # Thresholds from CLAUDE.md — 2× the split threshold ("+100% of recommended max")
-          # Source files: recommended split at ~240 lines → CI fails at 480+
-          # Test files:   recommended split at ~360 lines → CI fails at 720+
-          SOURCE_LIMIT=480
-          TEST_LIMIT=720
+          # Thresholds from CLAUDE.md — 2× the recommended max ("+100% of recommended max")
+          # Source files: recommended max ~200 lines, split at ~240 → CI fails at 400+
+          # Test files:   recommended max ~300 lines, split at ~360 → CI fails at 600+
+          SOURCE_LIMIT=400
+          TEST_LIMIT=600
 
           failed=0
 
@@ -58,8 +58,8 @@ jobs:
           if [ "$failed" -ne 0 ]; then
             echo ""
             echo "One or more files exceed the maximum allowed line count."
-            echo "  Source files: split at ~240 lines, CI fails at ${SOURCE_LIMIT}+"
-            echo "  Test files:   split at ~360 lines, CI fails at ${TEST_LIMIT}+"
+            echo "  Source files: recommended max ~200 lines, split at ~240, CI fails at ${SOURCE_LIMIT}+"
+            echo "  Test files:   recommended max ~300 lines, split at ~360, CI fails at ${TEST_LIMIT}+"
             echo "Split large files by logical concern before merging."
             exit 1
           fi


### PR DESCRIPTION
The file-length CI workflow introduced in #286 used 2× the *split threshold* as the hard cap (480/720), but the intent is 2× the *recommended max* from CLAUDE.md (200 source / 300 test). The split threshold is already the +20% review-pushback point, so using it as the base effectively made the CI cap +140% of the recommended limit instead of the intended +100%.

Corrected limits:

| | Recommended max | Split threshold (+20%) | CI hard cap (+100%) |
|---|---|---|---|
| Source | 200 | ~240 | 400 (was 480) |
| Test | 300 | ~360 | 600 (was 720) |

---
*Created by Claude Sonnet 4.6*