### PR TITLE
ci(storybook screenshots): remove redundant Playwright Chromium install

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -162,9 +162,6 @@ jobs:
             --changed-files=changed-files.txt \
             --output=.github/screenshots.dynamic.yml \
             --github-output="$GITHUB_OUTPUT"
-      - name: Install Playwright Chromium
-        if: steps.screenshot-config.outputs.has_stories == 'true'
-        run: pnpm exec playwright install chromium
       - name: Start Storybook
         if: steps.screenshot-config.outputs.has_stories == 'true'
         run: pnpm storybook --ci --port 6006 &


### PR DESCRIPTION
## What & why

The **Storybook Screenshots** job installed Playwright's Chromium twice:

1. An explicit `Install Playwright Chromium` step ran `pnpm exec playwright install chromium`, installing the project's Playwright browser.
2. The capture action, `yoavf/auto-pr-screenshots-action@v1.4.0-beta`, then **installs its own pinned Chromium build** — it bundles `playwright@1.56.0` and runs its own `install --with-deps` (~174 MiB). The project pins a different Playwright (`1.61.0`), a different browser revision, so the action never touches the browser from step 1.

This removes the redundant explicit install step. The action still installs and uses its own Chromium exactly as before, so nothing about what gets captured changes — this only drops a duplicated ~174 MiB download that was eating into the job's setup budget (and contributing to the timeouts seen on [PR #264](https://github.com/rmartz/personal-budget/pull/264)).

## Context

Sister repos (`group-picks`, `firebase-nextjs-template`) went further and dropped the third-party action entirely in favour of a local `scripts/capture-screenshots.mjs` that reuses a single self-managed Chromium install. Adopting that pattern here would remove the double-install root cause completely, but it is a larger migration; this PR is the minimal, safe cleanup. The broader migration is worth a follow-up issue.

This is a CI-only change with no application-code impact.

---
*Created by Claude Opus 4.8*
