### PR TITLE
chore(lint): statically enforce prose code-style conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,10 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 
 ## TypeScript
 
-- Strict mode throughout. No `any` types. No `@ts-ignore`.
+- Strict mode throughout; `any` and `@ts-ignore` are blocked by ESLint (`strictTypeChecked`).
 - Do not use `null` unless required for API compatibility or when explicitly distinguishing `null` from `undefined`. Prefer `undefined` for absent/optional values throughout the codebase.
 - Prefer explicit `interface` names scoped to their component (e.g., `interface UserProfileCardProps` not `interface Props`).
-- Use `async/await`, not `.then()` chains.
+- Use `async/await`; `.then()` chains are blocked by ESLint (`no-restricted-syntax`).
 
 ## File Organization
 
@@ -79,8 +79,8 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 
 - **Favor type inference.** Explicit generic type arguments (for example, `someFn<Foo>(...)`) are a code smell when TypeScript can infer them.
 - **No spurious variables.** Do not assign a value to a variable only to immediately return it on the next line — return the expression directly instead.
-- **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
-- **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
+- **No IIFEs** (ESLint-enforced). Extract the logic into a named helper function, or compute the value with a plain expression.
+- **No function-style imports** (ESLint-enforced): use module-level `import type { … } from "…"` statements, never inline `import("…").Type` in a type annotation. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) remains acceptable — only the inline type form is blocked.
 - **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
 - **Alphabetical ordering** applies wherever sequence has no semantic value, to minimize merge conflicts:
   - **Import statements** — enforced automatically by ESLint (`simple-import-sort`). Run `pnpm lint --fix` to auto-correct.
@@ -143,13 +143,13 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 - Test files are co-located with their component: `ComponentName.spec.tsx`.
 - When adding or modifying a UI component, add or update its test to verify rendering behavior and key prop-driven states.
 - Use `@testing-library/react` with `vitest`. Always call `afterEach(cleanup)`.
-- Do not use `.toBeInTheDocument()` — use `.toBeDefined()` or check `.textContent` instead.
+- Do not use `.toBeInTheDocument()` (ESLint-enforced) — use `.toBeDefined()` or check `.textContent` instead.
 - Assert against copy constants (e.g., `HOME_PAGE_COPY`) rather than hardcoded strings.
 - Test presentational view components directly; avoid mocking hooks in tests where possible.
 
 ## Testing Conventions
 
-- Use `describe`/`it` from Vitest (not `test`).
+- Use `describe`/`it` from Vitest, not `test` (ESLint-enforced).
 - Test fixture generators use `make{DomainName}()` (e.g., `makeUser()`, `makeSession()`).
 - When splitting large test files, organize into `{module}-tests/` directories.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,12 +12,13 @@ import tseslint from "typescript-eslint";
 // re-include these general selectors alongside its test-only additions.
 const noRestrictedSyntax = [
   {
-    // "No function-style imports": inline `import("…").Type` in type position.
-    // (Dynamic `await import("…")` for a value is untouched — it is not a
-    // TSImportType node.)
+    // "No function-style imports": any inline TypeScript import type in type
+    // position — both the qualified `import("…").Type` form and the bare
+    // `import("…")` form. (Dynamic `await import("…")` for a value is
+    // untouched — it is not a TSImportType node.)
     selector: "TSImportType",
     message:
-      'No inline import("…").Type. Use a module-level `import type { … } from "…"` statement.',
+      'No inline import types. Use a module-level `import type { … } from "…"` statement.',
   },
   {
     // "No IIFEs": a function/arrow expression invoked in place.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,50 @@ import storybook from "eslint-plugin-storybook";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+// `no-restricted-syntax` selectors that statically enforce prose conventions
+// from CLAUDE.md. ESLint does not merge this rule's array across config
+// objects — the last matching config wins — so the test-file block below must
+// re-include these general selectors alongside its test-only additions.
+const noRestrictedSyntax = [
+  {
+    // "No function-style imports": inline `import("…").Type` in type position.
+    // (Dynamic `await import("…")` for a value is untouched — it is not a
+    // TSImportType node.)
+    selector: "TSImportType",
+    message:
+      'No inline import("…").Type. Use a module-level `import type { … } from "…"` statement.',
+  },
+  {
+    // "No IIFEs": a function/arrow expression invoked in place.
+    selector:
+      "CallExpression[callee.type='FunctionExpression'], CallExpression[callee.type='ArrowFunctionExpression']",
+    message:
+      "No IIFEs. Extract a named helper, or compute the value with a plain expression.",
+  },
+  {
+    // "Use async/await, not `.then()` chains."
+    selector: "CallExpression[callee.property.name='then']",
+    message: "Use async/await, not `.then()` chains.",
+  },
+];
+
+// Test-file superset: the general selectors plus the Vitest test conventions.
+const testNoRestrictedSyntax = [
+  ...noRestrictedSyntax,
+  {
+    // "Use `describe`/`it` from Vitest (not `test`)."
+    selector:
+      "CallExpression[callee.name='test'], CallExpression[callee.object.name='test']",
+    message: "Use `describe`/`it` from Vitest, not `test()`.",
+  },
+  {
+    // "Do not use `.toBeInTheDocument()`."
+    selector: "MemberExpression[property.name='toBeInTheDocument']",
+    message:
+      "Do not use `.toBeInTheDocument()`; use `.toBeDefined()` or check `.textContent`.",
+  },
+];
+
 export default tseslint.config(
   {
     ignores: [
@@ -37,6 +81,37 @@ export default tseslint.config(
         project: ["./tsconfig.json"],
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+  // Static enforcement of the prose code-style conventions in CLAUDE.md that
+  // were previously only caught by eye in /review. No new dependency — every
+  // rule is core ESLint or typescript-eslint (already installed via the
+  // strictTypeChecked preset above). The CLAUDE.md prose for these rules is
+  // deliberately kept brief: the rule is the source of truth.
+  {
+    files: ["src/**/*.{ts,tsx}", "*.{ts,tsx}"],
+    rules: {
+      // "Use module-level `import type`." Auto-fixes value imports of
+      // type-only bindings into a separate `import type` statement.
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "separate-type-imports" },
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "no-restricted-syntax": ["error", ...noRestrictedSyntax],
+    },
+  },
+  // Test files get the general selectors plus the Vitest test-only conventions.
+  // This block follows the general one so it wins for spec/test files (the
+  // array rule does not merge across configs).
+  {
+    files: [
+      "src/**/*.spec.{ts,tsx}",
+      "src/**/*.test.{ts,tsx}",
+      "src/**/*-tests/**/*.{ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-syntax": ["error", ...testNoRestrictedSyntax],
     },
   },
   {

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
 import { getAdminAuth } from "@/lib/firebase/admin";

--- a/src/components/accounts/CreateAccountDialog.tsx
+++ b/src/components/accounts/CreateAccountDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+import type { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
 
 import { CREATE_ACCOUNT_DIALOG_COPY } from "./copy";
 import { CreateAccountDialogView, isCashTier } from "./CreateAccountDialogView";

--- a/src/components/investments/InvestmentsView.tsx
+++ b/src/components/investments/InvestmentsView.tsx
@@ -6,7 +6,7 @@ import type {
   AllocationTarget,
   InvestmentAccount,
 } from "@/lib/firebase/schema/investments";
-import { Posture } from "@/lib/firebase/schema/investments";
+import type { Posture } from "@/lib/firebase/schema/investments";
 
 import { AllocationDashboardView } from "./AllocationDashboardView";
 import {

--- a/src/components/investments/InvestmentsView.tsx
+++ b/src/components/investments/InvestmentsView.tsx
@@ -5,8 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
   AllocationTarget,
   InvestmentAccount,
+  Posture,
 } from "@/lib/firebase/schema/investments";
-import type { Posture } from "@/lib/firebase/schema/investments";
 
 import { AllocationDashboardView } from "./AllocationDashboardView";
 import {

--- a/src/components/reconcile/ReconcileSetupView.tsx
+++ b/src/components/reconcile/ReconcileSetupView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { type ReconciliationAccount } from "@/lib/firebase/schema/reconciliation-accounts";
+import type { ReconciliationAccount } from "@/lib/firebase/schema/reconciliation-accounts";
 import {
   type ReconciliationExpense,
   ReconciliationExpenseType,

--- a/src/hooks/use-update-reconciliation-posture.ts
+++ b/src/hooks/use-update-reconciliation-posture.ts
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Posture } from "@/lib/firebase/schema/investments";
+import type { Posture } from "@/lib/firebase/schema/investments";
 import { updateUserSettings } from "@/services/user-settings";
 
 export function useUpdateReconciliationPosture(uid: string) {

--- a/src/lib/reconciliation/tier-targets.ts
+++ b/src/lib/reconciliation/tier-targets.ts
@@ -1,11 +1,7 @@
-import {
-  ReconciliationAccount,
-  ReconciliationAccountTier,
-} from "@/lib/firebase/schema/reconciliation-accounts";
-import {
-  ReconciliationExpense,
-  ReconciliationExpenseType,
-} from "@/lib/firebase/schema/reconciliation-expenses";
+import type { ReconciliationAccount } from "@/lib/firebase/schema/reconciliation-accounts";
+import { ReconciliationAccountTier } from "@/lib/firebase/schema/reconciliation-accounts";
+import type { ReconciliationExpense } from "@/lib/firebase/schema/reconciliation-expenses";
+import { ReconciliationExpenseType } from "@/lib/firebase/schema/reconciliation-expenses";
 
 export interface TierTargetInputs {
   accounts: ReconciliationAccount[];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { SESSION_COOKIE_NAME } from "@/lib/auth-constants";
 


### PR DESCRIPTION
Increases static enforcement of the code-style conventions that `CLAUDE.md` states in prose but only `/review` enforced by eye. **No new dependency** — every rule is core ESLint or `typescript-eslint` (already installed via the `strictTypeChecked` preset). Measured against the whole tree first, so the migration is bounded and known.

Follows the pattern of [rmartz/hidden-role-game#820](https://github.com/rmartz/hidden-role-game/pull/820).

## Rules added

| Rule | Enforces (CLAUDE.md) | Current violations |
|---|---|---|
| `@typescript-eslint/consistent-type-imports` | "module-level `import type`" | 7 files — **auto-fixed** |
| `@typescript-eslint/no-import-type-side-effects` | (companion) | 0 |
| `no-restricted-syntax`: inline `import("…").Type` | "no function-style imports" | 0 |
| `no-restricted-syntax`: IIFEs | "no IIFEs" | 0 |
| `no-restricted-syntax`: `.then()` | "async/await, not `.then()`" | 0 |
| `no-restricted-syntax`: `test()` (test files) | "use `describe`/`it` from Vitest" | 0 |
| `no-restricted-syntax`: `.toBeInTheDocument()` (test files) | test convention | 0 |

Six of the seven have **zero** current violations — pure future-proofing insurance the tree already satisfies. The one with violations, `consistent-type-imports`, was `eslint --fix`'d: 7 files' type-only imports converted to `import type` (`separate-type-imports` style, matching the repo), then Prettier-formatted. Behavior-preserving — the changes are purely type-level.

The general selectors live in one block; test files get a superset block (general selectors + the two Vitest-only ones), because ESLint does not merge `no-restricted-syntax` arrays across configs — the last matching config wins.

## Prose relaxed

Per "rules that are automatically enforced can be inferred from the ESLint config," the now-redundant `CLAUDE.md` prose is condensed to brief pointers for each newly-enforced rule, plus the two that `strictTypeChecked` already enforced (`no-explicit-any`, `ban-ts-comment` → the "No `any` / No `@ts-ignore`" bullet). The valuable nuances are kept — e.g. the "no function-style imports" bullet still notes that dynamic `await import("…")` remains acceptable (only the inline type form is banned).

## Deliberately not included

- **`no-null` (prefer `undefined`)** — 38 `null` usages in `src/`, several legitimate (API compatibility, and the explicit `null`-vs-`undefined` distinction the prose itself carves out). Too noisy to enforce mechanically; stays prose.
- **`no-default-export`** — 69 default exports, most legitimate (Next.js pages/layouts, Redux slices, Storybook `meta`). Would need `eslint-plugin-import` plus careful per-file overrides — a config/dependency tradeoff to weigh separately; stays prose.
- **Enum / `as const` alphabetization**, **favor type inference**, **no spurious variables**, **no unnecessary helpers**, **named `interface` props**, **no imperative logic in JSX** — no core rule expresses these mechanically (they'd need extra plugins or aren't statically checkable); they remain prose reviewers enforce.

## Verification

- `format` / `lint` / `typecheck` pass (`pre-push-verify`); **1456 tests pass** (179 files).
- No dependency or lockfile changes.

---
*Created by Claude Opus 4.8*
