### PR TITLE
ci(storybook screenshots): raise job timeout from 3 to 10 minutes

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -143,7 +143,15 @@ jobs:
       group: storybook-screenshots-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    # The capture step drives a real browser: the third-party action installs
+    # its own ~174 MiB Chromium build, then a full Storybook dev server boots
+    # and every changed story is screenshotted. 3 minutes could not cover that
+    # setup, so the job was hitting the timeout mid-install (a cancellation, not
+    # a hang) on every run. Sister repos budget 8 minutes for the equivalent
+    # job; 10 leaves headroom for the double browser download this job still
+    # incurs. The timeout is a backstop against a genuine hang, not a cap on
+    # legitimate setup time.
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,7 +14,7 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     format: 2,
     lint: 2,
     "storybook-build": 2,
-    "storybook-screenshots": 3,
+    "storybook-screenshots": 10,
     "storybook-tests": 4,
     tests: 2,
     "type-check": 2,


### PR DESCRIPTION
## What & why

The **Storybook Screenshots** CI job has been cancelled on every recent run (e.g. [PR #264](https://github.com/rmartz/personal-budget/pull/264)) — not failing on a screenshot diff, but hitting its own `timeout-minutes: 3` wall. In the run for #264 the job started at `02:12:04` and was SIGINT'd at exactly `02:15:04`; GitHub records a `timeout-minutes` kill as a `cancelled` conclusion, and because a cancelled job outranks success in the run-level rollup, the whole CI run showed `cancelled` even though every hard gate passed.

This raises the job timeout from **3 to 10 minutes**.

## Investigation (why the timeout — not a hang — is the problem)

Per our policy, a timeout bump has to justify that the timeout itself is misconfigured rather than masking a real problem. It is: the job legitimately needs more than 3 minutes of setup before it can capture anything.

- The explicit `Install Playwright Chromium` step installs the project's Playwright browser.
- Then the third-party `yoavf/auto-pr-screenshots-action@v1.4.0-beta` **installs its own ~174 MiB Chromium build again** (it pins `playwright@1.56.0` and runs its own `install --with-deps`). In the #264 log that download finished at `02:13:18` — leaving under two minutes for the Storybook dev server to boot and every changed story to be screenshotted.
- The clock ran out at 3:00 exactly, before capture completed. No hang; the work simply doesn't fit in 3 minutes.

Sister repos (`group-picks`, `firebase-nextjs-template`) budget **8 minutes** for the equivalent job. 10 leaves headroom for the redundant double browser download this job still incurs (removed separately). The timeout remains a genuine backstop against a hung browser — just set to a realistic ceiling.

The job stays `continue-on-error: true` (advisory, never a merge gate). This is a CI-only change with no application-code impact.

---
*Created by Claude Opus 4.8*
