### PR TITLE
ci: require a full-semver version comment in the action SHA-pin check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,16 @@
 
 ## GitHub Actions
 
-- **Pin every external GitHub Action to a full commit SHA**, with the release in a trailing
-  comment: `uses: actions/checkout@<40-hex-sha> # v7.0.0`. A mutable tag (`@v7`) can be
-  re-pointed at malicious code by a compromised maintainer or token; an immutable SHA cannot.
-  Local composite actions (`./.github/actions/*`) and `docker://` image refs are exempt — they
-  are not mutable Git tags.
-- `pnpm run check:action-pins` (`scripts/check-action-pins.mjs`) enforces this across every
-  workflow and composite action; the `Action Pins` CI workflow runs it, gated to PRs that touch
-  `.github/`. Dependabot's `github-actions` updater maintains the pins — it bumps the SHA and
-  the `# vX.Y.Z` comment together on new releases.
+- **Pin every external GitHub Action to a full commit SHA _and_ a trailing version comment**:
+  `uses: actions/checkout@<40-hex-sha> # v7.0.0`. A mutable tag (`@v7`) can be re-pointed at
+  malicious code by a compromised maintainer or token; an immutable SHA cannot. The `# vX.Y.Z`
+  comment is required, not cosmetic — Dependabot reads it to know the current version, so a SHA
+  with no version comment is pinned but un-updatable. Local composite actions
+  (`./.github/actions/*`) and `docker://` image refs are exempt — they are not mutable Git tags.
+- `pnpm run check:action-pins` (`scripts/check-action-pins.mjs`) enforces **both** the SHA pin
+  and the version comment across every workflow and composite action; the `Action Pins` CI
+  workflow runs it, gated to PRs that touch `.github/`. Dependabot's `github-actions` updater
+  then bumps the SHA and the `# vX.Y.Z` comment together on new releases.
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,16 +23,17 @@
 
 ## GitHub Actions
 
-- **Pin every external GitHub Action to a full commit SHA _and_ a trailing version comment**:
-  `uses: actions/checkout@<40-hex-sha> # v7.0.0`. A mutable tag (`@v7`) can be re-pointed at
-  malicious code by a compromised maintainer or token; an immutable SHA cannot. The `# vX.Y.Z`
-  comment is required, not cosmetic — Dependabot reads it to know the current version, so a SHA
-  with no version comment is pinned but un-updatable. Local composite actions
+- **Pin every external GitHub Action to a full commit SHA _and_ a full `major.minor.patch`
+  version comment**: `uses: actions/checkout@<40-hex-sha> # v7.0.0`. A mutable tag (`@v7`) can be
+  re-pointed at malicious code by a compromised maintainer or token; an immutable SHA cannot.
+  The `# vMAJOR.MINOR.PATCH` comment is required, not cosmetic — Dependabot reads it to know the
+  current version, and tracks partial comments (`# v7`, `# v7.0`) inconsistently, so a SHA with
+  no or partial version comment is pinned but un-updatable. Local composite actions
   (`./.github/actions/*`) and `docker://` image refs are exempt — they are not mutable Git tags.
 - `pnpm run check:action-pins` (`scripts/check-action-pins.mjs`) enforces **both** the SHA pin
-  and the version comment across every workflow and composite action; the `Action Pins` CI
-  workflow runs it, gated to PRs that touch `.github/`. Dependabot's `github-actions` updater
-  then bumps the SHA and the `# vX.Y.Z` comment together on new releases.
+  and a full-semver version comment across every workflow and composite action; the `Action
+Pins` CI workflow runs it, gated to PRs that touch `.github/`. Dependabot's `github-actions`
+  updater then bumps the SHA and the `# vX.Y.Z` comment together on new releases.
 
 ## Common Commands
 

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -8,11 +8,12 @@
  * compromised maintainer or token; a 40-char commit SHA is immutable. Every
  * `uses:` that references an external action must therefore:
  *   1. pin a 40-char commit SHA, and
- *   2. carry a trailing version comment (`@<sha> # v7.0.0`).
+ *   2. carry a full `major.minor.patch` version comment (`@<sha> # v7.0.0`).
  * The comment is not cosmetic: Dependabot's github-actions updater reads it to
  * know the current version, and bumps the SHA and the comment together on a new
- * release. A SHA with no version comment is pinned but un-trackable, so it is a
- * violation too.
+ * release. It tracks partial comments (`# v7`, `# v7.0`) inconsistently, so full
+ * semver is required; a SHA with no (or partial) version comment is pinned but
+ * un-trackable, and is a violation too.
  *
  * Skipped: local composite actions (`./…`, `../…`) and `docker://` image refs —
  * neither is a mutable Git tag this rule governs.
@@ -25,9 +26,11 @@ import { join } from "node:path";
 
 const SHA = /^[0-9a-f]{40}$/;
 const USES = /^\s*(?:-\s*)?uses:\s*["']?([^"'#\s]+)/;
-// A version comment right after the ref (`# v7.0.0`, optional `v`, `# 7.0` ok):
-// the token Dependabot reads to track the pin. Must lead the comment.
-const VERSION_COMMENT = /#\s*v?\d+(?:\.\d+)*/;
+// A full major.minor.patch version comment leading the trailing comment
+// (`# v7.0.0`; optional `v`; a `-prerelease`/`+build` suffix is tolerated). Full
+// semver is required because Dependabot tracks partial comments (`# v7`, `# v7.0`)
+// inconsistently — the token it reads to bump the pin must be a complete version.
+const VERSION_COMMENT = /#\s*v?\d+\.\d+\.\d+/;
 const IN_CI = process.env.GITHUB_ACTIONS === "true";
 
 function findWorkflowFiles(directory) {
@@ -66,7 +69,7 @@ function violationsFor(file) {
       );
     } else if (!VERSION_COMMENT.test(line)) {
       found.push(
-        `${location} — "${ref}" is SHA-pinned but has no version comment; add \`# vX.Y.Z\` so Dependabot can track and bump the pin`,
+        `${location} — "${ref}" is SHA-pinned but lacks a full-semver version comment; add \`# vMAJOR.MINOR.PATCH\` (e.g. \`# v7.0.0\`) so Dependabot can track and bump the pin`,
       );
     } else {
       found.push(null); // compliant external ref (counted below)
@@ -96,5 +99,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `All external GitHub Actions are SHA-pinned with version comments (${checkedCount} ref(s) checked).`,
+  `All external GitHub Actions are SHA-pinned with full-semver version comments (${checkedCount} ref(s) checked).`,
 );

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -6,9 +6,13 @@
  *
  * A mutable tag (`actions/checkout@v7`) can be re-pointed at malicious code by a
  * compromised maintainer or token; a 40-char commit SHA is immutable. Every
- * `uses:` that references an external action must therefore pin a SHA, with the
- * human-readable version in a trailing comment (`@<sha> # v7.0.0`) — the form
- * Dependabot maintains.
+ * `uses:` that references an external action must therefore:
+ *   1. pin a 40-char commit SHA, and
+ *   2. carry a trailing version comment (`@<sha> # v7.0.0`).
+ * The comment is not cosmetic: Dependabot's github-actions updater reads it to
+ * know the current version, and bumps the SHA and the comment together on a new
+ * release. A SHA with no version comment is pinned but un-trackable, so it is a
+ * violation too.
  *
  * Skipped: local composite actions (`./…`, `../…`) and `docker://` image refs —
  * neither is a mutable Git tag this rule governs.
@@ -21,6 +25,9 @@ import { join } from "node:path";
 
 const SHA = /^[0-9a-f]{40}$/;
 const USES = /^\s*(?:-\s*)?uses:\s*["']?([^"'#\s]+)/;
+// A version comment right after the ref (`# v7.0.0`, optional `v`, `# 7.0` ok):
+// the token Dependabot reads to track the pin. Must lead the comment.
+const VERSION_COMMENT = /#\s*v?\d+(?:\.\d+)*/;
 const IN_CI = process.env.GITHUB_ACTIONS === "true";
 
 function findWorkflowFiles(directory) {
@@ -57,6 +64,10 @@ function violationsFor(file) {
       found.push(
         `${location} — "${ref}" is tag/branch-pinned; pin the commit SHA instead (\`@<sha> # vX.Y.Z\`)`,
       );
+    } else if (!VERSION_COMMENT.test(line)) {
+      found.push(
+        `${location} — "${ref}" is SHA-pinned but has no version comment; add \`# vX.Y.Z\` so Dependabot can track and bump the pin`,
+      );
     } else {
       found.push(null); // compliant external ref (counted below)
     }
@@ -85,5 +96,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `All external GitHub Actions are SHA-pinned (${checkedCount} ref(s) checked).`,
+  `All external GitHub Actions are SHA-pinned with version comments (${checkedCount} ref(s) checked).`,
 );


### PR DESCRIPTION
## Purpose

`check-action-pins` (added in #372) only verified that external actions were pinned to a 40-char SHA — it didn't require the version comment. That leaves a gap: `uses: actions/foo@<sha>` with no (or a partial) comment is immutable but **un-updatable**, because Dependabot's `github-actions` updater reads the `# vX.Y.Z` comment to know the current release and bump the pin.

## Change

`scripts/check-action-pins.mjs` now requires a SHA-pinned external action to **also** carry a full `major.minor.patch` version comment:

- ✅ `uses: actions/checkout@<sha> # v7.0.0`
- ✅ `uses: getsentry/action-release@<sha> # v3.7.0-beta` (prerelease/build suffix tolerated)
- ❌ `uses: actions/checkout@<sha>` — no version comment
- ❌ `uses: actions/checkout@<sha> # v7` / `# v7.0` — **partial semver**
- ❌ `uses: actions/checkout@<sha> # pinned` — not a version
- ❌ `uses: actions/checkout@v7` — still caught (tag pin)

**Full semver is required** because Dependabot tracks partial comments (`# v7`, `# v7.0`) inconsistently — the version token it reads to bump the pin must be complete. The token must lead the comment. Local composite actions (`./…`) and `docker://` refs remain exempt. `AGENTS.md` is updated to state the full-semver comment is required, not cosmetic.

## Verification

- Passes on `main`'s current pins (all 22 refs carry a full `# vX.Y.Z`).
- Flags — with the exact `file:line` — a missing comment, `# v7`, `# v7.0`, a non-version comment, and a tag pin; accepts `# v7.0.0` and `# v1.4.0-beta`; skips local composites.
- `format` / `lint` / `tsc` pass.

Pure CI-tooling tightening (checker script + docs only); no workflow structure changed.

---
*Created by Claude Opus 4.8*
