### PR TITLE
chore: scrub stale VDS command references from deployment config comments

### DIFF
--- a/deployment/environments.yml
+++ b/deployment/environments.yml
@@ -15,6 +15,6 @@ active:
 
 # Staging re-enabled (#319): the staging Firebase project
 # (personal-budget-staging-a99af) has its Realtime Database created and its URL
-# populated in deployment/staging.yml. Run `pnpm exec sync-env --env=staging` to
-# push the staging config to Vercel's Preview environment.
+# populated in deployment/staging.yml. Push the staging config to Vercel's
+# Preview environment with the local env tooling (envctl, forthcoming).
 single_environment: false

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -5,9 +5,9 @@
 # will be rejected by the pre-commit hook and CI.
 #
 # Sensitive variables are managed directly in Vercel and are never committed.
-# Run `pnpm env:pull` to generate a local .env.local from Vercel's stored values.
-#
-# To sync these values to Vercel: pnpm exec sync-env --env=production
+# Generating a local .env.local and syncing public values to Vercel were
+# provided by vercel-deploy-scripts (now removed); a local `envctl` CLI will
+# replace them (forthcoming).
 
 environment: production
 

--- a/deployment/schema.yml
+++ b/deployment/schema.yml
@@ -20,7 +20,7 @@ allowed_patterns:
 allowed_keys:
   - FIREBASE_PROJECT_ID # Non-sensitive; also exposed via NEXT_PUBLIC_FIREBASE_PROJECT_ID
   - FIREBASE_DATABASE_URL # Non-sensitive RTDB URL; also exposed as NEXT_PUBLIC_FIREBASE_DATABASE_URL when used client-side
-  - FIREBASE_SA_EMAIL # Service account email (not a credential) — read by sync-env to rotate keys
+  - FIREBASE_SA_EMAIL # Service account email (not a credential) — used by the env tooling for key rotation
   - SENTRY_ORG # Sentry organisation slug — not a credential
   - SENTRY_PROJECT # Sentry project slug — not a credential
 

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -3,10 +3,10 @@
 # Staging Firebase project (personal-budget-staging-a99af), separate from
 # production. Its Realtime Database exists and its URL is populated below.
 #
-# After changing values here, sync them to Vercel's Preview environment with
-# `pnpm exec sync-env --env=staging` so previews use the staging project rather
-# than production. The staging RTDB should carry the same security rules as
-# production (firebase/database.rules.json).
+# After changing values here, sync them to Vercel's Preview environment with the
+# local env tooling (envctl, forthcoming) so previews use the staging project
+# rather than production. The staging RTDB should carry the same security rules
+# as production (firebase/database.rules.json).
 #
 # Only non-sensitive variables belong here. All keys are validated against
 # deployment/schema.yml — sensitive variables (private keys, auth tokens, DSNs)


### PR DESCRIPTION
Comment-only cleanup. `sync-env` and `env:pull` were provided by `vercel-deploy-scripts` (removed in #323), so the deployment config comments that referenced them now point at commands that no longer exist. Reworded to reference the forthcoming local `envctl` tooling instead.

Touches comments in `deployment/environments.yml`, `production.yml`, `staging.yml`, and `schema.yml` — **no config values changed**. `env:validate` and the full pre-push gate pass.

This finishes the local-env-management removal: with #323 (commands/dependency) merged and this scrub, no reference to the removed VDS commands remains anywhere in the repo.

---
*Created by Claude Opus 4.8*