### PR TITLE
ci: skip heavy code jobs on documentation-only PRs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -9,8 +9,48 @@ permissions:
   contents: read
 
 jobs:
+  # Detects whether a PR touches anything beyond inert documentation, so the
+  # heavy code-validation jobs can skip doc-only PRs. Denylist, not allowlist:
+  # code_changed defaults to true and is only cleared when EVERY changed file is
+  # provably-inert docs, so a new/unanticipated file type fails safe (runs CI).
+  # On push (e.g. to main) it is always true.
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          code_changed=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              # Inert documentation — anything else trips the full suite.
+              *.md | docs/* | LICENSE | *.txt) ;;
+              *)
+                code_changed=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
+
   tests:
     name: Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -21,6 +61,8 @@ jobs:
 
   storybook-tests:
     name: Storybook Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -58,6 +100,8 @@ jobs:
 
   type-check:
     name: Type Check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -67,6 +111,8 @@ jobs:
 
   build:
     name: Build
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -76,6 +122,8 @@ jobs:
 
   storybook-build:
     name: Storybook Build
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -10,6 +10,7 @@ import { parse } from "yaml";
 const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
   "ci-actions.yml": {
     build: 2,
+    "detect-changes": 1,
     format: 2,
     lint: 2,
     "storybook-build": 2,


### PR DESCRIPTION
Adds a `detect-changes` job and gates the heavy code-validation jobs on it so documentation-only PRs skip them.

## Design (denylist, fail-safe)

`detect-changes` sets `code_changed=true` by default and only clears it when **every** changed file is provably-inert documentation (`*.md`, `docs/**`, `LICENSE`, `*.txt`). A new/unanticipated file type therefore fails *safe* (runs the suite) rather than *open*. On `push` it's always `true`.

Gated via `needs: detect-changes` + `if: needs.detect-changes.outputs.code_changed == 'true'`: **Tests, Storybook Tests, Type Check, Build, Storybook Build**.

Ungated (still run on doc-only PRs): **Format** (Prettier validates markdown), **Lint**, plus the other workflows (file-length, PR-title, validate-config).

## Why this is safe

A doc-only PR changes no code, so nothing can regress — the "always run Storybook Tests" rule (#328) is about *code* edits and isn't violated here. A gated job that's skipped via `if:` reports a `skipped` conclusion, which branch protection treats as passing (no hung required check). If a heavy job is a required check, confirm this holds; the `if:`-skip pattern is the branch-protection-safe choice.

Registered `detect-changes` in `src/workflow-timeouts.spec.ts`. Verified: timeouts test passes, YAML parses with exactly the five intended jobs gated, lint/format/tsc clean.

## CI loosening — isolated, needs sign-off
This conditionally skips correctness gates, so per the CI directive it's its own PR and needs the **`CI change approved`** label.

> **Stacked on #327** (→ #326). Targets `feat/advisory-screenshots`; merges after #326/#327.

Closes #329

---
*Created by Claude Opus 4.8*