### PR TITLE
feat(deploy): re-enable staging environment with its RTDB URL

### DIFF
--- a/deployment/environments.yml
+++ b/deployment/environments.yml
@@ -11,9 +11,15 @@
 
 active:
   - production
+  - staging
 
-# Staging is temporarily disabled — the dedicated staging Firebase project
-# (personal-budget-staging-a99af) cannot have a Realtime Database created due
-# to a Firebase console bug. Re-add staging here and set single_environment: false
-# once the staging RTDB is available.
-single_environment: true
+# Staging re-enabled (#319). The dedicated staging Firebase project
+# (personal-budget-staging-a99af) needs its Realtime Database created in the
+# Firebase console, after which NEXT_PUBLIC_FIREBASE_DATABASE_URL and
+# FIREBASE_DATABASE_URL must be filled in deployment/staging.yml. The earlier
+# "Firebase console bug" note was never a confirmed Firebase limitation —
+# RTDB creation should simply be retried.
+#
+# TODO(#319): until the staging RTDB URL is populated, config validation and
+# staging deploys will not fully succeed. This is the only remaining manual step.
+single_environment: false

--- a/deployment/environments.yml
+++ b/deployment/environments.yml
@@ -13,13 +13,8 @@ active:
   - production
   - staging
 
-# Staging re-enabled (#319). The dedicated staging Firebase project
-# (personal-budget-staging-a99af) needs its Realtime Database created in the
-# Firebase console, after which NEXT_PUBLIC_FIREBASE_DATABASE_URL and
-# FIREBASE_DATABASE_URL must be filled in deployment/staging.yml. The earlier
-# "Firebase console bug" note was never a confirmed Firebase limitation —
-# RTDB creation should simply be retried.
-#
-# TODO(#319): until the staging RTDB URL is populated, config validation and
-# staging deploys will not fully succeed. This is the only remaining manual step.
+# Staging re-enabled (#319): the staging Firebase project
+# (personal-budget-staging-a99af) has its Realtime Database created and its URL
+# populated in deployment/staging.yml. Run `pnpm exec sync-env --env=staging` to
+# push the staging config to Vercel's Preview environment.
 single_environment: false

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -1,17 +1,21 @@
 # Public environment variables for the staging environment.
 #
-# ── DISABLED ──────────────────────────────────────────────────────────────────
-# Staging is not listed in deployment/environments.yml and is not part of the
-# active rotation or validation cycle. The dedicated staging Firebase project
-# (personal-budget-staging-a99af) cannot have a Realtime Database created due
-# to a Firebase console bug. Preview deployments currently use the production
-# Firebase project.
+# ── PENDING RTDB (#319) ───────────────────────────────────────────────────────
+# Staging is re-enabled in deployment/environments.yml. The one remaining manual
+# step is creating the Realtime Database in the staging Firebase project
+# (personal-budget-staging-a99af) and filling the two *_DATABASE_URL values below.
 #
-# To re-enable staging:
-#   1. Create the RTDB in the staging Firebase project
-#   2. Populate NEXT_PUBLIC_FIREBASE_DATABASE_URL and FIREBASE_DATABASE_URL below
-#   3. Re-add staging to deployment/environments.yml and set single_environment: false
-#   4. Run: pnpm exec sync-env --env=staging
+# The previous "Firebase console bug" note was never a confirmed Firebase
+# limitation — RTDB creation should simply be retried in the console.
+#
+# To finish:
+#   1. Create the RTDB in the staging Firebase project (Firebase console)
+#   2. Fill NEXT_PUBLIC_FIREBASE_DATABASE_URL and FIREBASE_DATABASE_URL below.
+#      Likely https://personal-budget-staging-a99af-default-rtdb.firebaseio.com,
+#      or a region URL like ...-default-rtdb.<region>.firebasedatabase.app —
+#      use the exact value the console shows.
+#   3. Run: pnpm exec sync-env --env=staging
+#   4. Point the Vercel Preview environment at the staging Firebase config
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # Only non-sensitive variables belong here. All keys are validated against
@@ -28,11 +32,13 @@ variables:
   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "personal-budget-staging-a99af.firebasestorage.app"
   NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "655402175210"
   NEXT_PUBLIC_FIREBASE_APP_ID: "1:655402175210:web:e8b1339a4e630335b9a593"
+  # TODO(#319): fill after creating the staging RTDB (see header). Until then,
+  # config validation and staging deploys will not fully succeed.
   NEXT_PUBLIC_FIREBASE_DATABASE_URL: ""
 
   # Firebase Admin SDK — project identifier only, not a credential
-  # NEXT_PUBLIC_FIREBASE_DATABASE_URL is empty — staging project may not have Realtime DB enabled
   FIREBASE_PROJECT_ID: "personal-budget-staging-a99af"
+  # TODO(#319): fill with the same RTDB URL as NEXT_PUBLIC_FIREBASE_DATABASE_URL above.
   FIREBASE_DATABASE_URL: ""
 
   # Sentry — slugs only, not credentials

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -1,22 +1,12 @@
 # Public environment variables for the staging environment.
 #
-# ── PENDING RTDB (#319) ───────────────────────────────────────────────────────
-# Staging is re-enabled in deployment/environments.yml. The one remaining manual
-# step is creating the Realtime Database in the staging Firebase project
-# (personal-budget-staging-a99af) and filling the two *_DATABASE_URL values below.
+# Staging Firebase project (personal-budget-staging-a99af), separate from
+# production. Its Realtime Database exists and its URL is populated below.
 #
-# The previous "Firebase console bug" note was never a confirmed Firebase
-# limitation — RTDB creation should simply be retried in the console.
-#
-# To finish:
-#   1. Create the RTDB in the staging Firebase project (Firebase console)
-#   2. Fill NEXT_PUBLIC_FIREBASE_DATABASE_URL and FIREBASE_DATABASE_URL below.
-#      Likely https://personal-budget-staging-a99af-default-rtdb.firebaseio.com,
-#      or a region URL like ...-default-rtdb.<region>.firebasedatabase.app —
-#      use the exact value the console shows.
-#   3. Run: pnpm exec sync-env --env=staging
-#   4. Point the Vercel Preview environment at the staging Firebase config
-# ──────────────────────────────────────────────────────────────────────────────
+# After changing values here, sync them to Vercel's Preview environment with
+# `pnpm exec sync-env --env=staging` so previews use the staging project rather
+# than production. The staging RTDB should carry the same security rules as
+# production (firebase/database.rules.json).
 #
 # Only non-sensitive variables belong here. All keys are validated against
 # deployment/schema.yml — sensitive variables (private keys, auth tokens, DSNs)
@@ -32,14 +22,11 @@ variables:
   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "personal-budget-staging-a99af.firebasestorage.app"
   NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "655402175210"
   NEXT_PUBLIC_FIREBASE_APP_ID: "1:655402175210:web:e8b1339a4e630335b9a593"
-  # TODO(#319): fill after creating the staging RTDB (see header). Until then,
-  # config validation and staging deploys will not fully succeed.
-  NEXT_PUBLIC_FIREBASE_DATABASE_URL: ""
+  NEXT_PUBLIC_FIREBASE_DATABASE_URL: "https://personal-budget-staging-a99af-default-rtdb.firebaseio.com"
 
   # Firebase Admin SDK — project identifier only, not a credential
   FIREBASE_PROJECT_ID: "personal-budget-staging-a99af"
-  # TODO(#319): fill with the same RTDB URL as NEXT_PUBLIC_FIREBASE_DATABASE_URL above.
-  FIREBASE_DATABASE_URL: ""
+  FIREBASE_DATABASE_URL: "https://personal-budget-staging-a99af-default-rtdb.firebaseio.com"
 
   # Sentry — slugs only, not credentials
   SENTRY_ORG: "reedmartz"


### PR DESCRIPTION
Restores the staging environment now that the staging Realtime Database exists.

## What this does

- Re-adds `staging` to `deployment/environments.yml` (`single_environment: false`).
- Populates `NEXT_PUBLIC_FIREBASE_DATABASE_URL` / `FIREBASE_DATABASE_URL` in `deployment/staging.yml` with the staging RTDB URL (`https://personal-budget-staging-a99af-default-rtdb.firebaseio.com`).
- Removes the stale **"Firebase console bug"** note. Investigation traced it to a single agent commit ([#49](https://github.com/rmartz/personal-budget/pull/49), 2026-04-29), not a real Firebase limitation — and the RTDB was created normally with the default URL, confirming there was no bug.

`env:validate` and the full pre-push gate (format/lint/typecheck/test) pass.

## Remaining outward ops (post-merge, require Vercel/Firebase access)

These have no repo artifact and are done against the live services after this config merges:

1. `pnpm exec sync-env --env=staging` — push staging config to Vercel's Preview environment so previews use staging, not production.
2. Confirm a preview deployment reads/writes the **staging** RTDB.
3. Deploy `firebase/database.rules.json` to the staging RTDB so it carries production-equivalent security rules.

## Acceptance Criteria
- [x] Stale "console bug" note removed / corrected
- [x] `staging` re-added to `environments.yml` with `single_environment: false`
- [x] Staging RTDB created and URL populated
- [ ] Previews point at staging (post-merge `sync-env` + Vercel Preview env)
- [ ] Staging RTDB has production-equivalent rules (post-merge `firebase deploy`)

## Tests
Config-only change; `env:validate` + pre-push gate pass.

Closes #319

---
*Created by Claude Opus 4.8*