### PR TITLE
fix(ci): capture portal-rendered dialog stories in screenshot script

### DIFF
--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -37,6 +37,18 @@ const indexPath = join(staticDir, "index.json");
 const CONCURRENCY = 4;
 const NAV_TIMEOUT_MS = 15000;
 const RENDER_TIMEOUT_MS = 4000;
+
+// A story is "rendered" once something visible appears. Most stories mount into
+// #storybook-root, but overlay components (Dialog, AlertDialog) render their
+// content into a portal on document.body — outside #storybook-root — so an
+// open-dialog story leaves the root empty. Accept a visible portal overlay as
+// an equivalent ready signal so those stories are captured instead of timing
+// out. page.screenshot() shoots the whole viewport, so the portal is included.
+const RENDER_READY_SELECTOR = [
+  "#storybook-root > *",
+  "[role='dialog']",
+  "[role='alertdialog']",
+].join(", ");
 const DEADLINE_MS = Number(process.env["CAPTURE_DEADLINE_MS"] ?? 4 * 60 * 1000);
 if (Number.isNaN(DEADLINE_MS)) {
   console.error(
@@ -122,7 +134,7 @@ async function worker() {
         timeout: NAV_TIMEOUT_MS,
       });
       await page
-        .locator("#storybook-root > *")
+        .locator(RENDER_READY_SELECTOR)
         .first()
         .waitFor({ state: "visible", timeout: RENDER_TIMEOUT_MS });
       await page.screenshot({ path: join(outDir, `${story.id}.png`) });


### PR DESCRIPTION
## Purpose

The advisory `Storybook Screenshots` job was failing on every open-overlay story — 62 of them, all `*dialog*` stories (`createaccountdialog`, `editexpensedialog`, `deleteaccountdialog`, …). This fix makes the capture script handle portal-rendered overlays so those stories capture instead of timing out.

## Root cause

`Dialog` / `AlertDialog` render their content into a **portal on `document.body`**, outside `#storybook-root`. An open-dialog story therefore leaves `#storybook-root` empty. The capture script waited only for `#storybook-root > *` to become visible, so those stories hit the 4s render budget and were reported as failures. (This is unrelated to the Vite 8 → 7 fix; it was previously masked by the reselect error and surfaced once that was resolved.)

## Fix

Accept a visible `[role="dialog"]` / `[role="alertdialog"]` overlay as an equivalent "rendered" signal, in addition to `#storybook-root > *`. `page.screenshot()` already captures the whole viewport, so the portal content is included in the image.

## Verification

Built the Storybook (Vite 7) and ran the capture locally:

- **Before:** `Captured 129/191 … (62 failed)` → exit 1
- **After:** `Captured 191/191 … (0 failed)` → exit 0, and faster (8s vs 76s, since 62 stories no longer burn the full 4s timeout)

Spot-checked a dialog screenshot — the full dialog renders correctly on its backdrop.

---
*Created by Claude Opus 4.8*
