### PR TITLE
chore(dependabot): isolate Prettier major/minor bumps in their own group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,21 @@ updates:
     # as individual PRs, since they more often need code changes and warrant
     # isolated review.
     groups:
+      # Prettier (and its plugins) gets its own group for major/minor bumps so a
+      # formatting-affecting upgrade lands in an isolated PR — a Prettier minor
+      # bump can reformat the whole tree and require code changes, which must not
+      # be buried in a batched dev-dependencies PR. Listed first to win
+      # group-assignment precedence (a dependency joins the first group whose
+      # patterns AND update-types match). Patch bumps are intentionally excluded
+      # here, so trivial Prettier patches fall through to the dev-dependencies
+      # group and ride along with the routine batch.
+      prettier:
+        patterns:
+          - "prettier"
+          - "prettier-plugin-*"
+        update-types:
+          - "major"
+          - "minor"
       dev-dependencies:
         dependency-type: development
         patterns:


### PR DESCRIPTION
## Purpose

A Prettier minor bump can reformat the entire tree and require code changes, so it should never arrive buried inside a batched `dev-dependencies` update PR. This adds a dedicated Dependabot group so Prettier upgrades are reviewed in isolation.

## Changes

Adds a `prettier` group to the npm ecosystem in `.github/dependabot.yml`, matching `prettier` and `prettier-plugin-*`:

- **`update-types: [major, minor]`** — only major and minor Prettier bumps split into their own PR. Trivial patch bumps are intentionally excluded, so they fall through to the existing `dev-dependencies` group and ride along with the routine batch.
- The group is **listed first** so it wins group-assignment precedence (a dependency joins the first group whose `patterns` *and* `update-types` match). A Prettier minor matches `prettier` before the catch-all `dev-dependencies`; a Prettier patch matches neither the `prettier` group's `update-types` nor escapes the dev batch.

Follows the per-dependency group pattern from `rmartz/ai-tools/.github/dependabot.yml`, adapted so only major/minor (not patch) are isolated.

---
*Created by Claude Opus 4.8*
