### PR TITLE
ci: pin GitHub Actions to commit SHAs and enforce it in CI

### DIFF
--- a/.github/actions/playwright-chromium/action.yml
+++ b/.github/actions/playwright-chromium/action.yml
@@ -7,7 +7,7 @@ runs:
     - id: version
       shell: bash
       run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: playwright-chromium-${{ runner.os }}-${{ steps.version.outputs.version }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,8 +14,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v5
-    - uses: actions/setup-node@v6
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24.x
         cache: "pnpm"

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,0 +1,55 @@
+name: Action Pins
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Whether this PR touches workflow/action definitions the pin check reads. An
+  # allowlist is safe because the check's verdict is a pure function of the
+  # .github YAML. On push it is always true.
+  detect-changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      workflows_changed: ${{ steps.filter.outputs.workflows_changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "workflows_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          workflows_changed=false
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/*.yml | .github/workflows/*.yaml | .github/actions/*)
+                workflows_changed=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "workflows_changed=$workflows_changed" >> "$GITHUB_OUTPUT"
+
+  check-action-pins:
+    name: Check action SHA pins
+    needs: detect-changes
+    if: needs.detect-changes.outputs.workflows_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Pure Node script (no dependencies), so it runs on the runner's built-in
+      # Node without the pnpm-install setup step.
+      - run: node scripts/check-action-pins.mjs

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - id: filter
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       # Headless Vitest projects only — no browser, so no Playwright install.
       - run: pnpm exec vitest run --project node --project hooks --project components
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright-chromium
       - run: pnpm exec vitest run --project storybook
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm lint
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm tsc
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm build
 
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright-chromium
       - run: pnpm build-storybook

--- a/.github/workflows/package-pins.yml
+++ b/.github/workflows/package-pins.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       packages_changed: ${{ steps.filter.outputs.packages_changed }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - id: filter
@@ -50,6 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm run check:package-pins

--- a/.github/workflows/pr-screenshots-cleanup.yml
+++ b/.github/workflows/pr-screenshots-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
     # branch regardless of the permissions block above.
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Delete gh-screenshots-pr-${{ github.event.pull_request.number }}
         run: |

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       STORYBOOK_DISABLE_TELEMETRY: "1"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: getsentry/action-release@v3
+      - uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: reedmartz

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       config_changed: ${{ steps.filter.outputs.config_changed }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - id: filter
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: node scripts/validate-config.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,18 @@
   Prettier and its plugins. The `Package Pins` CI workflow runs it, gated to PRs that touch
   `package.json` or `pnpm-lock.yaml`.
 
+## GitHub Actions
+
+- **Pin every external GitHub Action to a full commit SHA**, with the release in a trailing
+  comment: `uses: actions/checkout@<40-hex-sha> # v7.0.0`. A mutable tag (`@v7`) can be
+  re-pointed at malicious code by a compromised maintainer or token; an immutable SHA cannot.
+  Local composite actions (`./.github/actions/*`) and `docker://` image refs are exempt — they
+  are not mutable Git tags.
+- `pnpm run check:action-pins` (`scripts/check-action-pins.mjs`) enforces this across every
+  workflow and composite action; the `Action Pins` CI workflow runs it, gated to PRs that touch
+  `.github/`. Dependabot's `github-actions` updater maintains the pins — it bumps the SHA and
+  the `# vX.Y.Z` comment together on new releases.
+
 ## Common Commands
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky",
+    "check:action-pins": "node scripts/check-action-pins.mjs",
     "check:package-pins": "node scripts/check-package-pins.mjs",
     "env:validate": "node scripts/validate-config.mjs"
   },

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Enforce that every external GitHub Action is pinned to a full commit SHA
+ * (CLAUDE.md — CI / supply-chain hardening), the Actions analogue of
+ * check-package-pins.mjs.
+ *
+ * A mutable tag (`actions/checkout@v7`) can be re-pointed at malicious code by a
+ * compromised maintainer or token; a 40-char commit SHA is immutable. Every
+ * `uses:` that references an external action must therefore pin a SHA, with the
+ * human-readable version in a trailing comment (`@<sha> # v7.0.0`) — the form
+ * Dependabot maintains.
+ *
+ * Skipped: local composite actions (`./…`, `../…`) and `docker://` image refs —
+ * neither is a mutable Git tag this rule governs.
+ *
+ * Exit 0 = compliant, 1 = violations found, 2 = usage error.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SHA = /^[0-9a-f]{40}$/;
+const USES = /^\s*(?:-\s*)?uses:\s*["']?([^"'#\s]+)/;
+const IN_CI = process.env.GITHUB_ACTIONS === "true";
+
+function findWorkflowFiles(directory) {
+  const found = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...findWorkflowFiles(path));
+    } else if (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+function violationsFor(file) {
+  const found = [];
+  const lines = readFileSync(file, "utf8").split("\n");
+  lines.forEach((line, index) => {
+    const match = USES.exec(line);
+    if (!match) return;
+    const ref = match[1];
+    // Local composite actions and Docker image refs are not mutable Git tags.
+    if (ref.startsWith("./") || ref.startsWith("../")) return;
+    if (ref.startsWith("docker://")) return;
+
+    const at = ref.lastIndexOf("@");
+    const location = `${file}:${index + 1}`;
+    if (at === -1) {
+      found.push(
+        `${location} — "${ref}" has no ref; pin a commit SHA (\`@<sha> # vX.Y.Z\`)`,
+      );
+    } else if (!SHA.test(ref.slice(at + 1))) {
+      found.push(
+        `${location} — "${ref}" is tag/branch-pinned; pin the commit SHA instead (\`@<sha> # vX.Y.Z\`)`,
+      );
+    } else {
+      found.push(null); // compliant external ref (counted below)
+    }
+  });
+  return found;
+}
+
+const root = process.argv[2] ?? ".github";
+const results = findWorkflowFiles(root).flatMap(violationsFor);
+const violations = results.filter((entry) => entry !== null);
+const checkedCount = results.length;
+
+for (const violation of violations) {
+  if (IN_CI) {
+    console.log(`::error title=Unpinned GitHub Action::${violation}`);
+  } else {
+    console.error(`error: ${violation}`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    `\n${violations.length} unpinned GitHub Action(s). Pin each to a commit SHA — see CLAUDE.md (CI).`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `All external GitHub Actions are SHA-pinned (${checkedCount} ref(s) checked).`,
+);

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -8,6 +8,10 @@ import { parse } from "yaml";
 // Adding a new job to any workflow requires adding an entry here — the test
 // asserts every non-reusable-workflow caller job has an explicit expected cap.
 const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
+  "action-pins.yml": {
+    "check-action-pins": 1,
+    "detect-changes": 1,
+  },
   "ci-actions.yml": {
     build: 2,
     "detect-changes": 1,


### PR DESCRIPTION
## Purpose

Harden against the **mutable-tag supply-chain attack**: a compromised action maintainer (or leaked token) can re-point a tag like `v7` at malicious code, and every workflow that tracks the tag silently runs it (the `tj-actions/changed-files` compromise, 2025). This pins every external action to an immutable commit SHA **and** adds a CI check so the pins can't regress.

## Pin the actions

Every external `uses:` in the workflows and both composite actions now pins a full 40-char SHA with the release in a trailing comment:

| Action | Pinned SHA | Comment |
|--------|-----------|---------|
| `actions/checkout` | `9c091bb…` | `# v7.0.0` |
| `actions/cache` | `0057852…` | `# v4.3.0` |
| `actions/setup-node` | `48b55a0…` | `# v6.4.0` |
| `pnpm/action-setup` | `fc06bc1…` | `# v5.0.0` |
| `getsentry/action-release` | `ff07929…` | `# v3.7.0` |

Local composite actions (`./.github/actions/*`) are unchanged — in-repo, not a mutable external ref.

## Enforce it (the guardrail you asked for)

The Actions analogue of `check-package-pins`:

- **`scripts/check-action-pins.mjs`** — scans every `.github` workflow and composite action; fails if an external `uses:` isn't pinned to a 40-char commit SHA. Skips local (`./`, `../`) composite actions and `docker://` image refs. Pure Node, no dependencies.
- **`.github/workflows/action-pins.yml`** — runs it, gated (like `Package Pins`) to PRs touching `.github/`; always runs on `push`.
- **`pnpm run check:action-pins`** for local use; registered in `workflow-timeouts.spec.ts`; documented in `AGENTS.md`.

## Dependabot keeps pins current

The `# vX.Y.Z` comment is the pattern Dependabot's `github-actions` updater reads — on a new release it bumps **both** the SHA and the comment, so pins stay current and updates stay visible in the diff. The existing `github-actions` Dependabot block (weekly + 7-day cooldown) covers this.

## Verification

- The checker passes on this branch (22 refs), fails on a tag- or short-SHA ref, and correctly skips local composite actions.
- `format` / `lint` / `tsc` and `workflow-timeouts` (new `action-pins.yml` registered) pass locally.
- The real proof each pinned SHA is runnable is CI going green on this PR — worth a glance before merge.

Only workflow/CI YAML + a check script change; it's a pure supply-chain tightening. If the review flow flags it for the CI-approval gate as a workflow change, it clears by inspection.

---
*Created by Claude Opus 4.8*
