### PR TITLE
chore: rename package to personal-budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "firebase-nextjs-template",
+  "name": "personal-budget",
   "version": "0.1.0",
-  "description": "Template repository for Next.js projects built on Firebase",
+  "description": "Personal budgeting app built on Next.js and Firebase",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
Renames the `package.json` `name` from the template-derived `firebase-nextjs-template` to `personal-budget`, and refreshes the now-stale `description` (it was a template's, not this app's).

The name is cosmetic — the app is `private` (never published) and the string is unreferenced anywhere outside `package.json` (verified by grep), so this only cleans up what shows in CI logs (`personal-budget@0.1.0 …`) and local tooling. No lockfile impact (pnpm keys the root importer as `.`, not by name).

---
*Created by Claude Opus 4.8*