### PR TITLE
ci: skip Vercel preview deploys for non-feat/fix PRs

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" gate.
+#
+# Preview deploys exist solely for UAT, so a preview is only worth building when
+# the PR introduces a user-facing change — a `feat` or `fix`. chore/docs/ci/
+# refactor/test/style/build PRs are skipped; they have no functional impact a
+# preview would help verify.
+#
+# The type is read from the PR title (Conventional Commits, enforced by the
+# pr-title-lint CI check), NOT the branch name: every branch in this repo is
+# named `feat/*` regardless of work type, and in-branch commit messages are
+# intentionally non-conventional, so neither is a reliable type signal. The repo
+# is public, so the PR title is fetched from the GitHub API unauthenticated — no
+# token or secret is required.
+#
+# Exit code contract (Vercel): 1 = build, 0 = skip.
+#
+# Fail-safe bias: any uncertainty (production branch, no associated PR, API
+# error, empty title) BUILDS. A preview a tester needs is never silently
+# withheld; the worst case is one extra build.
+set -uo pipefail
+
+ref="${VERCEL_GIT_COMMIT_REF:-}"
+pr="${VERCEL_GIT_PULL_REQUEST_ID:-}"
+owner="${VERCEL_GIT_REPO_OWNER:-}"
+slug="${VERCEL_GIT_REPO_SLUG:-}"
+
+build() {
+  echo "$1"
+  exit 1
+}
+skip() {
+  echo "$1"
+  exit 0
+}
+
+[ "$ref" = "main" ] && build "Production branch 'main' — building."
+[ -z "$pr" ] && build "No associated pull request — building (type unknown)."
+{ [ -z "$owner" ] || [ -z "$slug" ]; } && build "Repo owner/slug unavailable — building."
+
+title="$(curl -sS --max-time 10 -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$owner/$slug/pulls/$pr" |
+  node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).title??"")}catch{process.exit(1)}})' 2>/dev/null)" ||
+  build "Could not fetch PR #$pr title — building (fail-safe)."
+
+[ -z "$title" ] && build "Empty PR #$pr title — building (fail-safe)."
+
+if printf '%s' "$title" | grep -Eq '^(feat|fix)(\([^)]*\))?!?:'; then
+  build "PR #$pr is feat/fix ('$title') — building preview."
+else
+  skip "PR #$pr is not feat/fix ('$title') — skipping preview."
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "installCommand": "git config --global url.\"https://github.com/\".insteadOf \"git@github.com:\" && pnpm install --frozen-lockfile"
 }


### PR DESCRIPTION
## Purpose

Stop wasting a Vercel preview deploy on PRs that have no functional impact. Preview deploys exist for UAT, so a preview is only worth building when the PR introduces a user-facing change — a `feat` or `fix`. `chore`/`docs`/`ci`/`refactor`/`test`/`style`/`build` PRs are skipped.

## How it works

Adds a Vercel **Ignored Build Step** — `scripts/vercel-ignore-build.sh`, wired via `ignoreCommand` in `vercel.json`. It exits 1 (build) or 0 (skip) per Vercel's contract:

- Production (`main`) always builds.
- Otherwise it reads the **PR title** and builds only when the title's Conventional-Commit type is `feat` or `fix` (`^(feat|fix)(\(scope\))?!?:`).

### Why the PR title, not the branch or commit message

Every branch in this repo is named `feat/*` regardless of work type (e.g. the `ci:` PRs #332/#333/#337 all live on `feat/*` branches), and in-branch commit messages are intentionally non-conventional — so neither is a reliable type signal. The PR title *is* reliable: it's validated by the `pr-title-lint` CI check. The title is fetched from the **GitHub API unauthenticated** — the repo is public, so **no token or secret is required**.

### Fail-safe bias

Any uncertainty — production branch, no associated PR yet, API error/rate-limit, empty title — **builds** rather than skips. A preview a tester needs is never silently withheld; the worst case is one extra build.

## Testing

Validated `scripts/vercel-ignore-build.sh` locally against real PRs by simulating Vercel's env vars: `main` → build; #337 (`ci:`) → skip; #264 (`fix(...)`) → build; no PR id → build (fail-safe).

## Note on the alternative considered

A label-gated approach ("deploy only when `ready for UAT`") was rejected: Vercel deploys on git push, not on label changes, so the label — applied post-review with no later push — would never re-trigger a build. Making it correct would require disabling auto-previews plus a GitHub Action firing a Vercel deploy on the label event (and a Vercel token secret). This title-based gate captures the same intent with no secret and no extra wiring.

> **Heads-up for the reviewer:** if the Vercel deployment status is a *required* status check in branch protection, confirm a skipped preview still satisfies it (Vercel reports ignored builds as canceled/neutral, not failing). If it's required and blocks, the Vercel check should be made non-required for previews.

---
*Created by Claude Opus 4.8*
