### PR TITLE
ci!: split browser Storybook tests into their own job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,12 +12,31 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test
+      # Headless Vitest projects only — no browser, so no Playwright install.
+      - run: pnpm exec vitest run --project node --project hooks --project components
+
+  storybook-tests:
+    name: Storybook Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - name: Install Playwright Chromium
+        # Retry to ride out transient apt/CDN failures during --with-deps.
+        run: |
+          for attempt in 1 2 3; do
+            pnpm exec playwright install --with-deps chromium && exit 0
+            echo "playwright install attempt $attempt failed; retrying..." >&2
+            sleep 5
+          done
+          echo "playwright install failed after 3 attempts" >&2
+          exit 1
+      - run: pnpm exec vitest run --project storybook
 
   lint:
     name: Lint

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,7 +14,8 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     lint: 2,
     "storybook-build": 2,
     "storybook-screenshots": 3,
-    tests: 3,
+    "storybook-tests": 4,
+    tests: 2,
     "type-check": 2,
   },
   "file-length.yml": {


### PR DESCRIPTION
`pnpm test` runs four Vitest projects — three headless (`node`, `hooks`/happy-dom, `components`/happy-dom) and one **real-Chromium** browser project (`storybook`, via `@vitest/browser-playwright`). The single `Tests` job ran `playwright install --with-deps chromium` for the entire suite, so the fast headless tests waited on a heavyweight apt/browser install they don't need, and any Chromium/Storybook flake failed the whole `Tests` check.

## Change

- **`Tests`** now runs only the headless projects (`--project node --project hooks --project components`) — no Playwright install. Timeout 3 → 2.
- **`Storybook Tests`** (new) runs the `storybook` browser project, paying `playwright install --with-deps chromium` (wrapped in a 3× retry for transient apt/CDN failures). Timeout 4.
- Updated `src/workflow-timeouts.spec.ts` (the registry keys jobs by id): `tests` 3→2, added `storybook-tests` 4.

Same runner, same coverage — purely a split for faster headless feedback and an isolated, re-runnable browser-test signal. Not a CI loosening.

Verified locally: headless projects 1246 tests pass; workflow-timeouts test passes; lint/format/tsc clean. (The browser project runs in its dedicated CI job.)

## Note
If `Tests` is a required status check in branch protection, add **`Storybook Tests`** there too so the browser suite stays gating.

---
*Created by Claude Opus 4.8*