### PR TITLE
ci: make Storybook screenshot capture fail fast, not time out

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -156,7 +156,13 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
       - name: Capture screenshots
-        continue-on-error: true
+        # No step-level continue-on-error: a capture failure (a broken or slow
+        # story) must surface as a job *failure* so the coordinator routes it to
+        # fix-review. The script fails fast — stories run concurrently with a
+        # short per-story render budget and an overall wall-clock deadline below
+        # this job's timeout-minutes — so the job never hits its timeout and gets
+        # *cancelled* (which escalates to a human instead). Job-level
+        # continue-on-error still keeps the failure non-blocking for the run.
         run: node scripts/capture-screenshots.mjs
       - name: Upload screenshots
         if: always()

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -10,8 +10,15 @@
  * Output is written to a per-run directory with no shared resource, so it is
  * safe to upload as a CI artifact and never races across concurrent PR runs.
  *
- * Exits 0 on success, 1 if the build output is missing or any story fails to
- * capture (the CI job is advisory, so a non-zero exit does not block the PR).
+ * Fail-fast, not time-out: a story is given a short render budget, stories are
+ * captured concurrently, and the whole run has a wall-clock deadline (below the
+ * CI job's `timeout-minutes`). On the deadline the script exits non-zero
+ * immediately. This matters because a job that hits `timeout-minutes` is
+ * *cancelled* (which the PR coordinator escalates to a human), whereas a
+ * non-zero exit is a *failure* (auto-routed to fix-review). We want the latter.
+ *
+ * Exits 0 when every story was captured, 1 if the build output is missing, any
+ * story failed to render, or the deadline was hit.
  */
 
 import { existsSync, mkdirSync, readFileSync } from "fs";
@@ -23,6 +30,14 @@ import { chromium } from "playwright";
 const staticDir = "storybook-static";
 const outDir = "screenshots";
 const indexPath = join(staticDir, "index.json");
+
+// Concurrency and timeouts. The deadline is intentionally below the workflow's
+// `timeout-minutes` so we fail before the job is cancelled; override in CI with
+// CAPTURE_DEADLINE_MS if the story count grows.
+const CONCURRENCY = 4;
+const NAV_TIMEOUT_MS = 15000;
+const RENDER_TIMEOUT_MS = 4000;
+const DEADLINE_MS = Number(process.env["CAPTURE_DEADLINE_MS"] ?? 4 * 60 * 1000);
 
 if (!existsSync(indexPath)) {
   console.error(
@@ -80,28 +95,54 @@ await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
 const { port } = server.address();
 
 const browser = await chromium.launch();
-const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+const startedAt = Date.now();
+const deadlineExceeded = () => Date.now() - startedAt > DEADLINE_MS;
 
+const queue = [...stories];
+let captured = 0;
 let failed = 0;
-for (const story of stories) {
-  const url = `http://127.0.0.1:${port}/iframe.html?id=${encodeURIComponent(story.id)}&viewMode=story`;
-  try {
-    await page.goto(url, { waitUntil: "networkidle" });
-    await page
-      .locator("#storybook-root > *")
-      .first()
-      .waitFor({ timeout: 10000 });
-    await page.screenshot({ path: join(outDir, `${story.id}.png`) });
-  } catch (error) {
-    console.error(`Failed to capture ${story.id}: ${error.message}`);
-    failed += 1;
+
+async function worker() {
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 800 },
+  });
+  while (queue.length > 0 && !deadlineExceeded()) {
+    const story = queue.shift();
+    if (!story) break;
+    const url = `http://127.0.0.1:${port}/iframe.html?id=${encodeURIComponent(story.id)}&viewMode=story`;
+    try {
+      await page.goto(url, {
+        waitUntil: "domcontentloaded",
+        timeout: NAV_TIMEOUT_MS,
+      });
+      await page
+        .locator("#storybook-root > *")
+        .first()
+        .waitFor({ state: "visible", timeout: RENDER_TIMEOUT_MS });
+      await page.screenshot({ path: join(outDir, `${story.id}.png`) });
+      captured += 1;
+    } catch (error) {
+      console.error(`Failed to capture ${story.id}: ${error.message}`);
+      failed += 1;
+    }
   }
+  await page.close();
 }
 
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+// Any stories left in the queue were dropped by the deadline.
+const skipped = queue.length;
 await browser.close();
 await new Promise((resolve) => server.close(resolve));
 
+const elapsed = Math.round((Date.now() - startedAt) / 1000);
+if (skipped > 0) {
+  console.error(
+    `Deadline (${Math.round(DEADLINE_MS / 1000)}s) hit after ${elapsed}s — ${skipped} story(ies) not attempted. Exiting non-zero so the CI job fails fast rather than being cancelled at its timeout.`,
+  );
+}
 console.log(
-  `Captured ${stories.length - failed}/${stories.length} story screenshot(s) into ${outDir}/`,
+  `Captured ${captured}/${stories.length} story screenshot(s) into ${outDir}/ in ${elapsed}s (${failed} failed${skipped ? `, ${skipped} skipped` : ""}).`,
 );
-process.exit(failed > 0 ? 1 : 0);
+process.exit(failed > 0 || skipped > 0 ? 1 : 0);

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -38,6 +38,12 @@ const CONCURRENCY = 4;
 const NAV_TIMEOUT_MS = 15000;
 const RENDER_TIMEOUT_MS = 4000;
 const DEADLINE_MS = Number(process.env["CAPTURE_DEADLINE_MS"] ?? 4 * 60 * 1000);
+if (Number.isNaN(DEADLINE_MS)) {
+  console.error(
+    `error: CAPTURE_DEADLINE_MS="${process.env["CAPTURE_DEADLINE_MS"]}" is not a valid number.`,
+  );
+  process.exit(1);
+}
 
 if (!existsSync(indexPath)) {
   console.error(


### PR DESCRIPTION
Makes the advisory Storybook Screenshots job **fail fast** instead of running to `timeout-minutes` and being **cancelled** — so a capture problem is routed to fix-review (a `failure`) rather than escalated to a human (a `cancellation`).

## The problem

The job could only ever go non-green by hitting its 8-minute `timeout-minutes`, because:
1. The capture step had `continue-on-error: true`, which **swallowed the script's exit code** — so a story failing to render never failed the step.
2. The capture ran ~190 stories **serially** with a 10s-per-story timeout, so once stories failed to render the run overran 8 minutes and the job was **cancelled**. (That's exactly what happened on #349 — its `Storybook Screenshots` check reported `cancelled`.)

## The fix

- **`scripts/capture-screenshots.mjs`** now fails fast: stories render **concurrently** (pool of 4); each gets a short budget (`domcontentloaded` + a 4s visibility wait instead of `networkidle` + 10s); and an overall **wall-clock deadline** (default 4 min, overridable via `CAPTURE_DEADLINE_MS`, kept below the job's `timeout-minutes`) exits non-zero rather than letting the job time out.
- **`ci-actions.yml`**: removed the capture step's `continue-on-error` so that non-zero exit surfaces as a job **`failure`** (→ fix-review). The **job-level** `continue-on-error` stays, so a failure remains non-blocking for the run.

## Verified locally

Against a build where ~half the stories currently fail to render, the run finishes in **~106s** (was hitting the 8-min cap) and exits `1`; forcing a tiny `CAPTURE_DEADLINE_MS` exits `1` immediately with a clear message.

## Note — separate underlying bug

This PR fixes the **fail-vs-cancel behavior**, not the reason so many stories currently fail: a **Vite 8 / Rolldown ↔ Redux Toolkit / reselect** bundling bug drops reselect from the *built* Storybook, crashing every Redux-connected story with `createSelectorCreator is not defined` (only in the built render path the capture uses — `vitest`/`storybook-build` are fine). That render bug is tracked separately; with this change it now surfaces as a fast, fix-review-routed failure instead of a cancellation.

---
*Created by Claude Opus 4.8*
