### PR TITLE
feat(staging): seed staging test accounts with distinct data profiles

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,3 +11,7 @@ This is a `type` convention, not a closed set — add a new value when none fits
 # Schema
 
 - [Firebase Realtime Database Schema](database-schema.md) - Path structure, field formats, and security rules for all user data in the Firebase Realtime Database.
+
+# Guide
+
+- [Staging Test Accounts](staging-test-accounts.md) - The seeded email/password test users in the staging Firebase project and how to (re-)seed them.

--- a/docs/staging-test-accounts.md
+++ b/docs/staging-test-accounts.md
@@ -1,0 +1,59 @@
+---
+type: Guide
+title: Staging Test Accounts
+description: The seeded email/password test users in the staging Firebase project and how to (re-)seed them.
+resource: scripts/seed-staging.mjs
+tags: [staging, testing, firebase, seed, preview]
+---
+
+# Staging Test Accounts
+
+`scripts/seed-staging.mjs` seeds a small set of email/password test users into the
+**staging** Firebase project, each with a distinct, recognizable data profile so
+preview/staging testing (and the account switcher, #321) exercises realistic
+states. It never touches production — see [Safety](#safety).
+
+## Accounts
+
+| Email                   | Profile                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `new-user@staging.test` | **New user** — no data; the first-run empty state.                                                                                       |
+| `active@staging.test`   | **Active user** — two ledgers (one cash-capped), transactions, two savings goals, two annuities, and reconciliation accounts + expenses. |
+| `edge@staging.test`     | **Edge cases** — a fully-funded goal (`fundedAmount == targetAmount`) and a cash-capped ledger.                                          |
+
+All three share one password, supplied via `STAGING_TEST_PASSWORD` (below). The
+data shapes match the [Firebase Realtime Database Schema](database-schema.md).
+
+## Running the seed
+
+The script uses the Firebase Admin SDK against the staging project. Provide the
+staging service-account credentials and the shared test password as environment
+variables (the Firebase vars are the same ones `src/lib/firebase/admin.ts` reads):
+
+```bash
+export FIREBASE_PROJECT_ID="personal-budget-staging-…"   # must contain "staging"
+export FIREBASE_CLIENT_EMAIL="…@…iam.gserviceaccount.com"
+export FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n…"
+export FIREBASE_DATABASE_URL="https://personal-budget-staging-…-default-rtdb.firebaseio.com"
+export STAGING_TEST_PASSWORD="<staging-only password>"
+
+node scripts/seed-staging.mjs
+```
+
+Each account is created if missing (its password is (re)set on every run), then
+its `/users/{uid}` subtree is written with a single `set()`.
+
+## Idempotency
+
+Re-running is safe: profiles use deterministic child keys and each user's subtree
+is written with one `set()`, so a re-run upserts the same nodes rather than
+duplicating — and resets the account to its known profile (any manual edits made
+while testing are overwritten).
+
+## Safety
+
+The script **refuses to run** unless `FIREBASE_PROJECT_ID` names a staging
+project (its id must contain `"staging"`), so it can never seed production. The
+separate staging Firebase project (#319) is the real safety boundary; the emails
+use the non-routable `.test` TLD and the password comes only from
+`STAGING_TEST_PASSWORD` — no production credentials are ever referenced.

--- a/scripts/seed-staging.mjs
+++ b/scripts/seed-staging.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Seed the STAGING Firebase project with a small set of email/password test
+ * users, each carrying a distinct, recognizable data profile so preview testing
+ * (and the account switcher in #321) exercises realistic states.
+ *
+ * Safety: the script refuses to run unless FIREBASE_PROJECT_ID names a staging
+ * project (must contain "staging"), so it can never touch production. The
+ * separate staging Firebase project (#319) is the real safety boundary.
+ *
+ * Idempotent: profiles use deterministic child keys and each user's subtree is
+ * written with a single `set()` at `/users/{uid}`, so re-running upserts the
+ * same nodes rather than duplicating — and resets the account to a known state.
+ *
+ * Required env (staging service account + RTDB; same vars as src/lib/firebase/admin.ts):
+ *   FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY,
+ *   FIREBASE_DATABASE_URL, and STAGING_TEST_PASSWORD (shared test password).
+ *
+ * Run: node scripts/seed-staging.mjs   (see docs/staging-test-accounts.md)
+ *
+ * Data shapes match docs/database-schema.md exactly (Firebase layer).
+ */
+
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { getDatabase } from "firebase-admin/database";
+
+const STAGING_MARKER = "staging";
+
+// Staging-only accounts. Emails use the non-routable `.test` TLD so they can
+// never collide with a real user; the password comes from env, never hardcoded.
+const TEST_ACCOUNTS = [
+  {
+    key: "new",
+    email: "new-user@staging.test",
+    label: "New user",
+    description: "No data — the first-run empty state.",
+  },
+  {
+    key: "active",
+    email: "active@staging.test",
+    label: "Active user",
+    description:
+      "Multiple ledgers, transactions, goals, an annuity, and reconciliation setup.",
+  },
+  {
+    key: "edge",
+    email: "edge@staging.test",
+    label: "Edge cases",
+    description:
+      "A fully-funded goal and a cash-capped ledger for boundary testing.",
+  },
+];
+
+/**
+ * Throw unless `projectId` names a staging project. This is the production
+ * guard: a production project id will not contain "staging", so seeding aborts.
+ */
+function assertStagingProject(projectId) {
+  if (!projectId || !projectId.includes(STAGING_MARKER)) {
+    throw new Error(
+      `Refusing to seed: FIREBASE_PROJECT_ID (${projectId ? `"${projectId}"` : "unset"}) is not a staging project — it must contain "${STAGING_MARKER}". This guard prevents seeding production.`,
+    );
+  }
+  return projectId;
+}
+
+/**
+ * The per-account data subtrees, keyed by account `key`, shaped exactly as the
+ * Firebase layer stores them under `/users/{uid}/` (see docs/database-schema.md).
+ * Deterministic keys + fixed timestamps keep re-runs byte-identical.
+ */
+function buildProfiles() {
+  return {
+    new: {},
+    active: {
+      budgetLedgers: {
+        "car-maintenance": { name: "Car Maintenance", cashCap: 2000 },
+        "emergency-fund": { name: "Emergency Fund" },
+      },
+      budgetLedgerTransactions: {
+        "car-maintenance": {
+          "tx-1": {
+            type: "deposit",
+            date: "2026-01-05T00:00:00.000Z",
+            amount: 300,
+            description: "Monthly set-aside",
+          },
+          "tx-2": {
+            type: "expense",
+            date: "2026-02-14T00:00:00.000Z",
+            amount: 180,
+            description: "Oil change + tires",
+          },
+        },
+        "emergency-fund": {
+          "tx-1": {
+            type: "deposit",
+            date: "2026-01-01T00:00:00.000Z",
+            amount: 1500,
+            description: "Initial funding",
+          },
+        },
+      },
+      budgetLedgerSavingsGoals: {
+        "emergency-fund": {
+          "three-month-buffer": {
+            name: "Three-month buffer",
+            targetAmount: 9000,
+            fundedAmount: 1500,
+            priority: 1,
+          },
+          vacation: {
+            name: "Vacation",
+            targetAmount: 3000,
+            fundedAmount: 500,
+            priority: 2,
+          },
+        },
+      },
+      annuities: {
+        netflix: {
+          name: "Netflix",
+          monthlyAmount: 15.49,
+          startDate: "2025-06-01T00:00:00.000Z",
+          durationMonths: null,
+        },
+        "car-loan": {
+          name: "Car Loan",
+          monthlyAmount: 420,
+          startDate: "2024-09-01T00:00:00.000Z",
+          durationMonths: 60,
+        },
+      },
+      reconciliationAccounts: {
+        "chase-checking": {
+          name: "Chase Checking",
+          tier: "short-term",
+          targetFloat: 2500,
+        },
+        "ally-savings": {
+          name: "Ally Savings",
+          tier: "reserve",
+          targetFloat: 10000,
+        },
+      },
+      reconciliationExpenses: {
+        electric: {
+          name: "Electric Bill",
+          type: "statement-balance",
+          typicalAmount: 120,
+        },
+        rent: {
+          name: "Rent",
+          type: "running-balance",
+          typicalAmount: 1800,
+        },
+      },
+    },
+    edge: {
+      budgetLedgers: {
+        "capped-savings": { name: "Capped Savings", cashCap: 500 },
+      },
+      budgetLedgerSavingsGoals: {
+        "capped-savings": {
+          "fully-funded": {
+            name: "Fully-funded goal",
+            targetAmount: 1200,
+            fundedAmount: 1200,
+            priority: 1,
+          },
+        },
+      },
+    },
+  };
+}
+
+async function ensureUser(auth, email, password) {
+  try {
+    const user = await auth.getUserByEmail(email);
+    await auth.updateUser(user.uid, { password, emailVerified: true });
+    return user.uid;
+  } catch (error) {
+    if (error.code === "auth/user-not-found") {
+      const created = await auth.createUser({
+        email,
+        password,
+        emailVerified: true,
+      });
+      return created.uid;
+    }
+    throw error;
+  }
+}
+
+async function main() {
+  const projectId = assertStagingProject(process.env["FIREBASE_PROJECT_ID"]);
+  const password = process.env["STAGING_TEST_PASSWORD"];
+  if (!password) {
+    throw new Error("STAGING_TEST_PASSWORD is required to seed test accounts.");
+  }
+
+  const app =
+    getApps().find((a) => a.name === "[DEFAULT]") ??
+    initializeApp({
+      credential: cert({
+        projectId,
+        clientEmail: process.env["FIREBASE_CLIENT_EMAIL"],
+        privateKey: process.env["FIREBASE_PRIVATE_KEY"]?.replace(/\\n/g, "\n"),
+      }),
+      databaseURL: process.env["FIREBASE_DATABASE_URL"],
+    });
+
+  const auth = getAuth(app);
+  const db = getDatabase(app);
+  const profiles = buildProfiles();
+
+  for (const account of TEST_ACCOUNTS) {
+    const uid = await ensureUser(auth, account.email, password);
+    // Full-subtree set = deterministic upsert; resets the account to its profile.
+    await db.ref(`/users/${uid}`).set(profiles[account.key]);
+    console.log(`Seeded ${account.email} (${account.label}) → uid ${uid}`);
+  }
+
+  console.log(`Done. Seeded ${TEST_ACCOUNTS.length} staging test account(s).`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  // `--dump-profiles` prints the profile data as JSON and exits without touching
+  // Firebase — used by the test suite to assert the seed shapes.
+  if (process.argv.includes("--dump-profiles")) {
+    console.log(JSON.stringify(buildProfiles(), null, 2));
+    process.exit(0);
+  }
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error.message);
+      process.exit(1);
+    });
+}

--- a/src/scripts/seed-staging.spec.ts
+++ b/src/scripts/seed-staging.spec.ts
@@ -1,0 +1,172 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// The seed script is plain JS run as a subprocess (matching the repo's other
+// script specs). Its pure output is inspected via the `--dump-profiles` flag,
+// and its production guard is exercised by running it with different env.
+const SCRIPT_PATH = join(process.cwd(), "scripts", "seed-staging.mjs");
+
+// Env with the seed-relevant vars stripped, so a developer's real credentials
+// never leak into these tests (the guard/password checks run before any Firebase
+// call, so no test ever touches the network).
+function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env["FIREBASE_PROJECT_ID"];
+  delete env["STAGING_TEST_PASSWORD"];
+  return env;
+}
+
+function run(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync("node", [SCRIPT_PATH, ...args], { env, encoding: "utf8" });
+}
+
+// Firebase-shaped profile types (mirror docs/database-schema.md) for typed
+// assertions against the dumped JSON.
+interface Ledger {
+  name: string;
+  cashCap?: number;
+}
+interface Transaction {
+  type: string;
+  date: string;
+  amount: number;
+  description: string;
+}
+interface Goal {
+  name: string;
+  targetAmount: number;
+  fundedAmount: number;
+  priority: number;
+}
+interface Annuity {
+  name: string;
+  monthlyAmount: number;
+  startDate: string;
+}
+interface ReconciliationAccount {
+  tier: string;
+  targetFloat: number;
+}
+interface ReconciliationExpense {
+  type: string;
+  typicalAmount: number;
+}
+interface ProfileSubtree {
+  budgetLedgers?: Record<string, Ledger>;
+  budgetLedgerTransactions?: Record<string, Record<string, Transaction>>;
+  budgetLedgerSavingsGoals?: Record<string, Record<string, Goal>>;
+  annuities?: Record<string, Annuity>;
+  reconciliationAccounts?: Record<string, ReconciliationAccount>;
+  reconciliationExpenses?: Record<string, ReconciliationExpense>;
+}
+type Profiles = Record<"new" | "active" | "edge", ProfileSubtree>;
+
+function dumpProfiles(): Profiles {
+  const result = run(["--dump-profiles"], cleanEnv());
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout) as Profiles;
+}
+
+describe("seed-staging — refuses to run against non-staging projects", () => {
+  it("aborts when FIREBASE_PROJECT_ID is not a staging project", () => {
+    const result = run([], {
+      ...cleanEnv(),
+      FIREBASE_PROJECT_ID: "personal-budget-prod",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("staging");
+  });
+
+  it("aborts when FIREBASE_PROJECT_ID is unset", () => {
+    const result = run([], cleanEnv());
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("staging");
+  });
+
+  it("aborts on a staging project when STAGING_TEST_PASSWORD is missing", () => {
+    const result = run([], {
+      ...cleanEnv(),
+      FIREBASE_PROJECT_ID: "personal-budget-staging-a99af",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("STAGING_TEST_PASSWORD");
+  });
+});
+
+describe("seed-staging — profiles cover empty, rich, and edge-case accounts", () => {
+  it("gives the new-user account an empty profile", () => {
+    expect(Object.keys(dumpProfiles().new)).toHaveLength(0);
+  });
+
+  it("gives the active account ledgers, transactions, goals, and annuities", () => {
+    const active = dumpProfiles().active;
+    expect(Object.keys(active.budgetLedgers ?? {}).length).toBeGreaterThan(0);
+    expect(
+      Object.keys(active.budgetLedgerTransactions ?? {}).length,
+    ).toBeGreaterThan(0);
+    expect(
+      Object.keys(active.budgetLedgerSavingsGoals ?? {}).length,
+    ).toBeGreaterThan(0);
+    expect(Object.keys(active.annuities ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it("gives the edge account a fully-funded goal and a cash-capped ledger", () => {
+    const edge = dumpProfiles().edge;
+    const goals = Object.values(edge.budgetLedgerSavingsGoals ?? {}).flatMap(
+      (byGoal) => Object.values(byGoal),
+    );
+    expect(goals.some((g) => g.fundedAmount === g.targetAmount)).toBe(true);
+    const ledgers = Object.values(edge.budgetLedgers ?? {});
+    expect(ledgers.some((l) => typeof l.cashCap === "number")).toBe(true);
+  });
+});
+
+describe("seed-staging — data matches the Firebase schema", () => {
+  it("shapes ledgers, transactions, goals, annuities, and reconciliation records per schema", () => {
+    const profiles = dumpProfiles();
+    for (const profile of [profiles.active, profiles.edge]) {
+      for (const ledger of Object.values(profile.budgetLedgers ?? {})) {
+        expect(typeof ledger.name).toBe("string");
+      }
+      for (const byTx of Object.values(
+        profile.budgetLedgerTransactions ?? {},
+      )) {
+        for (const tx of Object.values(byTx)) {
+          expect(["deposit", "expense"]).toContain(tx.type);
+          expect(typeof tx.amount).toBe("number");
+        }
+      }
+      for (const byGoal of Object.values(
+        profile.budgetLedgerSavingsGoals ?? {},
+      )) {
+        for (const goal of Object.values(byGoal)) {
+          expect(typeof goal.targetAmount).toBe("number");
+          expect(typeof goal.fundedAmount).toBe("number");
+          expect(typeof goal.priority).toBe("number");
+        }
+      }
+      for (const annuity of Object.values(profile.annuities ?? {})) {
+        expect(typeof annuity.monthlyAmount).toBe("number");
+        expect(typeof annuity.startDate).toBe("string");
+      }
+      for (const account of Object.values(
+        profile.reconciliationAccounts ?? {},
+      )) {
+        expect(["short-term", "reserve", "long-term"]).toContain(account.tier);
+      }
+      for (const expense of Object.values(
+        profile.reconciliationExpenses ?? {},
+      )) {
+        expect(["statement-balance", "running-balance"]).toContain(
+          expense.type,
+        );
+      }
+    }
+  });
+
+  it("is deterministic so re-running upserts identical nodes (no duplicates)", () => {
+    expect(dumpProfiles()).toEqual(dumpProfiles());
+  });
+});


### PR DESCRIPTION
Adds an idempotent seed script that populates the **staging** Firebase project with a small set of email/password test users, each with a distinct data profile, so preview/staging testing (and the account switcher in #321) exercises realistic states.

Key decisions:

- **Production guard**: the script refuses to run unless `FIREBASE_PROJECT_ID` names a staging project (must contain `"staging"`), so it can never touch production. It also requires `STAGING_TEST_PASSWORD` (test password from env, never hardcoded).
- **Idempotent**: deterministic child keys + a single `set()` per user subtree mean re-runs upsert the same nodes (no duplicates) and reset the account to its known profile.
- **Testable plain-JS script**: follows the repo's `validate-config.spec.ts` pattern — the spec drives the script via `spawnSync` (a `--dump-profiles` flag prints the seed data as JSON; the guard is exercised with different env), so no Firebase or credentials are needed to test. Data shapes mirror `docs/database-schema.md`.

## Acceptance Criteria
- [x] Seed script creates the test users + profiles in staging, idempotently, and refuses to run against the production project
- [x] Profiles cover at least: empty/new, rich/active, and an edge-case account
- [x] Data matches the current Firebase schema
- [x] Test accounts and run instructions are documented (`docs/staging-test-accounts.md`)
- [x] No production data is touched (enforced by the staging-project guard)

## Tests
8 tests added (guard behavior + profile shape/coverage/determinism), all passing.

## Manual run step (yours — needs staging credentials)
The script *code* is fully tested, but actually seeding staging requires the staging service-account credentials, which I don't have. To run it: set `FIREBASE_PROJECT_ID` / `FIREBASE_CLIENT_EMAIL` / `FIREBASE_PRIVATE_KEY` / `FIREBASE_DATABASE_URL` (staging) and `STAGING_TEST_PASSWORD`, then `node scripts/seed-staging.mjs` (see the docs page).

Closes #320

---
*Created by Claude Opus 4.8*
