### PR TITLE
chore(deps): scope same-tier families to majors and split out TypeScript in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,18 @@ updates:
         update-types:
           - "major"
           - "minor"
+      # TypeScript is the language itself, not just another dependency — a
+      # compiler major or minor can surface new type errors across the codebase
+      # and warrants isolated, visible review, so split those into their own PR
+      # (like prettier). The exact `typescript` pattern does not claim
+      # typescript-eslint, which stays in the eslint family. Patch bumps fall
+      # through to dev-dependencies and ride the routine batch.
+      typescript:
+        patterns:
+          - "typescript"
+        update-types:
+          - "major"
+          - "minor"
       dev-dependencies:
         dependency-type: development
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,16 +18,22 @@ updates:
     # more often need code changes and warrant isolated review.
     groups:
       # Version-locked families. Each is a set of packages that ship on a shared
-      # version line (or whose majors are dictated by one member), so bumping one
-      # without the rest breaks the build. Grouped across ALL update types (major,
-      # minor, AND patch) and listed first to win group-assignment precedence, so
-      # any bump within a family lands as one atomic PR. Update-types are
-      # deliberately unrestricted: a react patch without react-dom is as broken as
-      # a major, and the prod/dev split below would otherwise scatter react and
-      # react-dom from their @types.
+      # version line (or whose majors are dictated by one member), so a major bump
+      # to one without the rest breaks the build. Listed first to win
+      # group-assignment precedence, so a family major lands as one atomic PR
+      # instead of scattered individual PRs.
+      #
+      # Scope by tier: a family whose members are ALL dev (or all prod) only groups
+      # MAJORS (`update-types: [major]`) — its minor/patch bumps already batch in
+      # lockstep via the dev-dependencies / production-dependencies groups below, so
+      # grouping them here too would just split routine churn into extra PRs. The
+      # react family is the exception: it spans prod (react, react-dom) and dev
+      # (@types), so its minor/patch would otherwise scatter across the two tier
+      # groups — it stays unrestricted (all update types) to keep the four together.
       react:
         # react + react-dom ship the same version and must move together; the
-        # @types track react's major. Spans prod (react, react-dom) and dev (@types).
+        # @types track react's major. Spans prod + dev, so — unlike the same-tier
+        # families below — it groups every update type, not just majors.
         patterns:
           - "react"
           - "react-dom"
@@ -42,6 +48,8 @@ updates:
           - "storybook"
           - "@storybook/*"
           - "eslint-plugin-storybook"
+        update-types:
+          - "major"
       vite:
         # vite + its react plugin + vitest + @vitest/* are one interlocked
         # toolchain: a vite major dictates the plugin and vitest majors (the
@@ -52,6 +60,8 @@ updates:
           - "@vitejs/*"
           - "vitest"
           - "@vitest/*"
+        update-types:
+          - "major"
       eslint:
         # eslint + @eslint/js share a version line; typescript-eslint and the
         # react-hooks plugin track the eslint major.
@@ -60,12 +70,16 @@ updates:
           - "@eslint/js"
           - "typescript-eslint"
           - "eslint-plugin-react-hooks"
+        update-types:
+          - "major"
       tailwind:
         # tailwindcss core + its postcss plugin ship in lockstep; a mismatch
         # fails the build.
         patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
+        update-types:
+          - "major"
       # Prettier (and its plugins) gets its own group for major/minor bumps so a
       # formatting-affecting upgrade lands in an isolated PR — a Prettier minor
       # bump can reformat the whole tree and require code changes, which must not

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,14 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Version-locked families (first below) group across every update type so
-    # interdependent packages bump atomically, including majors. Otherwise, group
-    # only minor and patch bumps into one batched PR per dependency type;
-    # non-family major bumps match no group and raise individual PRs, since they
-    # more often need code changes and warrant isolated review.
+    # Version-locked families (first below) group interdependent packages so they
+    # bump atomically instead of scattering into separate PRs — chiefly for
+    # majors, which break the build if split (each family's note below states how
+    # far it scopes: same-tier families group majors only, while react spans both
+    # tiers and groups every update type). Otherwise, group only minor and patch
+    # bumps into one batched PR per dependency type; non-family major bumps match
+    # no group and raise individual PRs, since they more often need code changes
+    # and warrant isolated review.
     groups:
       # Version-locked families. Each is a set of packages that ship on a shared
       # version line (or whose majors are dictated by one member), so a major bump


### PR DESCRIPTION
## Purpose

Two refinements to the Dependabot dependency grouping introduced in #374, aimed at fewer/clearer PRs.

## 1. Scope same-tier families to majors only

The version-locked family groups (#374) grouped across **all** update types, which pulled routine minor/patch churn out of the single batched `dev-dependencies` PR into a separate PR per family — more PRs than we want.

For a family whose members are all one tier (all dev, or all prod), the `dev-dependencies` / `production-dependencies` catch-alls already batch its minor/patch **in lockstep** — so the family group only needs to catch the case that would otherwise scatter into lockstep-breaking individual PRs: **major bumps**.

- `storybook`, `vite`, `eslint`, `tailwind` (all dev) → `update-types: [major]`; their minor/patch ride the weekly `dev-dependencies` batch.
- `react` → **unchanged** (all update types): it spans prod (`react`, `react-dom`) and dev (`@types/*`), so its minor/patch would otherwise split across the two tier catch-alls.

## 2. Split out TypeScript (major + minor)

TypeScript is the language itself — a compiler major or minor can surface new type errors across the codebase, a more significant change than a routine package bump — so give it its own group (like `prettier`) for an isolated, **visible** PR. The exact `typescript` pattern doesn't claim `typescript-eslint` (that stays in the `eslint` family); TypeScript **patch** bumps fall through to `dev-dependencies`.

## Verification

Re-simulated Dependabot's first-match assignment for **every** dependency across major/minor/patch:

- The four dev families route **major → family group**, **minor/patch → `dev-dependencies`**; `react` routes **all three → react**.
- `typescript` routes **major/minor → typescript**, **patch → `dev-dependencies`**; `typescript-eslint` unchanged (**major → eslint**, minor/patch → `dev-dependencies`).
- Major-bump precedence still holds: `eslint-plugin-storybook` / `@storybook/nextjs-vite` / `@storybook/addon-vitest` → storybook.

YAML parses; `format` / `lint` / `tsc` green. Only `dependabot.yml` changed.

---
*Created by Claude Opus 4.8*
