### PR TITLE
chore: remove vercel-deploy-scripts dev dependency

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,4 @@
 if [ -f ".git" ]; then
   exit 0
 fi
-pnpm exec lint-staged && pnpm run secrets-check && node scripts/check-file-length.mjs --staged
+pnpm exec lint-staged && pnpm run env:validate && node scripts/check-file-length.mjs --staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,13 @@ pnpm test             # Run tests with Vitest
 pnpm tsc              # Type check
 pnpm storybook        # Start Storybook dev server (port 6006)
 pnpm build-storybook  # Build static Storybook
-pnpm run env:pull     # Pull .env.local from Vercel
 pnpm run env:validate # Validate deployment config files against schema
-pnpm run secrets-check # Config validation + gitleaks scan (also runs pre-commit)
 ```
+
+Local environment-config management (pulling `.env.local`, syncing values to
+Vercel) previously ran through `vercel-deploy-scripts`; it is being replaced by a
+local `envctl` CLI (forthcoming). `pnpm run env:validate` is the one env command
+that remains in `package.json` (a local script with no external dependency).
 
 ## Worktree Setup
 
@@ -28,10 +31,9 @@ After creating a git worktree (`git worktree add .git-worktrees/<name>`), run `p
 
 Public (non-secret) environment config lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; patterns matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied.
 
-- To sync public config values to Vercel: `pnpm exec sync-env` (all environments) or `pnpm exec sync-env --env=<staging|production>`
-- To rotate all secrets (Firebase + Sentry): `pnpm exec sync-env --rotate-keys --env=<staging|production>`
-- To validate config files against schema locally: `pnpm run env:validate`
-- Secrets checks run automatically on every commit via `.husky/pre-commit`; also enforced in CI via `.github/workflows/secret-scan.yml`
+- To validate config files against schema locally: `pnpm run env:validate` (also runs in the pre-commit hook and the CI `validate-config` job).
+- Syncing config values to Vercel and pulling a local `.env.local` were provided by `vercel-deploy-scripts` (now removed); a local `envctl` CLI will replace them (forthcoming, local-only — not wired into CI).
+- Secret scanning (gitleaks) runs in CI via `.github/workflows/secret-scan.yml`. With `vercel-deploy-scripts` removed, the pre-commit hook no longer runs gitleaks locally — only config validation; CI remains the enforcing secret-scan gate.
 
 ## TypeScript
 

--- a/claude/hooks/pre-commit
+++ b/claude/hooks/pre-commit
@@ -8,5 +8,5 @@
 #
 # Bypass: git commit --no-verify
 set -e
-pnpm run secrets-check
+pnpm run env:validate
 node scripts/check-file-length.mjs --staged

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky",
-    "env:pull": "generate-local-env",
-    "env:validate": "node scripts/validate-config.mjs",
-    "secrets-check": "node scripts/validate-config.mjs && secrets-check --config .gitleaks.toml"
+    "env:validate": "node scripts/validate-config.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -77,7 +75,6 @@
     "typescript": "^6",
     "typescript-eslint": "^8.61.1",
     "vercel": "^54.14.2",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v3.1.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       vercel:
         specifier: ^54.14.2
         version: 54.14.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(rollup@4.61.1)
-      vercel-deploy-scripts:
-        specifier: github:rmartz/vercel-deploy-scripts#v3.1.0
-        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -6173,12 +6170,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f:
-    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f}
-    version: 0.0.0
-    engines: {node: '>=18', pnpm: '>=9'}
-    hasBin: true
 
   vercel@54.14.2:
     resolution: {integrity: sha512-XMUBq4mEYniGGIHTAIY7Egop120x6d2NLZ9wezk3032VfKRMsB3q2UYFiZduWETG/TwFSddlNJ6UI8jBskleog==}
@@ -12701,10 +12692,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f:
-    dependencies:
-      js-yaml: 4.1.1
 
   vercel@54.14.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(rollup@4.61.1):
     dependencies:


### PR DESCRIPTION
Removes the `vercel-deploy-scripts` (VDS) dev dependency ahead of replacing its local env-management scripts with a forthcoming local `envctl` CLI. The `deployment/*.yml` env configs are kept as-is.

## What's removed

- The `vercel-deploy-scripts` devDependency (and from the lockfile).
- `package.json` scripts that relied on VDS bins: `env:pull` (`generate-local-env`) and `secrets-check` (the VDS `secrets-check`/gitleaks bin). `pnpm exec sync-env` likewise goes away with the package.

## What's kept

- All `deployment/*.yml` configs and `deployment/schema.yml`.
- `scripts/validate-config.mjs` + the `env:validate` script — a local script with no external dependency (verified: it imports only Node builtins).
- The CI secret-scan workflow (`.github/workflows/secret-scan.yml`) — it consumes VDS as a **reusable GitHub Actions workflow** (`uses: …@v3.1.0`), which is independent of the npm devDependency. Left untouched, per "envctl won't be exposed in CI."

## Hook changes

Both pre-commit hooks (`.husky/pre-commit` and `claude/hooks/pre-commit`) called the now-removed `secrets-check` script; they now run `pnpm run env:validate` instead.

## ⚠️ Behavior change to note

**Local pre-commit gitleaks scanning is dropped** (it was provided by the VDS `secrets-check` bin; there's no other local gitleaks source). Config validation still runs at commit time, and **CI secret scanning is unchanged** — `secret-scan.yml` remains the enforcing gate. Restoring a local secret-scan (if wanted) is a candidate for `envctl` or a follow-up.

`env:validate`, `pnpm install --frozen-lockfile`, and the full pre-push gate (format/lint/typecheck/test) all pass.

Opened as a **draft** — `envctl` is still TBD, and you may want to land it alongside the replacement rather than leaving a gap in local env tooling.

---
*Created by Claude Opus 4.8*