### PR TITLE
ci(storybook tests): cache Playwright browsers

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -68,8 +68,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
+      - name: Resolve Playwright version
+        id: playwright-version
+        # Key the browser cache on the exact installed Playwright version, so a
+        # dependency bump fetches the matching Chromium rather than restoring a
+        # stale build. Resolvable because setup has already run pnpm install.
+        run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Chromium
-        # Retry to ride out transient apt/CDN failures during --with-deps.
+        # Retry to ride out transient apt/CDN failures during --with-deps. On a
+        # cache hit the Chromium build is already present, so this only installs
+        # the OS-level dependencies (which the browser cache cannot carry).
         run: |
           for attempt in 1 2 3; do
             pnpm exec playwright install --with-deps chromium && exit 0


### PR DESCRIPTION
## What & why

The **Storybook Tests** job downloads Playwright's Chromium (~130 MB) from scratch on every run. This caches it: `~/.cache/ms-playwright` is restored via `actions/cache`, keyed on the exact installed Playwright version, so a cache hit skips the download entirely.

## Key technical decisions

- **Keyed on the resolved Playwright version**, read at runtime from `require('playwright/package.json').version` (resolvable because the `setup` composite has already run `pnpm install`). Keying on the version — rather than a lockfile hash — means the cache invalidates precisely when Playwright itself is bumped, so we never restore a Chromium build that mismatches the installed Playwright, and unrelated dependency bumps don't needlessly evict it. No `restore-keys` fallback, deliberately: a partial-key restore could hand back a stale browser revision.
- **The install step is kept**, not replaced. On a cache hit it becomes fast because the browser is already present, but it still runs `--with-deps` to lay down the OS-level libraries (which a browser cache cannot carry) and still downloads the browser on a version-bump miss. The existing retry loop is untouched.

## Why only the Storybook Tests job

The **Storybook Screenshots** job's Chromium is downloaded *inside* the third-party `yoavf/auto-pr-screenshots-action`, which pins its own (different) Playwright version — so it genuinely fetches a different build and cannot share this cache. Caching around that action would couple the cache key to its internal pin, which isn't worth it given the plan to replace that action with local capture (as `group-picks` / `firebase-nextjs-template` already do). Once that migration happens the screenshots job will use the project Playwright, and this same cache key will cover it too.

This is a CI-only change with no application-code impact.

---
*Created by Claude Opus 4.8*
