### PR TITLE
ci: add dependency release-age cooldown gate

### DIFF
--- a/.github/workflows/release-age.yml
+++ b/.github/workflows/release-age.yml
@@ -1,0 +1,43 @@
+name: Release Age
+
+# Dependency-cooldown gate: fails a PR that introduces a package version younger
+# than the cooldown window (default 7 days). A deterministic second layer behind
+# Dependabot's own `cooldown` in .github/dependabot.yml, which is advisory at
+# PR-creation time and has documented npm reliability gaps (same-day patch walks
+# can land a version well inside the configured window). See
+# scripts/check-release-age.mjs for why this inspects the lockfile diff instead
+# of setting pnpm's `minimum-release-age` (which would slow Dependabot's own
+# resolution to a crawl).
+#
+# pull_request only: the gate blocks a hot version from *landing*. Running it on
+# push-to-main would only fail an already-merged commit. Gated to runs that
+# change the lockfile (or the checker itself) — nothing else affects the result.
+# In our merge flow a failing check blocks the merge via the standard CI gate,
+# so this needs no separate branch-protection rule to take effect.
+on:
+  pull_request:
+    paths:
+      - "pnpm-lock.yaml"
+      - "scripts/check-release-age.mjs"
+      - ".github/workflows/release-age.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-release-age:
+    name: Check dependency release age
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      # fetch-depth: 0 so the base commit is present for `git show <base>:...`.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      # The check needs only Node + git + network (no dependency install).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+      - run: node scripts/check-release-age.mjs "$BASE_SHA"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "husky",
     "check:action-pins": "node scripts/check-action-pins.mjs",
     "check:package-pins": "node scripts/check-package-pins.mjs",
+    "check:release-age": "node scripts/check-release-age.mjs",
     "env:validate": "node scripts/validate-config.mjs"
   },
   "pnpm": {

--- a/scripts/check-release-age.mjs
+++ b/scripts/check-release-age.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Dependency-cooldown gate. Fails a PR that introduces a package version younger
+ * than RELEASE_AGE_MIN_DAYS (default 7). This enforces the "let a release age
+ * before we adopt it" supply-chain policy deterministically, at the layer we
+ * control — a second line of defense behind Dependabot's own `cooldown`
+ * (`.github/dependabot.yml`), which is advisory at PR-creation time and has
+ * documented reliability gaps for the npm ecosystem
+ * (https://github.com/dependabot/dependabot-core/issues/12677): same-day patch
+ * walks can slip a version in well inside the configured window.
+ *
+ * Why this shape and not pnpm's `minimum-release-age`: putting that setting in
+ * committed pnpm config makes Dependabot's own lockfile regeneration honor it,
+ * which forces pnpm to fetch publish-time metadata for the whole candidate tree
+ * on every update — the full-metadata storm that causes multi-minute/hour
+ * Dependabot timeouts on large repos. This gate never touches Dependabot's
+ * resolver: it inspects the *result* (the lockfile diff) and queries the
+ * registry for only the handful of newly-introduced versions.
+ *
+ * Usage:  node scripts/check-release-age.mjs [baseRef]
+ *   baseRef  git ref to diff against (default: origin/main). The base
+ *            pnpm-lock.yaml is read via `git show <baseRef>:pnpm-lock.yaml`;
+ *            the head lockfile is read from ./pnpm-lock.yaml in the working
+ *            tree. Only versions present in head but not base are checked.
+ *
+ * Exits 0 if every newly-introduced version is at least the threshold old (or
+ * could not be resolved on the public registry — private/workspace/tarball
+ * specifiers are skipped). Exits 1 listing each too-young version. Registry
+ * fetch failures are warned and skipped (fail-open) so a flaky registry does
+ * not produce a spurious red build; a confirmed too-young version always fails.
+ */
+
+import { execFileSync } from "child_process";
+import { readFileSync } from "fs";
+
+const baseRef = process.argv[2] ?? "origin/main";
+const minDays = Number(process.env.RELEASE_AGE_MIN_DAYS ?? "7");
+const minMs = minDays * 24 * 60 * 60 * 1000;
+
+const SEMVER_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+/**
+ * Collect the `name@version` keys from the top-level `packages:` block of a
+ * pnpm v9 lockfile. That block lists each resolved package canonically, without
+ * the peer-dependency suffixes that appear in `snapshots:`, so its keys are
+ * exactly the `name@version` pairs we want. Returns a Set of "name@version".
+ */
+function lockedPackages(lockfileText) {
+  const packages = new Set();
+  let inPackages = false;
+  for (const rawLine of lockfileText.split("\n")) {
+    const topLevel = /^(\S.*):\s*$/.exec(rawLine);
+    if (topLevel) {
+      inPackages = topLevel[1] === "packages";
+      continue;
+    }
+    if (!inPackages) continue;
+    // A package key is indented exactly two spaces and ends with a colon.
+    const entry = /^ {2}(\S.*):\s*$/.exec(rawLine);
+    if (entry) packages.add(entry[1].replace(/^['"]|['"]$/g, ""));
+  }
+  return packages;
+}
+
+/** Split a `name@version` key into its name and semver version, else undefined. */
+function parseKey(key) {
+  const at = key.lastIndexOf("@");
+  if (at <= 0) return undefined;
+  const name = key.slice(0, at);
+  const version = key.slice(at + 1).split("(")[0];
+  if (!SEMVER_VERSION.test(version)) return undefined;
+  return { name, version };
+}
+
+/** Publish timestamp (ms) for name@version, or undefined if unresolvable. */
+async function publishedAt(name, version) {
+  const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
+  const res = await fetch(url);
+  if (!res.ok) return undefined;
+  const time = (await res.json()).time?.[version];
+  return time ? Date.parse(time) : undefined;
+}
+
+const headLock = readFileSync("pnpm-lock.yaml", "utf8");
+const baseLock = execFileSync("git", ["show", `${baseRef}:pnpm-lock.yaml`], {
+  encoding: "utf8",
+});
+
+const basePackages = lockedPackages(baseLock);
+const introduced = [...lockedPackages(headLock)]
+  .filter((key) => !basePackages.has(key))
+  .map(parseKey)
+  .filter((parsed) => parsed !== undefined);
+
+const now = Date.now();
+const violations = [];
+for (const { name, version } of introduced) {
+  let published;
+  try {
+    published = await publishedAt(name, version);
+  } catch (err) {
+    console.warn(
+      `  warning: could not check ${name}@${version}: ${err.message}`,
+    );
+    continue;
+  }
+  if (published === undefined) continue; // private / workspace / unpublished
+  const ageDays = (now - published) / (24 * 60 * 60 * 1000);
+  if (now - published < minMs) {
+    violations.push(`  ${name}@${version} — ${ageDays.toFixed(1)} days old`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    `pnpm-lock.yaml — ${violations.length} newly-introduced version(s) younger than the ${minDays}-day cooldown:`,
+  );
+  for (const v of violations) console.error(v);
+  console.error(
+    "\nHold the update until the version ages past the cooldown, then re-run this\n" +
+      "check. Malicious releases are typically caught and yanked within days.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `pnpm-lock.yaml — all newly-introduced versions are at least ${minDays} days old. OK`,
+);

--- a/scripts/check-release-age.mjs
+++ b/scripts/check-release-age.mjs
@@ -35,6 +35,12 @@ import { readFileSync } from "fs";
 
 const baseRef = process.argv[2] ?? "origin/main";
 const minDays = Number(process.env.RELEASE_AGE_MIN_DAYS ?? "7");
+if (!Number.isFinite(minDays) || minDays <= 0) {
+  console.error(
+    `Invalid RELEASE_AGE_MIN_DAYS: ${process.env.RELEASE_AGE_MIN_DAYS ?? "(unset)"} — must be a positive finite number.`,
+  );
+  process.exit(1);
+}
 const minMs = minDays * 24 * 60 * 60 * 1000;
 
 const SEMVER_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
@@ -72,12 +78,29 @@ function parseKey(key) {
   return { name, version };
 }
 
+/** Cache of package-name → registry `time` map (keyed by version). null = fetch failed. */
+const registryTimeCache = new Map();
+
 /** Publish timestamp (ms) for name@version, or undefined if unresolvable. */
 async function publishedAt(name, version) {
-  const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
-  const res = await fetch(url);
-  if (!res.ok) return undefined;
-  const time = (await res.json()).time?.[version];
+  let timeMap;
+  if (registryTimeCache.has(name)) {
+    timeMap = registryTimeCache.get(name);
+  } else {
+    const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(
+        `  warning: registry returned HTTP ${res.status} for ${name} — skipping`,
+      );
+      registryTimeCache.set(name, null);
+      return undefined;
+    }
+    timeMap = (await res.json()).time ?? null;
+    registryTimeCache.set(name, timeMap);
+  }
+  if (!timeMap) return undefined;
+  const time = timeMap[version];
   return time ? Date.parse(time) : undefined;
 }
 

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -38,6 +38,9 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
   "preview-deploy.yml": {
     "deploy-preview": 10,
   },
+  "release-age.yml": {
+    "check-release-age": 2,
+  },
   "sentry-release.yml": {
     "create-release": 2,
   },


### PR DESCRIPTION
## Purpose

A **deterministic dependency-cooldown gate**: fail any PR that introduces a package version younger than a cooldown window (default 7 days). This adds a second layer on top of Dependabot's own `cooldown` (`.github/dependabot.yml`, `default-days: 7`) — which is only advisory at PR-creation time and has [documented reliability gaps for the npm ecosystem](https://github.com/dependabot/dependabot-core/issues/12677) that appear impossible to configure around: same-day patch walks can land a version well inside the configured window. This gate enforces the "let releases age before we adopt them" supply-chain policy at a layer we fully control.

Modeled on [rmartz/hidden-role-game#828](https://github.com/rmartz/hidden-role-game/pull/828).

## How it works

- **`scripts/check-release-age.mjs`** diffs the PR's `pnpm-lock.yaml` against the base, collects only the **newly-introduced** `name@version` entries (from the lockfile's canonical `packages:` block), and queries the npm registry publish date for each. Fails listing any younger than `RELEASE_AGE_MIN_DAYS` (default 7).
- **`.github/workflows/release-age.yml`** runs it on PRs that change the lockfile (or the checker itself). `pull_request`-only — the gate blocks a hot version from *landing*; running on `main` would only fail an already-merged commit. Node-only setup, no `pnpm install`, ~2-min timeout.
- **No separate branch-protection rule needed here**: in our merge flow a failing GitHub Actions check already blocks the merge (the `/merge` CI-passed prerequisite), so a red release-age check holds the PR automatically.

## Technical considerations

- **Why not pnpm's `minimum-release-age` in committed config:** that setting is read by Dependabot's own lockfile regeneration, forcing pnpm to fetch publish-time metadata for the whole candidate tree on every update — a full-metadata storm that causes multi-minute/hour Dependabot timeouts. This gate never touches Dependabot's resolver; it inspects the *result* (the lockfile diff) and queries only the handful of changed versions.
- **Diffing the lockfile (not just `package.json`)** means the gate also catches fresh **transitive** bumps. Verified locally against an older base: it surfaced `postcss@8.5.17` (4.3 days) alongside its transitive cluster — `browserslist`, `caniuse-lite`, `node-releases`, `baseline-browser-mapping` — plus `hono`, `tar`, `tldts`, and others, exactly the class of same-day bump this is meant to hold.
- **Fail-open on registry errors**: a flaky registry warns-and-skips rather than producing a spurious red build; a confirmed too-young version always fails.
- Our lockfile is `lockfileVersion: '9.0'`, whose `packages:` block the parser targets; the workflow's `actions/checkout` / `actions/setup-node` pins and Node `24.x` match the rest of our CI and pass `check:action-pins`.

## Follow-ups

- **Coordinator/`/dependabot` handling**: a release-age failure means "hold until the version ages," not "a code bug to fix." The coordinator should recognize this failure class and simply **re-run** the check once the version crosses the window (flipping the PR green), rather than attempting a fix PR or closing it. That logic lives in the shared tooling, not this repo — tracked as cross-repo follow-up.
- Optionally make it a **required** status check via branch protection as belt-and-suspenders (the merge gate already blocks on it in our flow).

## Verification

- `check:release-age` runs clean on this branch (no lockfile change → no newly-introduced versions); the end-to-end age/registry path is demonstrated above.
- `format` / `lint` / `typecheck` and `check:action-pins` all pass (`pre-push-verify`). No dependency or lockfile changes.

---
*Created by Claude Opus 4.8*
