### PR TITLE
ci: make Storybook Screenshots advisory

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,12 +12,31 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test
+      # Headless Vitest projects only — no browser, so no Playwright install.
+      - run: pnpm exec vitest run --project node --project hooks --project components
+
+  storybook-tests:
+    name: Storybook Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - name: Install Playwright Chromium
+        # Retry to ride out transient apt/CDN failures during --with-deps.
+        run: |
+          for attempt in 1 2 3; do
+            pnpm exec playwright install --with-deps chromium && exit 0
+            echo "playwright install attempt $attempt failed; retrying..." >&2
+            sleep 5
+          done
+          echo "playwright install failed after 3 attempts" >&2
+          exit 1
+      - run: pnpm exec vitest run --project storybook
 
   lint:
     name: Lint

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -86,6 +86,11 @@ jobs:
   storybook-screenshots:
     name: Storybook Screenshots
     if: github.event_name == 'pull_request'
+    # Advisory only: PR-preview decoration built on a flaky third-party beta
+    # action. A hang or failure must report neutral, never block merge. The
+    # correctness gates (Tests, Storybook Tests, Lint, Format, Type Check,
+    # Build) remain hard-gating.
+    continue-on-error: true
     concurrency:
       group: storybook-screenshots-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,7 +14,8 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     lint: 2,
     "storybook-build": 2,
     "storybook-screenshots": 3,
-    tests: 3,
+    "storybook-tests": 4,
+    tests: 2,
     "type-check": 2,
   },
   "file-length.yml": {


### PR DESCRIPTION
Makes the `Storybook Screenshots` job advisory by adding `continue-on-error: true`.

## Why this is justified

That job is **PR-preview decoration**, not a correctness gate — it posts screenshots of changed stories via the third-party beta action `yoavf/auto-pr-screenshots-action@v1.4.0-beta`. That action has repeatedly **hung to its timeout** in practice (it's why per-job timeouts were added in #273). A flaky, best-effort preview should never block a mergeable PR. With `continue-on-error: true`, a hang or failure reports neutral instead of red.

The job keeps its existing guardrails (`timeout-minutes: 3`, concurrency group). **All correctness gates remain hard-gating** — Tests, Storybook Tests, Lint, Format, Type Check, Build are unaffected; only this advisory preview job changes.

## This is a deliberate CI loosening

Per the repo's CI directive it's isolated in its own PR and needs the **`CI change approved`** label to merge. It loosens **only** the non-correctness screenshots job.

> **Stacked on #326** — targets `feat/split-storybook-tests`, not `main`. Merge #326 first; this will retarget to `main` automatically.

---
*Created by Claude Opus 4.8*